### PR TITLE
fix: allow the use of sub directories in the /etc/nginx/app directory…

### DIFF
--- a/scripts/install/nginx.sh
+++ b/scripts/install/nginx.sh
@@ -110,7 +110,7 @@ server {
   server_tokens off;
   root /srv/;
 
-  include /etc/nginx/apps/*;
+  include /etc/nginx/apps/*.conf;
 
   location ~ /\.ht {
     deny all;
@@ -189,8 +189,8 @@ fancyindex_localtime on;
 fancyindex_exact_size off;
 fancyindex_header "/fancyindex/header.html";
 fancyindex_footer "/fancyindex/footer.html";
-#fancyindex_ignore "examplefile.html"; # Ignored files will not show up in the directory listing, but will still be public. 
-#fancyindex_ignore "Nginx-Fancyindex-Theme"; # Making sure folder where files are don't show up in the listing. 
+#fancyindex_ignore "examplefile.html"; # Ignored files will not show up in the directory listing, but will still be public.
+#fancyindex_ignore "Nginx-Fancyindex-Theme"; # Making sure folder where files are don't show up in the listing.
 fancyindex_name_length 255; # Maximum file name length in bytes, change as you like.
 FIC
 sed -i 's/href="\/[^\/]*/href="\/fancyindex/g' /srv/fancyindex/header.html
@@ -209,7 +209,7 @@ done
 
 echo_progress_start "Restarting nginx"
 systemctl restart nginx
-echo_progress_done "Nginx restared"
+echo_progress_done "Nginx restarted"
 
 #shellcheck source=sources/functions/php
 . /etc/swizzin/sources/functions/php

--- a/scripts/update/nginx.sh
+++ b/scripts/update/nginx.sh
@@ -96,10 +96,10 @@ location /rtorrent.downloads {
   include /etc/nginx/snippets/fancyindex.conf;
   auth_basic "What's the password?";
   auth_basic_user_file /etc/htpasswd;
-  
+
   location ~* \.php$ {
 
-  } 
+  }
 }
 EOR
         fi
@@ -118,7 +118,7 @@ location /deluge.downloads {
 
   location ~* \.php$ {
 
-  } 
+  }
 }
 DIN
         fi
@@ -137,6 +137,9 @@ DIN
     . /etc/swizzin/sources/functions/php
     restart_php_fpm
     systemctl reload nginx
+
+    # fix /etc/nginx/sites-enabled/default to load from subdirectories on /etc/nginx/apps
+    sed 's|include /etc/nginx/apps/\*;|include /etc/nginx/apps/\*\.conf;|g' -i /etc/nginx/sites-enabled/default
 }
 
 if [[ -f /install/.nginx.lock ]]; then update_nginx; fi

--- a/scripts/update/nginx.sh
+++ b/scripts/update/nginx.sh
@@ -138,7 +138,7 @@ DIN
     restart_php_fpm
     systemctl reload nginx
 
-    # fix /etc/nginx/sites-enabled/default to load from subdirectories on /etc/nginx/apps
+    # fix /etc/nginx/sites-enabled/default to no fail to reload when there are subdirectories in /etc/nginx/apps like /etc/nginx/apps/authelia
     sed 's|include /etc/nginx/apps/\*;|include /etc/nginx/apps/\*\.conf;|g' -i /etc/nginx/sites-enabled/default
 }
 

--- a/scripts/update/nginx.sh
+++ b/scripts/update/nginx.sh
@@ -138,8 +138,8 @@ DIN
     restart_php_fpm
     systemctl reload nginx
 
-    # fix /etc/nginx/sites-enabled/default to no fail to reload when there are subdirectories in /etc/nginx/apps like /etc/nginx/apps/authelia
-    sed 's|include /etc/nginx/apps/\*;|include /etc/nginx/apps/\*\.conf;|g' -i /etc/nginx/sites-enabled/default
+    # fix /etc/nginx/sites-enabled/default to not cause nginx to fail on reloading when there are subdirectories in /etc/nginx/apps like /etc/nginx/apps/authelia
+    sed 's|include /etc/nginx/apps/\*;|include /etc/nginx/apps/\*.conf;|g' -i /etc/nginx/sites-enabled/default
 }
 
 if [[ -f /install/.nginx.lock ]]; then update_nginx; fi


### PR DESCRIPTION
…. This is a prerequisite patch for Authelia

<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description
<!-- Any general story time goes here :) Feel free to add screenshots/recording of your change in action here-->

Change how the nginx apps directory is sourced so that it only loads `conf` files and does not break for trying to load a directory.

## Fixes issues: 

nginx not restarting if there is a directory in the `/etc/nginx/apps` directory.

## Proposed Changes:

`include /etc/nginx/apps/*;|` becomes `include /etc/nginx/apps/*.conf;` in the `/etc/nginx/sites-enabled/default`

## Change Categories
- Bug fix <!-- non-breaking change which fixes an issue -->
- New feature <!-- non-breaking change which adds functionality -->

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Docs have been made OR are not necessary
    - PR link: 
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas

## Test scenarios
<!-- Please let us know what has been done or anything else that works/doesn't. Feel free to copy-paste the examples at the bottom of this section -->

### Architectures
<!--
Please use these emojis here to fill the table below. It will nicely auto-format with spacing, don't worry. Leave empty wherever you do not know / have not tested
✅ = Works successfully
❎ = Does not work BUT is handled gracefully
🛠 = Still WIP
❌ = Broken / not working
-->
|   			| `amd64` 	| `armhf` 	| `arm64` 	| Unspecified 	|
|--------		|-------- 	|-------- 	|-------- 	|----------		|
| Focal 		|			|			|			|				|
| Bionic		|			|			|			|				|
| Buster		|			|			|			|				|
| Stretch		|			|			|			|				|
| Raspbian  	|	⚫️		|			|	⚫️		|	⚫️			|

### ✅❎ Passed

### 🛠🛠 TODO

### ❌❌ Currently failing

<!-- EXAMPLES :
- Fresh app install without nginx
    - With only one user
    - With multiple users present
- Fresh Install with nginx present nginx
    - With only one user
    - With multiple users present
- Fresh install and nginx install afterwards
    - With only one user
    - With multiple users present
- Update from version in master
- Upgrade from version in master
- Password gets changed from `box` in app
- User removal from `box` acting on app
- New user in `box` gets added to app
- Sysinfo compatibility
    - Info washed
    - Content available
-->

