### PR TITLE
HOTFIX don't run rtx when no rutorrent installed

### DIFF
--- a/scripts/rtx
+++ b/scripts/rtx
@@ -1,6 +1,14 @@
 #!/bin/bash
 # ruTorrent e(x)tras management
 
+function _check_for_rutorrent() {
+    if [ -f "/install/.rutorrent.lock" ]; then
+        echo_error "RuTorrent is not installed. Installing extensions into something that is not installed is slightly impossible ;)"
+        exit 1
+    fi
+}
+_check_for_rutorrent
+
 function _intro() {
     whiptail --title "ruTorrent Extras Manager" --msgbox "Welcome to rtx! Using this script you can choose to install and remove the plugins and themes for ruTorrent. Use the arrow keys to navigate, spacebar to toggle the currently selected item and enter to continue." 15 50
 }


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Fixes issues: 
- `rtx` can run even if rutorrent is not installed

## Proposed Changes:
- Add a lockfile check and `exit 1` if rutorrent is missing

## Categories
<!-- Delete whichever don't apply -->
- Bug fix (non-breaking change which fixes an issue)

## Architectures
<!-- In case it is impossible to handle due to some issues, please make sure to handle that case for the end-user's sexperience-->
- `x86_64` is specifically handled as:
    - [ ] Success
    - [ ] Error
    - Notes: 
- `arm64` is specifically handled as:
    - [ ] Success
    - [ ] Error
    - Notes: 
- [x] Changes are arch agnostic <!-- This means things like nginx/systemd/bash changes -->
    - Notes: Just a lockfile check that

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [ ] Docs have been made OR are not necessary
    - PR link: 
- [ ] Changes to panel have been made OR are not necessary
    - PR link: 
- [ ] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [ ] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [ ] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [ ] I have commented my code, particularly in hard-to-understand areas

## Testing done
OS & Version:

### How have you tested this
None, should just work

## Other remarks


