### PR TITLE
Update python minimum version of the panel to 3.6

### DIFF
--- a/scripts/install/panel.sh
+++ b/scripts/install/panel.sh
@@ -45,9 +45,6 @@ esac
 
 apt_install $LIST
 
-mkdir -p /opt/swizzin/
-#TODO do the pyenv?
-
 echo_progress_start "Cloning panel"
 git clone https://github.com/liaralabs/swizzin_dashboard.git /opt/swizzin >> ${log} 2>&1
 echo_progress_done "Panel cloned"

--- a/scripts/install/panel.sh
+++ b/scripts/install/panel.sh
@@ -21,6 +21,7 @@ if [[ ! -f /install/.nginx.lock ]]; then
 fi
 
 master=$(_get_master_username)
+useradd -r swizzin -s /usr/sbin/nologin > /dev/null 2>&1
 
 systempy3_ver=$(get_candidate_version python3)
 

--- a/scripts/install/panel.sh
+++ b/scripts/install/panel.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# QuickBox dashboard installer for Swizzin
+# swizzin dashboard installer
 # Author: liara
-# Copyright (C) 2017 Swizzin
+# Copyright (C) 2020 Swizzin
 # Licensed under GNU General Public License v3.0 GPL-3 (in short)
 #
 #   You may copy, distribute and modify the software as long as you track
@@ -35,8 +35,8 @@ fi
 case ${PYENV} in
     True)
         pyenv_install
-        pyenv_install_version 3.7.7
-        pyenv_create_venv 3.7.7 /opt/.venv/swizzin
+        pyenv_install_version 3.8.6
+        pyenv_create_venv 3.8.6 /opt/.venv/swizzin
         chown -R swizzin: /opt/.venv/swizzin
         ;;
     *)
@@ -56,6 +56,7 @@ echo_progress_done
 
 echo_progress_start "Setting permissions"
 chown -R swizzin: /opt/swizzin
+chown -R swizzin: /opt/.venv/swizzin
 setfacl -m g:swizzin:rx /home/*
 echo_progress_done
 

--- a/scripts/install/panel.sh
+++ b/scripts/install/panel.sh
@@ -116,7 +116,7 @@ Cmnd_Alias   SYSDCMNDS = /bin/systemctl start *, /bin/systemctl stop *, /bin/sys
 swizzin     ALL = (ALL) NOPASSWD: CMNDS, SYSDCMNDS
 EOSUD
 
-systemctl enable -q --now panel 2>&1 | tee -a $log
+systemctl enable -q --now panel >> ${log} 2>&1
 echo_progress_done "Panel started"
 
 echo_success "Panel installed"

--- a/scripts/install/panel.sh
+++ b/scripts/install/panel.sh
@@ -20,7 +20,13 @@ if [[ ! -f /install/.nginx.lock ]]; then
     fi
 fi
 
+#shellcheck source=sources/functions/utils
+. /etc/swizzin/sources/functions/utils
+#shellcheck source=sources/functions/pyenv
+. /etc/swizzin/sources/functions/pyenv
+
 master=$(_get_master_username)
+
 useradd -r swizzin -s /usr/sbin/nologin > /dev/null 2>&1
 
 systempy3_ver=$(get_candidate_version python3)

--- a/scripts/nginx/panel.sh
+++ b/scripts/nginx/panel.sh
@@ -10,7 +10,7 @@
 #   under the GPL along with build & install instructions.
 #
 
-echo "HOST = '127.0.0.1'" >> /opt/swizzin/swizzin/swizzin.cfg
+echo "HOST = '127.0.0.1'" >> /opt/swizzin/swizzin.cfg
 
 cat > /etc/nginx/apps/panel.conf << 'EON'
 location / {

--- a/scripts/update/panel.sh
+++ b/scripts/update/panel.sh
@@ -16,10 +16,15 @@ if [[ -f /install/.panel.lock ]]; then
     else
         echo_progress_start "Updating panel to latest version"
         if [[ -d /opt/swizzin/venv ]]; then
+            echo_progress_start "Moving swizzin venv to /opt/.venv"
             mkdir -p /opt/.venv
             mv /opt/swizzin/venv /opt/.venv/swizzin
             mv /opt/swizzin/swizzin/* /opt/swizzin
             rm_if_exists "/opt/swizzin/swizzin"
+            sed -i 's|ExecStart=.*|ExecStart=/opt/.venv/swizzin/bin/python swizzin.py|g' /etc/systemd/system/panel.service
+            sed -i 's|WorkingDirectory=.*|WorkingDirectory=/opt/swizzin|g' /etc/systemd/system/panel.service
+            systemctl daemon-reload
+            echo_progress_done "venv moved"
         fi
         pyminver=3.6.0
         pyenv_version=$(/opt/.venv/swizzin/bin/python3 --version | awk '{print $2}')

--- a/scripts/update/panel.sh
+++ b/scripts/update/panel.sh
@@ -9,10 +9,7 @@ if [[ -f /install/.panel.lock ]]; then
 
         bash /usr/local/bin/swizzin/install/panel.sh
 
-        systemctl enable -q --now panel
-
         echo_progress_done "Panel has been swizzified"
-
     else
         echo_progress_start "Updating panel to latest version"
         if [[ -d /opt/swizzin/venv ]]; then

--- a/scripts/update/panel.sh
+++ b/scripts/update/panel.sh
@@ -18,7 +18,7 @@ if [[ -f /install/.panel.lock ]]; then
             echo_progress_start "Moving swizzin venv to /opt/.venv"
             mkdir -p /opt/.venv
             mv /opt/swizzin/venv /opt/.venv/swizzin
-            mv /opt/swizzin/swizzin/* /opt/swizzin
+            mv /opt/swizzin/swizzin/* /opt/swizzin/swizzin/.git /opt/swizzin
             rm_if_exists "/opt/swizzin/swizzin"
             sed -i 's|ExecStart=.*|ExecStart=/opt/.venv/swizzin/bin/python swizzin.py|g' /etc/systemd/system/panel.service
             sed -i 's|WorkingDirectory=.*|WorkingDirectory=/opt/swizzin|g' /etc/systemd/system/panel.service

--- a/scripts/update/panel.sh
+++ b/scripts/update/panel.sh
@@ -3,6 +3,8 @@
 if [[ -f /install/.panel.lock ]]; then
     #shellcheck source=sources/functions/utils
     . /etc/swizzin/sources/functions/utils
+    #shellcheck source=sources/functions/pyenv
+    . /etc/swizzin/sources/functions/pyenv
     if [[ ! -d /opt/swizzin ]]; then
         echo_progress_start "swizzifying the panel"
         rm_if_exists "/srv/panel"

--- a/scripts/update/panel.sh
+++ b/scripts/update/panel.sh
@@ -2,87 +2,36 @@
 
 if [[ -f /install/.panel.lock ]]; then
     if [[ ! -d /opt/swizzin ]]; then
-        master=$(cut -d: -f1 < /root/.master.info)
+        echo_progress_start "swizzifying the panel"
+        rm_if_exists "/srv/panel"
+        rm_if_exists "/etc/cron.d/set_interface"
+        rm_if_exists "/etc/nginx/apps/panel.conf"
 
-        apt_install python3-venv
-        mkdir -p /opt/swizzin/
-        python3 -m venv /opt/swizzin/venv
-        git clone https://github.com/liaralabs/swizzin_dashboard.git /opt/swizzin/swizzin > /dev/null 2>&1
-        /opt/swizzin/venv/bin/pip install -r /opt/swizzin/swizzin/requirements.txt > /dev/null 2>&1
-        useradd -r swizzin > /dev/null 2>&1
-        chown -R swizzin: /opt/swizzin
-        setfacl -m g:swizzin:rx /home/*
-        mkdir -p /etc/nginx/apps
-
-        if [[ -f /install/.deluge.lock ]]; then
-            touch /install/.delugeweb.lock
-        fi
-
-        if [[ $master == $(id -nu 1000) ]]; then
-            :
-        else
-            echo "ADMIN_USER = '$master'" >> /opt/swizzin/swizzin/swizzin.cfg
-        fi
-
-        if [[ -f /install/.nginx.lock ]]; then
-            echo "HOST = '127.0.0.1'" >> /opt/swizzin/swizzin/swizzin.cfg
-
-            cat > /etc/nginx/apps/panel.conf << 'EON'
-location / {
-  #rewrite ^/panel/(.*) /$1 break;
-  proxy_set_header Host $host;
-  proxy_set_header X-Real-IP $remote_addr;
-  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-  proxy_set_header X-Forwarded-Host $host;
-  proxy_set_header X-Forwarded-Proto $scheme;
-  proxy_set_header Origin "";
-  proxy_pass http://127.0.0.1:8333;
-  proxy_http_version 1.1;
-  proxy_set_header Upgrade $http_upgrade;
-  proxy_set_header Connection "Upgrade";
-}
-EON
-            systemctl reload nginx
-
-        fi
-
-        cat > /etc/systemd/system/panel.service << EOS
-[Unit]
-Description=swizzin panel service
-After=nginx.service
-
-[Service]
-Type=simple
-User=swizzin
-
-ExecStart=/opt/swizzin/venv/bin/python swizzin.py
-WorkingDirectory=/opt/swizzin/swizzin
-Restart=on-failure
-TimeoutStopSec=300
-
-[Install]
-WantedBy=multi-user.target
-EOS
-
-        cat > /etc/sudoers.d/panel << EOSUD
-#Defaults  env_keep -="HOME"
-Defaults:swizzin !logfile
-Defaults:swizzin !syslog
-Defaults:swizzin !pam_session
-
-Cmnd_Alias   CMNDS = /usr/bin/quota
-Cmnd_Alias   SYSDCMNDS = /bin/systemctl start *, /bin/systemctl stop *, /bin/systemctl restart *, /bin/systemctl disable *, /bin/systemctl enable *
-
-swizzin     ALL = (ALL) NOPASSWD: CMNDS, SYSDCMNDS
-EOSUD
-
-        rm -rf /srv/panel
-        rm -f /etc/cron.d/set_interface
+        bash /usr/local/bin/swizzin/install/panel.sh
 
         systemctl enable -q --now panel
 
+        echo_progress_done "Panel has been swizzified"
+
     else
         echo_progress_start "Updating panel to latest version"
+        if [[ -d /opt/swizzin/venv ]]; then
+            mkdir -p /opt/.venv
+            mv /opt/swizzin/venv /opt/.venv/swizzin
+            mv /opt/swizzin/swizzin/* /opt/swizzin
+            rm_if_exists "/opt/swizzin/swizzin"
+        fi
+        pyminver=3.6.0
+        pyenv_version=$(/opt/.venv/swizzin/bin/python3 --version | awk '{print $2}')
+
+        if dpkg --compare-versions ${pyenv_version} lt ${pyminver}; then
+            rm_if_exists "/opt/.venv/swizzin"
+            pyenv_install
+            pyenv_install_version 3.8.6
+            pyenv_create_venv 3.8.6 /opt/.venv/swizzin
+            chown -R swizzin: /opt/.venv/swizzin
+        fi
+
         bash /usr/local/bin/swizzin/upgrade/panel.sh
         echo_progress_done
     fi

--- a/scripts/update/panel.sh
+++ b/scripts/update/panel.sh
@@ -1,6 +1,8 @@
 #! /bin/bash
 
 if [[ -f /install/.panel.lock ]]; then
+    #shellcheck source=sources/functions/utils
+    . /etc/swizzin/sources/functions/utils
     if [[ ! -d /opt/swizzin ]]; then
         echo_progress_start "swizzifying the panel"
         rm_if_exists "/srv/panel"

--- a/scripts/upgrade/panel.sh
+++ b/scripts/upgrade/panel.sh
@@ -8,7 +8,8 @@ if [[ -f /install/.panel.lock ]]; then
         setfacl -m g:swizzin:rx /home/*
         echo_progress_done
     fi
-    cd /opt/swizzin/swizzin
+
+    cd /opt/swizzin
     #git reset HEAD --hard
     echo_progress_start "Pulling new commits"
     git pull >> ${log} 2>&1 || { PANELRESET=1; }
@@ -22,8 +23,8 @@ if [[ -f /install/.panel.lock ]]; then
     fi
     echo_progress_done "Commits pulled"
     echo_progress_start "Checking pip for new depends"
-    if ! /opt/swizzin/venv/bin/python /opt/swizzin/swizzin/tests/test_requirements.py >> ${log} 2>&1; then
-        /opt/swizzin/venv/bin/pip install -r /opt/swizzin/swizzin/requirements.txt >> ${log} 2>&1
+    if ! /opt/.venv/swizzin/bin/python /opt/swizzin/tests/test_requirements.py >> ${log} 2>&1; then
+        /opt/.venv/swizzin/bin/pip install -r /opt/swizzin/requirements.txt >> ${log} 2>&1
     fi
     echo_progress_done "Depends up-to-date"
     echo_progress_start "Restarting Panel"


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Fixes issues: 
- Panel now requires python3.6+

## Proposed Changes:
- Update scripts to detect whether or not the venv needs an upgraded python version
- Align swizzin_dashboard venv with our standard venv folder (`/opt/.venv`)
- Use `scripts/install/panel.sh` to pull people away from old dashboard onto the new one so we don't have to constantly maintain that section of the script

## Categories
<!-- Delete whichever don't apply -->
- Bug fix (non-breaking change which fixes an issue)
- QoL/Best Practices

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Docs have been made OR are not necessary
- [x] Changes to panel have been made OR are not necessary (Changes only to the install method)
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas

## Testing done
OS & Version: Debian 10

### How have you tested this
<!-- Story time, please! -->
Scenarios tested:
- Fresh install on Debian 10
- `box update` on Debian 10


