### PR TITLE
Reapply sicko-mode logic to JF and Emby seeing as they're forks of each other

### DIFF
--- a/scripts/install/emby.sh
+++ b/scripts/install/emby.sh
@@ -12,6 +12,24 @@
 #   including (via compiler) GPL-licensed code must also be made available
 #   under the GPL along with build & install instructions.
 
+if [[ $(systemctl is-active jellyfin) == "active" ]]; then
+	active=jellyfin
+fi
+
+if [[ -n $active ]]; then
+	echo_info "Jellyfin and Emby cannot be active at the same time.\nDo you want to disable $active and continue with the installation?\nDon't worry, your install will remain"
+	if ask "Do you want to disable $active?" Y; then
+		disable=yes
+	fi
+	if [[ $disable == "yes" ]]; then
+		echo_progress_start "Disabling service"
+		systemctl disable -q --now ${active} >> ${log} 2>&1
+		echo_progress_done
+	else
+		exit 1
+	fi
+fi
+
 username=$(cut -d: -f1 < /root/.master.info)
 
 if [[ ! $(command -v mono) ]]; then

--- a/scripts/install/jellyfin.sh
+++ b/scripts/install/jellyfin.sh
@@ -21,6 +21,25 @@ function dist_info() {
 # Get our some useful information from functions in the sourced utils script
 username="$(_get_master_username)"
 dist_info # get our distribution ID, set to DIST_ID, and VERSION_CODENAME, set to DIST_CODENAME, from /etc/os-release
+
+if [[ $(systemctl is-active emby) == "active" ]]; then
+	active=emby
+fi
+
+if [[ -n $active ]]; then
+	echo_info "Jellyfin and Emby cannot be active at the same time.\nDo you want to disable $active and continue with the installation?\nDon't worry, your install will remain"
+	if ask "Do you want to disable $active?" Y; then
+		disable=yes
+	fi
+	if [[ $disable == "yes" ]]; then
+		echo_progress_start "Disabling service"
+		systemctl disable -q --now ${active} >> ${log} 2>&1
+		echo_progress_done
+	else
+		exit 1
+	fi
+fi
+
 #
 ########
 ######## Variables End


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Fixes issues: 
- JF and Emby can be installed side by side but their ports are clashing and they're a fork of one another anyway
- One of dan's customers got this

## Proposed Changes:
- Disable the service of the other program during install, or quit the installer.

## Tick these if they apply
- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] Docs have been made/are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas

## Testing done
OS & Version: Ubuntu 20.04

### How have you tested this
<!-- Story time, please! -->

Scenarios tested:
- None at all just yet. This works for the Medusa, Sickrage and Sickchill combo so I would assume it works here too.

