### PR TITLE
Mango on Arm (fail until issues upstream of upstream are rresolved )

### DIFF
--- a/scripts/install/mango.sh
+++ b/scripts/install/mango.sh
@@ -26,12 +26,10 @@ function _install_mango() {
 
     mkdir -p "$mangodir"
     mkdir -p "$mangodir"/library
-    wget "${dlurl}" -O $mangodir/mango >> $log 2>&1
-    # shellcheck disable=SC2181
-    if [[ $? != 0 ]]; then
+    wget "${dlurl}" -O $mangodir/mango >> "$log" 2>&1 || {
         echo_error "Failed to download binary"
         exit 1
-    fi
+    }
     echo_progress_done "Binary downloaded"
 
     chmod +x $mangodir/mango

--- a/scripts/install/mango.sh
+++ b/scripts/install/mango.sh
@@ -13,7 +13,9 @@ function _install_mango() {
     case "$(_os_arch)" in
         "arm64" | "arm32")
             # TODO this needs the build process for amr
-            dlurl=$(curl -s https://api.github.com/repos/hkalexling/Mango/releases/latest | grep "browser_download_url" | grep "$(_os_arch)" | cut -d\" -f 4)
+            # dlurl=$(curl -s https://api.github.com/repos/hkalexling/Mango/releases/latest | grep "browser_download_url" | grep "$(_os_arch)" | cut -d\" -f 4)
+            echo_error "Currently unsupported but might be in the future. Please check back later!\nhttps://github.com/hkalexling/Mango/issues/131"
+            exit 1
             ;;
         "amd64")
             dlurl=$(curl -s https://api.github.com/repos/hkalexling/Mango/releases/latest | grep "browser_download_url" | head -1 | cut -d\" -f 4)

--- a/scripts/install/mango.sh
+++ b/scripts/install/mango.sh
@@ -12,6 +12,7 @@ function _install_mango() {
 
     case "$(_os_arch)" in
         "arm64" | "arm32")
+            # TODO this needs the build process for amr
             dlurl=$(curl -s https://api.github.com/repos/hkalexling/Mango/releases/latest | grep "browser_download_url" | grep "$(_os_arch)" | cut -d\" -f 4)
             ;;
         "amd64")

--- a/scripts/install/mango.sh
+++ b/scripts/install/mango.sh
@@ -9,12 +9,20 @@ mangousr="mango"
 # Downloading the latest binary
 function _install_mango() {
     echo_progress_start "Downloading binary"
-    dlurl=$(curl -s https://api.github.com/repos/hkalexling/Mango/releases/latest | grep "browser_download_url" | head -1 | cut -d\" -f 4)
-    # shellcheck disable=SC2181
-    if [[ $? != 0 ]]; then
-        echo_error "Failed to query github"
-        exit 1
-    fi
+
+    case "$(_os_arch)" in
+        "arm64" | "arm32")
+            dlurl=$(curl -s https://api.github.com/repos/hkalexling/Mango/releases/latest | grep "browser_download_url" | grep "$(_os_arch)" | cut -d\" -f 4)
+            ;;
+        "amd64")
+            dlurl=$(curl -s https://api.github.com/repos/hkalexling/Mango/releases/latest | grep "browser_download_url" | head -1 | cut -d\" -f 4)
+            ;;
+        *)
+            echo_error "Unsupported arch?"
+            exit 1
+            ;;
+    esac
+    echo_log_only "dlurl = $dlurl"
 
     mkdir -p "$mangodir"
     mkdir -p "$mangodir"/library


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Fixes issues: 
- Mango installer on `arm` wrongly succeeds

## Proposed Changes:
- Cancel builds on `arm` explicitly
- Handle failure of other architectures

## Categories
<!-- Delete whichever don't apply -->
- Bug fix (non-breaking change which fixes an issue)

## Architectures
<!-- In case it is impossible to handle due to some issues, please make sure to handle that case for the end-user's sexperience-->
- `x86_64` is specifically handled as:
    - [ ] Success
    - [ ] Error
    - Notes: 
- `arm64` is specifically handled as:
    - [ ] Success
    - [x] Error
    - Notes: Crystal can't build statically linked arm bins, following mid-stream (is that a word?) https://github.com/hkalexling/Mango/issues/131
- [ ] Changes are arch agnostic <!-- This means things like nginx/systemd/bash changes -->
    - Notes: 

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Docs have been made OR are not necessary
    - PR link: 
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas

## Testing done
OS & Version: Focal for `arm`

### How have you tested this
<!-- Story time, please! -->
Scenarios tested:
- Successfully fails to install on `arm64`

## Other remarks


