### PR TITLE
Ensure .editorconfig is set to spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,8 @@
 root = true
 
 [*]
-indent_style = tab
+indent_style = space
+intent_size = 4
 tab_width = 4
 end_of_line = lf
 charset = utf-8


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Fixes issues: 
- Formatting in vstudio still switching to tabs because of `./editorconfig`

## Proposed Changes:
- Fix `./editorconfig`

## Categories
<!-- Delete whichever don't apply -->
- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Impacts the flow of how we contribute

## Checklist
- [x] Docs have been made/are not necessary
    - PR link: 
- [x] Changes to panel have been made/are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas

## Testing done
OS & Version:

### How have you tested this
<!-- Story time, please! -->

Scenarios tested:
- I ran this and it worked
- I ran that and it didn't work

