### PR TITLE
HOTFIX: remove dumb mango file

### DIFF
--- a/scripts/update/mango.sh
+++ b/scripts/update/mango.sh
@@ -4,3 +4,8 @@
 if [[ -f /mango ]]; then 
     rm /mango
 fi
+
+#If this file existed, delete it
+if [[ -f /root/mango.info ]]; then 
+    rm /root/mango.info
+fi


### PR DESCRIPTION
The file broke the output of the `_get_user_list` function. We really need to restructure that whole mechanism