### PR TITLE
Fix ombi service reading as disabled after service update

### DIFF
--- a/scripts/update/ombi.sh
+++ b/scripts/update/ombi.sh
@@ -26,6 +26,10 @@ CONF
         if [[ $ombiwasactive = "true" ]]; then
             systemctl start ombi
         fi
+        if [[ -L /etc/systemd/system/multi-user.target.wants/ombi.service && ! -e /etc/systemd/system/multi-user.target.wants/ombi.service ]]; then
+            systemctl enable -q ombi >> $log 2>&1
+            echo_info "Fixing Ombi systemd symlinks"
+        fi
         echo_progress_done "Ombi reset back to stock service"
     fi
 fi


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Fixes issues: 
Ombi service was enabled before `box update` changed the service file back to the repo version, but is disabled after the update

## Proposed Changes:
Check if `/etc/systemd/system/multi-user.target.wants/ombi.service` is a broken symlink and re-enable ombi if it is.

## Categories
- Bug fix (non-breaking change which fixes an issue)


## Checklist
- [x] Docs have been made/are not necessary
    - PR link: 
- [x] Changes to panel have been made/are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas

## Testing done
OS & Version: Debian 10

### How have you tested this
The `enable` command removed the broken symlink and added a link to the correct service file in my testing

Scenarios tested:
Only tested on Debian 10

