### PR TITLE
fix(swizdb): handle bad keys in gets better

### DIFF
--- a/sources/functions/swizdb
+++ b/sources/functions/swizdb
@@ -88,12 +88,12 @@ export -f _setswizdb
 # **Returns code 1 if not found**
 _pathswizdb() {
     key="$1"
-    if [ -e "$dbdir/$key" ]; then
+    if [ -f "$dbdir/$key" ] || [ -L "$dbdir/$key" ]; then
         echo_log_only "Path of file for key \"$key\" is  \"$dbdir/$key\""
         echo "$dbdir/$key"
         return 0
     else
-        echo_log_only "File for key \"$key\" does not exist"
+        echo_log_only "File/symlink for key \"$key\" does not exist"
         return 1
     fi
 }

--- a/sources/functions/swizdb
+++ b/sources/functions/swizdb
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#shellcheck disable=SC2002
 
 export dbdir="/var/lib/swizzin/db"
 
@@ -39,6 +40,7 @@ _getswizdb() {
     }
     echo_log_only "Output of key \"$key\""
     cat "$path" | tee -a "$log"
+    return "${PIPESTATUS[0]}"
 }
 export -f _getswizdb
 


### PR DESCRIPTION
- fix(swizdb): check if key is file or link
- fix(swizdb): return code of first command in path

<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description
Return codes from swizdbget could give false positives

## Fixes issues: 
- those false psotives

## Proposed Changes:
- Check keys more strictly
- Return error code of `cat` without that of `tee`

## Change Categories
<!-- DELETE WHICHEVER BULLET DOES NOT APPLY -->
- Bug fix <!-- non-breaking change which fixes an issue -->
- Change in `functions` <!-- e.g. `utils`, `os`, `apt`, `ask`, etc. -->

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Docs have been made OR are not necessary
    - PR link: 
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have functionally tested the changes being introduced

## Test scenarios
<!-- Please let us know what has been done or anything else that works/doesn't. Feel free to copy-paste the examples at the bottom of this section -->

### Architectures
<!--
Please use these emojis here to fill the table below. It will nicely auto-format with spacing, don't worry. Leave empty wherever you do not know / have not tested
✅ = Works successfully
❎ = Does not work BUT is handled gracefully
🛠 = Still WIP
❌ = Broken / not working
-->
|   			| `amd64` 	| `armhf` 	| `arm64` 	| Unspecified 	|
|--------		|-------- 	|-------- 	|-------- 	|----------		|
| Focal 		|			|			|			|				|
| Bionic		|			|			|			|				|
| Buster		|			|			|			|				|
| Stretch		|			|			|			|				|
| Raspbian  	|	⚫️		|			|	⚫️		|	⚫️			|

### ✅❎ Passed
<img width="507" alt="image" src="https://user-images.githubusercontent.com/23618693/116616320-e03a9680-a93c-11eb-8472-4c666ec58b04.png">

(and when I disable the path check first, the pipestatus still catches that)
<img width="413" alt="image" src="https://user-images.githubusercontent.com/23618693/116616717-4fb08600-a93d-11eb-9e81-840458a1cd5a.png">


### 🛠🛠 TODO

### ❌❌ Currently failing

<!-- EXAMPLES :
- Fresh app install without nginx
    - With only one user
    - With multiple users present
- Fresh Install with nginx present nginx
    - With only one user
    - With multiple users present
- Fresh install and nginx install afterwards
    - With only one user
    - With multiple users present
- Update from version in master
- Upgrade from version in master
- Password gets changed from `box` in app
- User removal from `box` acting on app
- New user in `box` gets added to app
- Sysinfo compatibility
    - Info washed
    - Content available
-->

