### PR TITLE
feat(nextcloud): Offer to remove database server while removing

### DIFF
--- a/scripts/remove/nextcloud.sh
+++ b/scripts/remove/nextcloud.sh
@@ -5,7 +5,15 @@ read -s 'password'
 rm -rf /srv/nextcloud
 rm /etc/nginx/apps/nextcloud.conf
 systemctl reload nginx
-host=$(mysql -u root --password="$password" --execute="select host from mysql.user where user = 'nextcloud';" | grep -E "localhost|127.0.0.1")
-mysql --user="root" --password="$password" --execute="DROP DATABASE nextcloud;"
-mysql --user="root" --password="$password" --execute="DROP USER nextcloud@$host;"
+
+if ask "Would you like to also remove the mysql/mariadb server?" N; then
+    apt_remove mariadb-server --purge
+else
+    echo_progress_start "Dropping nextcloud tables and user"
+    host=$(mysql -u root --password="$password" --execute="select host from mysql.user where user = 'nextcloud';" | grep -E "localhost|127.0.0.1")
+    mysql --user="root" --password="$password" --execute="DROP DATABASE nextcloud;"
+    mysql --user="root" --password="$password" --execute="DROP USER nextcloud@$host;"
+    echo_progress_done "Nextcloud dropped from database"
+fi
+
 rm /install/.nextcloud.lock


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Fixes issues: 
- `mariadb-server` stays installed and enabled after a nextcloud removal which could be undesired

## Proposed Changes:
- Ask user whether or not to remove `mariadb-server` during nextcloud removal
- By default, just drop the database tables and user as before

## Categories
<!-- Delete whichever don't apply -->
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## Architectures
<!-- In case it is impossible to handle due to some issues, please make sure to handle that case for the end-user's sexperience-->
- `x86_64` is specifically handled as:
    - [ ] Success
    - [ ] Error
    - Notes: 
- `arm64` is specifically handled as:
    - [ ] Success
    - [ ] Error
    - Notes: 
- [x] Changes are arch agnostic <!-- This means things like nginx/systemd/bash changes -->
    - Notes: using `apt`

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [ ] Docs have been made OR are not necessary
    - PR link: 
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas

## Testing done
OS & Version:

### How have you tested this
<!-- Story time, please! -->
Scenarios tested:
- I ran this and it worked
- I ran that and it didn't work

## Other remarks


