### PR TITLE
fix bash_completion

### DIFF
--- a/sources/bash_completion
+++ b/sources/bash_completion
@@ -3,19 +3,19 @@
 # ln -fs /etc/swizzin/sources/bash_completion/swizzin /etc/bash_completion.d/swizzin
 #
 _command_complete() {
-    local cur prev
+    local cur sub_cmd
     cur=${COMP_WORDS[COMP_CWORD]}
-    prev=${COMP_WORDS[COMP_CWORD - 1]}
+    sub_cmd=${COMP_WORDS[1]}
 
-    readarray -t apps_array < <(cat '/var/lib/swizzin/db/bash_completion/apps.list')
-    readarray -t upgrade_array < <(cat '/var/lib/swizzin/db/bash_completion/upgrade.list')
+    mapfile -t apps_array < '/var/lib/swizzin/db/bash_completion/apps.list'
+    mapfile -t upgrade_array < '/var/lib/swizzin/db/bash_completion/upgrade.list'
 
     case ${COMP_CWORD} in
         1)
             mapfile -t COMPREPLY < <(compgen -W "install remove adduser deluser chpasswd update upgrade rtx rmgrsec list help" -- "${cur}")
             ;;
-        2)
-            case ${prev} in
+        *)
+            case ${sub_cmd} in
                 install)
                     mapfile -t COMPREPLY < <(compgen -W "$(printf "%s " "${apps_array[@]%.*}")" -- "${cur}")
                     ;;
@@ -26,11 +26,7 @@ _command_complete() {
                     mapfile -t COMPREPLY < <(compgen -W "$(printf "%s " "${upgrade_array[@]%.*}")" -- "${cur}")
                     ;;
                 *) ;;
-
             esac
-            ;;
-        *)
-            COMPREPLY=()
             ;;
     esac
 }


### PR DESCRIPTION
## Description

Fixes the completion not tabbing through the apps/upgrade list after the first result.

It now tabs as many times as needed

`box install TAB app TAB app TAB app`

and

`box remove TAB app TAB app TAB app`

Also removed `cat` command expansion as it turns out I can pass the file directly.

committed to `mapfile` instead of `readarray`

change made with help in `#bash`

## Fixes issues: 
- Un-tracked issue: bash completion not tabbing through apps list for multiple selections

## Proposed Changes:
- minor changes to the completion file.

## Change Categories
- Bug fix

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Docs have been made OR are not necessary
    - PR link: 
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have functionally tested the changes being introduced

## Test scenarios
<!-- Please let us know what has been done or anything else that works/doesn't. Feel free to copy-paste the examples at the bottom of this section -->

Debian Stable

### Architectures
<!--
Please use these emojis here to fill the table below. It will nicely auto-format with spacing, don't worry. Leave empty wherever you do not know / have not tested
✅ = Works successfully
❎ = Does not work BUT is handled gracefully
🛠 = Still WIP
❌ = Broken / not working
-->
|   			| `amd64` 	| `armhf` 	| `arm64` 	| Unspecified 	|
|--------		|-------- 	|-------- 	|-------- 	|----------		|
| Focal 		|			|			|			|				|
| Bionic		|			|			|			|				|
| Buster		|	✅		|			|			|				|
| Stretch		|			|			|			|				|
| Raspbian  	|	⚫️		|			|	⚫️		|	⚫️			|

### ✅❎ Passed

### 🛠🛠 TODO

### ❌❌ Currently failing

<!-- EXAMPLES :
- Fresh app install without nginx
    - With only one user
    - With multiple users present
- Fresh Install with nginx present nginx
    - With only one user
    - With multiple users present
- Fresh install and nginx install afterwards
    - With only one user
    - With multiple users present
- Update from version in master
- Upgrade from version in master
- Password gets changed from `box` in app
- User removal from `box` acting on app
- New user in `box` gets added to app
- Sysinfo compatibility
    - Info washed
    - Content available
-->

