### PR TITLE
HoTFIX: Add checks before chpasswd

### DIFF
--- a/scripts/box
+++ b/scripts/box
@@ -389,6 +389,17 @@ function _deluser() {
 
 function _chpasswd() {
     user=$2
+    if ! id -u $user > /dev/null 2>&1; then
+        echo_error "User '$user' does not exist"
+        exit 1
+    fi
+
+    . /etc/swizzin/sources/functions/utils
+    if ! _get_user_list | grep -q $user; then
+        echo_error "User '$user' is not managed through swizzin"
+        exit 1
+    fi
+
     echo_query "Enter new password for ${user}. Leave empty to generate a password" "hidden"
     read -s 'pass'
     echo


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Fixes issues: 
- Issue Users not being checked before running `chpasswd`

## Proposed Changes:
- Check if user exists before running `chpasswd`

## Categories
<!-- Delete whichever don't apply -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] Docs have been made/are not necessary
    - PR link: 
- [x] Changes to panel have been made/are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas

## Testing done
OS & Version: Ubuntu 20.04

### How have you tested this
<!-- Story time, please! -->

Scenarios tested:
- I ran this and it worked
- I ran that and it didn't work
![image](https://user-images.githubusercontent.com/23618693/101988543-9c4f3980-3c9a-11eb-8be2-4c7b08c78576.png)


