### PR TITLE
Hotfix plex upgrade lockfile boogaloo

### DIFF
--- a/scripts/update/plex.sh
+++ b/scripts/update/plex.sh
@@ -7,3 +7,9 @@ if [[ -f /etc/apt/sources.list.d/plexmediaserver.list ]]; then
         apt_update
     fi
 fi
+
+# removing lockfile for the upgrade script so that it can be re-run as many times as people want
+if [ -f "/install/.updateplex.lock" ]; then
+    # echo file exists
+    rm /install/.updateplex.lock
+fi

--- a/scripts/upgrade/plex.sh
+++ b/scripts/upgrade/plex.sh
@@ -7,11 +7,11 @@ if [[ ! -f /install/.plex.lock ]]; then
     exit 1
 fi
 
-if [[ ! -f /install/.updateplex.lock ]]; then
+if [[ ! -f /opt/plexupdate/plexupdate.sh ]]; then
     user=$(cut -d: -f1 < /root/.master.info)
     sudo -H -u $user bash -c "$(wget -qO - https://raw.githubusercontent.com/mrworf/plexupdate/master/extras/installer.sh)"
-    # In case I need this file to do more than install updateplex in the future (unlikely)
-    touch /install/.updateplex.lock
+else
+    /opt/plexupdate/plexupdate.sh
 fi
 
 # Yes that's it, get outta here you dirty club rats


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Fixes issues: 
- Issue with not being able to easily re-run the plex upgrader

## Proposed Changes:
- Remove lockfile
- Directly call upgrader script after it has been installed when requested

## Categories
<!-- Delete whichever don't apply -->
- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Docs have been made OR are not necessary
    - PR link: https://github.com/liaralabs/docs.swizzin.ltd/commit/b76cc18ab8ac979f545cfee6f281ad57301c50ac
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas

## Testing done
OS & Version:

### How have you tested this
<!-- Story time, please! -->
Scenarios tested:
- I ran this and it worked
- I ran that and it didn't work

