### PR TITLE
feature: function : app ports

### DIFF
--- a/sources/functions/app_port
+++ b/sources/functions/app_port
@@ -7,7 +7,7 @@ app_port[authelia]=9091
 app_port[filebrowser]=9090
 app_port[jackett]=9117
 #
-# Use this function to get a port from the array using the command inside an install script app_port="$(_get_app_port "$(basename -- "$0")")"
+# Use this function to get a port from the array using the command inside an install script app_proxy_port="$(_get_app_port "$(basename -- "$0" \.sh)")"
 _get_app_port() {
     if [[ -n "${1}" ]]; then
         if [[ -n ${app_port[$1]+$1} ]]; then

--- a/sources/functions/app_port
+++ b/sources/functions/app_port
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+declare -A app_port
+#
+# List our ports here using the forman array_name[app_name]port
+app_port[authelia]=9091
+app_port[filebrowser]=9090
+app_port[jackett]=9117
+#
+# Use this function to get a port from the array using the command inside an install script app_port="$(_get_app_port "$(basename -- "$0")")"
+_get_app_port() {
+    if [[ -n "${1}" ]]; then
+        if [[ -n ${app_port[$1]+$1} ]]; then
+            echo ${app_port[$1]}
+        else
+            echo "get_app_port ERROR app name does not exist "
+        fi
+    else
+        echo "get_app_port ERROR no app name provided"
+    fi
+}


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description

This function uses port values stored in a bash associative array, like this:

```bash
app_port[authelia]=9091
app_port[filebrowser]=9090
app_port[jackett]=9117
```

And calls the function passing the script name as the positional parameter using this command

```bash
_get_app_port "$(basename -- "$0" \.sh)"
```
So if the `jackett.sh` script uses this command:

```bash
app_proxy_port="$(_get_app_port "$(basename -- "$0" \.sh)")"
```

`app_proxy_port` will be set to `9117`

Since all scripts are named as their respective application defining the port as the script name, minus the extension, will give a predictable and constant result.

**Other considerations:**

- The array does not have to be stored in the function.
- The errors could be mad set to use existing functions or provide a different result.

## Fixes issues: 
- na
- 
## Proposed Changes:
All scripts use this command and variable instead of hardcoding the port

```bash
app_proxy_port="$(_get_app_port "$(basename -- "$0" \.sh)")"
```

## Change Categories
- New feature <!-- non-breaking change which adds functionality -->
- Change in `functions` <!-- e.g. `utils`, `os`, `apt`, `ask`, etc. -->
- Contribution flow <!-- IDE changes, `.github` dir, etc. -->

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Docs have been made OR are not necessary
    - PR link: 
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas

## Test scenarios
<!-- Please let us know what has been done or anything else that works/doesn't. Feel free to copy-paste the examples at the bottom of this section -->

### Architectures
<!--
Please use these emojis here to fill the table below. It will nicely auto-format with spacing, don't worry. Leave empty wherever you do not know / have not tested
✅ = Works successfully
❎ = Does not work BUT is handled gracefully
🛠 = Still WIP
❌ = Broken / not working
-->
|   			| `amd64` 	| `armhf` 	| `arm64` 	| Unspecified 	|
|--------		|-------- 	|-------- 	|-------- 	|----------		|
| Focal 		|			|			|			|				|
| Bionic		|			|			|			|				|
| Buster		|			|			|			|				|
| Stretch		|			|			|			|				|
| Raspbian  	|	⚫️		|			|	⚫️		|	⚫️			|

### ✅❎ Passed

### 🛠🛠 TODO

### ❌❌ Currently failing

<!-- EXAMPLES :
- Fresh app install without nginx
    - With only one user
    - With multiple users present
- Fresh Install with nginx present nginx
    - With only one user
    - With multiple users present
- Fresh install and nginx install afterwards
    - With only one user
    - With multiple users present
- Update from version in master
- Upgrade from version in master
- Password gets changed from `box` in app
- User removal from `box` acting on app
- New user in `box` gets added to app
- Sysinfo compatibility
    - Info washed
    - Content available
-->

