### PR TITLE
feat(IDE): enforce linux line breaks in vscode

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,7 @@
 *.fish text eol=lf
 *.sh text eol=lf
 
-sources/functions/* diff=bash
+sources/functions/* diff=bash eol=lf
 
 # To disable checking modes, run `git config core.fileMode false`
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,5 +27,6 @@
         "makefile",
         "shellscript",
         "bash"
-    ]
+    ],
+    "files.eol": "\n",
 }


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description
<!-- Any general story time goes here :) Feel free to add screenshots/recording of your change in action here-->
Forces lie breaks to be `\n` instead of letting vscode guess
## Fixes issues: 
- This guy
<img width="467" alt="image" src="https://user-images.githubusercontent.com/23618693/116276375-bccceb80-a784-11eb-8d8d-5e10ab37bdbe.png">


## Proposed Changes:
- Force it project-wide

## Change Categories
<!-- DELETE WHICHEVER BULLET DOES NOT APPLY -->
- Contribution flow <!-- IDE changes, `.github` dir, etc. -->

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Docs have been made OR are not necessary
    - PR link: 
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have functionally tested the changes being introduced

## Test scenarios
<!-- Please let us know what has been done or anything else that works/doesn't. Feel free to copy-paste the examples at the bottom of this section -->
N/A