### PR TITLE
fix: jellyfin reverse proxy with internal ip addresses.

### DIFF
--- a/scripts/nginx/jellyfin.sh
+++ b/scripts/nginx/jellyfin.sh
@@ -24,27 +24,27 @@ fi
 # Create our nginx application conf for jellyfin
 cat > /etc/nginx/apps/jellyfin.conf <<- NGINXCONF
 	location /jellyfin {
-	    proxy_pass https://127.0.0.1:8920;
-	    #
-	    proxy_pass_request_headers on;
-	    #
-	    proxy_set_header Host \$host;
-	    #
-	    proxy_http_version 1.1;
-	    #
-	    proxy_set_header X-Real-IP              \$remote_addr;
-	    proxy_set_header X-Forwarded-For        \$proxy_add_x_forwarded_for;
-	    proxy_set_header X-Forwarded-Proto      \$scheme;
-	    proxy_set_header X-Forwarded-Protocol   \$scheme;
-	    proxy_set_header X-Forwarded-Host       \$http_host;
-	    #
-	    proxy_set_header Upgrade                \$http_upgrade;
-	    proxy_set_header Connection             \$http_connection;
-	    #
-	    proxy_set_header X-Forwarded-Ssl        on;
-	    #
-	    proxy_redirect                          off;
-	    proxy_buffering                         off;
-	    auth_basic                              off;
+		proxy_pass https://127.0.0.1:8920;
+		#
+		proxy_pass_request_headers on;
+		#
+		proxy_set_header Host \$proxy_host;
+		#
+		proxy_http_version 1.1;
+		#
+		proxy_set_header X-Real-IP              \$remote_addr;
+		proxy_set_header X-Forwarded-For        \$proxy_add_x_forwarded_for;
+		proxy_set_header X-Forwarded-Proto      \$scheme;
+		proxy_set_header X-Forwarded-Protocol   \$scheme;
+		proxy_set_header X-Forwarded-Host       \$http_host;
+		#
+		proxy_set_header Upgrade                \$http_upgrade;
+		proxy_set_header Connection             \$http_connection;
+		#
+		proxy_set_header X-Forwarded-Ssl        on;
+		#
+		proxy_redirect                          off;
+		proxy_buffering                         off;
+		auth_basic                              off;
 	}
 NGINXCONF


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Fixes issues: 
- N/A

## Proposed Changes:
- use `proxy_set_header Host \$proxy_host;` instead of `proxy_set_header Host \$host;`
- ...

## Tick these if they apply
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] Docs have been made/are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas

## Testing done
OS & Version: N/A

### How have you tested this
<!-- Story time, please! -->

Panic averted!

Scenarios tested:
- I ran this on a vm using a local ip. it works

