### PR TITLE
Fix qbittorrent regex to include minor bugfix versions

### DIFF
--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -5,11 +5,12 @@ function whiptail_qbittorrent() {
 		. /etc/swizzin/sources/functions/apt
 		codename=$(lsb_release -cs)
 		repov=$(get_candidate_version qbittorrent-nox)
-		latestv41=$(curl -s https://github.com/qbittorrent/qBittorrent/releases | grep -m1 -oP '4\.1\.\d')
-		if [[ -z $latestv41 ]]; then latestv41=4.1.9; fi
-		latestv42=$(curl -s https://github.com/qbittorrent/qBittorrent/releases | grep -m1 -oP '4\.2\.\d')
-		if [[ -z $latestv41 ]]; then latestv42=4.2.5; fi
-		latestv=$(curl -s https://github.com/qbittorrent/qBittorrent/releases | grep -m1 .tar.gz | grep -oP '\d.\d?.?\d')
+		releases=$(git ls-remote -t --refs https://github.com/qbittorrent/qBittorrent.git | awk '{sub("refs/tags/release-", ""); print $2 }' | sort -r)
+
+		latestv41=$(echo "$releases" | grep -m1 -oP '4\.1\.\d?.?\d')
+		latestv42=$(echo "$releases" | grep -m1 -oP '4\.2\.\d?.?\d')
+		latestv=$(echo "$releases" | grep -m1 -oP '\d.\d?.?\d?.?\d')
+
 		case ${codename} in
 			"xenial" | "stretch")
 				function=$(whiptail --title "Install Software" --menu "Choose a qBittorrent version:" --ok-button "Continue" --nocancel 12 50 3 \


### PR DESCRIPTION
The qBittorrent script doesn't support specific qBittorrent versioning and doesn't pull the latest version:
```
curl -s https://github.com/qbittorrent/qBittorrent/releases | grep .tar.gz | grep -oP '\d.\d?.?\d'
4.3.0
4.3.0
4.2.5
4.2.4
4.2.3
4.2.2
4.2.1
4.2.0
4.1.9
4.1.9
```

```
curl -s https://github.com/qbittorrent/qBittorrent/releases | grep .tar.gz | grep -oP '\d.\d?.?\d?.?\d'
4.3.0.1
4.3.0
4.2.5
4.2.4
4.2.3
4.2.2
4.2.1
4.2.0
4.1.9.1
4.1.9
```