### PR TITLE
fix: make sure globals is resourced before updating apps.

### DIFF
--- a/scripts/box
+++ b/scripts/box
@@ -140,10 +140,6 @@ function _update() {
         echo_progress_done "Local repository updated"
     fi
 
-    # source globals again in case changes were made
-    #shellcheck source=sources/globals.sh
-    . /etc/swizzin/sources/globals.sh
-
     for f in /etc/swizzin/scripts/update/*; do
         bash "$f"
     done

--- a/scripts/box
+++ b/scripts/box
@@ -140,6 +140,10 @@ function _update() {
         echo_progress_done "Local repository updated"
     fi
 
+    # source globals again in case changes were made
+    #shellcheck source=sources/globals.sh
+    . /etc/swizzin/sources/globals.sh
+
     for f in /etc/swizzin/scripts/update/*; do
         bash "$f"
     done

--- a/scripts/update/00-checkreqs.sh
+++ b/scripts/update/00-checkreqs.sh
@@ -2,6 +2,9 @@
 # Checks if required functions are loaded before continuing with the update scripts.
 # Function should be loaded on the next run (by `box`) without further need for interaction.
 
+# DO NOT SOURCE GLOBALS HERE, THAT DEFEATS THE WHOLE PURPOSE OF THIS CHECK
+# SOURCING GLOBALS HERE WILL MAKE THESE TESTS PASS BUT THE FUNCTIONS WON'T BE AVAILABLE IN THE SHELL ABOVE
+
 if ! command -v apt_install > /dev/null 2>&1; then
     echo
     echo "Due to internal restructuring please restart \`box update\`. You should only have to do this once."
@@ -22,6 +25,14 @@ if [[ -z $log ]]; then
     echo
     echo "Due to internal restructuring please restart \`box update\`. You should only have to do this once."
     echo "Reason: log not set"
+    kill -13 $(ps --pid $$ -oppid=)
+    exit 1
+fi
+
+if ! swizdb list; then
+    echo
+    echo "Due to internal restructuring please restart \`box update\`. You should only have to do this once."
+    echo "Reason: swizdb licommand unavailable"
     kill -13 $(ps --pid $$ -oppid=)
     exit 1
 fi

--- a/scripts/update/00-checkreqs.sh
+++ b/scripts/update/00-checkreqs.sh
@@ -29,7 +29,7 @@ if [[ -z $log ]]; then
     exit 1
 fi
 
-if ! swizdb list; then
+if ! swizdb list > /dev/null; then
     echo
     echo "Due to internal restructuring please restart \`box update\`. You should only have to do this once."
     echo "Reason: swizdb list command unavailable"

--- a/scripts/update/00-checkreqs.sh
+++ b/scripts/update/00-checkreqs.sh
@@ -32,7 +32,7 @@ fi
 if ! swizdb list; then
     echo
     echo "Due to internal restructuring please restart \`box update\`. You should only have to do this once."
-    echo "Reason: swizdb licommand unavailable"
+    echo "Reason: swizdb list command unavailable"
     kill -13 $(ps --pid $$ -oppid=)
     exit 1
 fi

--- a/scripts/update/00-checkreqs.sh
+++ b/scripts/update/00-checkreqs.sh
@@ -2,10 +2,6 @@
 # Checks if required functions are loaded before continuing with the update scripts.
 # Function should be loaded on the next run (by `box`) without further need for interaction.
 
-# source globals again in case changes were made
-#shellcheck source=sources/globals.sh
-. /etc/swizzin/sources/globals.sh
-
 if ! command -v apt_install > /dev/null 2>&1; then
     echo
     echo "Due to internal restructuring please restart \`box update\`. You should only have to do this once."


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description

Globals needs to be sourced after git pull and before running the update scripts in a subshell.

## Fixes issues: 
- swizdb changes error on update
