### PR TITLE
IMPROVE: Nginx WebSocket support for Mango

### DIFF
--- a/scripts/nginx/mango.sh
+++ b/scripts/nginx/mango.sh
@@ -4,6 +4,9 @@
 cat > /etc/nginx/apps/mango.conf << EOF
 location /mango/ {
   proxy_pass http://localhost:9003/;
+  proxy_http_version 1.1;
+  proxy_set_header Upgrade $http_upgrade;
+  proxy_set_header Connection "upgrade";
 }
 EOF
 

--- a/scripts/nginx/mango.sh
+++ b/scripts/nginx/mango.sh
@@ -5,7 +5,7 @@ cat > /etc/nginx/apps/mango.conf << EOF
 location /mango/ {
   proxy_pass http://localhost:9003/;
   proxy_http_version 1.1;
-  proxy_set_header Upgrade $http_upgrade;
+  proxy_set_header Upgrade \$http_upgrade;
   proxy_set_header Connection "upgrade";
 }
 EOF

--- a/scripts/update/mango.sh
+++ b/scripts/update/mango.sh
@@ -9,3 +9,19 @@ fi
 if [[ -f /root/mango.info ]]; then
     rm /root/mango.info
 fi
+
+# Adding support for websockets
+if [[ -f /etc/nginx/apps/mango.conf ]]; then
+    if ! grep -q "proxy_set_header Upgrade \$http_upgrade;" /etc/nginx/apps/mango.conf; then
+        echo_log_only "Adding websocket support to mango nginx conf"
+        cat > /etc/nginx/apps/mango.conf << EOF
+location /mango/ {
+  proxy_pass http://localhost:9003/;
+  proxy_http_version 1.1;
+  proxy_set_header Upgrade \$http_upgrade;
+  proxy_set_header Connection "upgrade";
+}
+EOF
+        systemctl nginx reload
+    fi
+fi


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Fixes issues: 
N/A

## Proposed Changes:
-  Proxy WebSocket in Mango Nginx config

## Categories
<!-- Delete whichever don't apply -->
- Bug fix (non-breaking change which fixes an issue)

## Architectures
<!-- In case it is impossible to handle due to some issues, please make sure to handle that case for the end-user's sexperience-->
- `x86_64` is specifically handled as:
    - [ ] Success
    - [ ] Error
    - Notes: 
- `arm64` is specifically handled as:
    - [ ] Success
    - [ ] Error
    - Notes: 
- [x] Changes are arch agnostic <!-- This means things like nginx/systemd/bash changes -->
    - Notes: 

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Docs have been made OR are not necessary
    - PR link: 
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas

## Testing done
OS & Version: Ubuntu 20.04, amd64

### How have you tested this
<!-- Story time, please! -->
Scenarios tested:
- I ran this and it worked

## Other remarks

Since v0.17.0, Mango uses WebSocket on the download manager page. This PR updates the Nginx config so Nginx would proxy the WS requests to Mango.


