### PR TITLE
Moving global sources to one file

### DIFF
--- a/scripts/box
+++ b/scripts/box
@@ -14,16 +14,8 @@
 #
 #################################################################################
 
-# shellcheck source=sources/functions/color_echo
-. /etc/swizzin/sources/functions/color_echo
-export log="/root/logs/swizzin.log"
-# Sourcing functions
-#shellcheck source=sources/functions/os
-. /etc/swizzin/sources/functions/os
-#shellcheck source=sources/functions/apt
-. /etc/swizzin/sources/functions/apt
-#shellcheck source=sources/functions/ask
-. /etc/swizzin/sources/functions/ask
+#shellcheck source=sources/globals.sh
+. /etc/swizzin/sources/globals.sh
 echo_log_only "$(/usr/games/fortune -s)"
 
 function _intro() {
@@ -33,9 +25,9 @@ function _intro() {
 function _function() {
 	function=$(
 		whiptail --title "Swizzin" --menu "Choose an option:" --ok-button "Continue" --nocancel 12 50 3 \
-		Install "packages" \
-		Remove "packages" \
-		Exit "" 3>&1 1>&2 2>&3
+			Install "packages" \
+			Remove "packages" \
+			Exit "" 3>&1 1>&2 2>&3
 	)
 
 	if [[ $function == Install ]]; then

--- a/setup.sh
+++ b/setup.sh
@@ -81,8 +81,6 @@ function _preparation() {
 	echo "Cloning swizzin repo to localhost"
 	if [[ $dev != "true" ]]; then
 		git clone https://github.com/liaralabs/swizzin.git /etc/swizzin >> ${log} 2>&1
-		#shellcheck source=sources/functions/color_echo
-		. /etc/swizzin/sources/functions/color_echo
 	else
 		RelativeScriptPath=$(dirname "$0")
 		ln -sr "$RelativeScriptPath" /etc/swizzin
@@ -94,10 +92,9 @@ function _preparation() {
 	fi
 	ln -s /etc/swizzin/scripts/ /usr/local/bin/swizzin
 	chmod -R 700 /etc/swizzin/scripts
-	#shellcheck source=sources/functions/apt
-	. /etc/swizzin/sources/functions/apt
-	#shellcheck source=sources/functions/ask
-	. /etc/swizzin/sources/functions/ask
+	echo " ##### Switching logs to /root/logs/swizzin.log  ##### " >> "$log"
+	#shellcheck source=sources/globals.sh
+	. /etc/swizzin/sources/globals.sh
 }
 
 function _nukeovh() {

--- a/sources/globals.sh
+++ b/sources/globals.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# One place to keep track of the functions that are being sourced in at the beginning of the `box` and `setup.sh` scripts.
+# Please ensure that any functions or variables you'd like to have available through sourcing in this file need to be exported.
+# This means `export $variable` or `export -f function_name `.
+# If you're planning to test single scripts outside of either `box` or `setup.sh` context, source this very file in your
+# shell, and the functions and variables will be available until it is terminated.
+
+export log="/root/logs/swizzin.log"
+
+############################################
+# FUNCTIONS
+############################################
+
+# Provides the functions like `echo_info` and others. All of these will automatically log to $log
+# shellcheck source=sources/functions/color_echo
+. /etc/swizzin/sources/functions/color_echo
+
+# Parsing things like OS names and version, architecture, etc
+#shellcheck source=sources/functions/os
+. /etc/swizzin/sources/functions/os
+
+# Managing calls to `apt-get` in a streamlined and preventative manner
+#shellcheck source=sources/functions/apt
+. /etc/swizzin/sources/functions/apt
+
+# A script to standardise yes/no dialogues
+#shellcheck source=sources/functions/ask
+. /etc/swizzin/sources/functions/ask


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Fixes issues: 
- Keeping `box` and `setup.sh` in sync with sources
- Debugging or testing individual files right now is a pain because of the imports that are all over

## Proposed Changes:
- Move all imports to one file
- Properly detail how these imports need to work
- Make `setup.sh` and `box` point to this file as soon as it's available

## Tick these if they apply
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Some existing `utils` got changed

## Checklist
- [x] Docs have been made/are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas

## Testing done
OS & Version: Ubuntu 20.02

### How have you tested this
- Ran `box` commands that included an `ask` and `apt_install`, `echo`es are given to run too.
- Made a full run of `setup.sh` with no problem
- Sourced the `globals.sh` file and ran individual scripts directly


Scenarios tested:
- I ran this and it worked
- I ran that and it didn't work

