### PR TITLE
Fix venv paths that were mistakenly not updated during virtualenv migrations

### DIFF
--- a/scripts/update/00-venv.sh
+++ b/scripts/update/00-venv.sh
@@ -16,10 +16,11 @@ if [[ -d /home/${user}/.venv ]]; then
 fi
 
 if [[ -d /opt/.venv ]]; then
-    envs=($(ls /opt/.venv))
-    for app in ${envs[@]}; do
-        if ! grep -q "#\!/opt/.venv/${app}/bin/python" /opt/.venv/${app}/bin/*; then
-            sed -i "s|#\!/.*/bin/python|#\!/opt/.venv/${app}/bin/python|g" /opt/.venv/${app}/bin/*
+    envs=($(find /opt/.venv/* -maxdepth 0 -type d))
+    for venvpath in ${envs[@]}; do
+        if ! grep -q "#\!${venvpath}/bin/python" ${venvpath}/bin/*; then
+            echo_log_only "Replacing venv path in $venvpath"
+            sed -i "s|#\!/.*/bin/python|#\!${venvpath}/bin/python|g" ${venvpath}/bin/*
         fi
     done
 fi

--- a/scripts/update/00-venv.sh
+++ b/scripts/update/00-venv.sh
@@ -14,3 +14,12 @@ if [[ -d /home/${user}/.venv ]]; then
         systemctl try-restart $app
     done
 fi
+
+if [[ -d /opt/.venv ]]; then
+    envs=($(ls /opt/.venv))
+    for app in ${envs[@]}; do
+        if ! grep -q "#\!/opt/.venv/${app}/bin/python" /opt/.venv/${app}/bin/*; then
+            sed -i "s|#\!/.*/bin/python|#\!/opt/.venv/${app}/bin/python|g" /opt/.venv/${app}/bin/*
+        fi
+    done
+fi


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Fixes issues: 
- `-bash: /opt/.venv/swizzin/bin/pip: /opt/swizzin/venv/bin/python3: bad interpreter: No such file or directory`
- after moving virtual environments, pip will not function because the env is still pointing to the wrong location

## Proposed Changes:
- `sed` the correct path into venvs if a fix is needed

## Categories
<!-- Delete whichever don't apply -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Docs have been made OR are not necessary
    - PR link: 
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [ ] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [ ] I have commented my code, particularly in hard-to-understand areas

## Testing done
OS & Version:
grep and sed commands tested on Debian 10

### How have you tested this
<!-- Story time, please! -->
Scenarios tested:
- Beyond sed and grep nothing at the moment

