### PR TITLE
fix(swizdb): ensure key dirs get returned in path calls

### DIFF
--- a/sources/functions/swizdb
+++ b/sources/functions/swizdb
@@ -94,6 +94,9 @@ _pathswizdb() {
         echo_log_only "Path of file for key \"$key\" is  \"$dbdir/$key\""
         echo "$dbdir/$key"
         return 0
+    elif [ -d "$dbdir/$key" ]; then
+        echo "$dbdir/$key"
+        return 2
     else
         echo_log_only "File/symlink for key \"$key\" does not exist"
         return 1

--- a/sources/functions/swizdb
+++ b/sources/functions/swizdb
@@ -88,6 +88,7 @@ export -f _setswizdb
 # $1 = key
 # \
 # **Returns code 1 if not found**
+# **Returns code 2 if found, but a directory**
 _pathswizdb() {
     key="$1"
     if [ -f "$dbdir/$key" ] || [ -L "$dbdir/$key" ]; then

--- a/sources/functions/swizdb
+++ b/sources/functions/swizdb
@@ -95,7 +95,7 @@ _pathswizdb() {
         echo "$dbdir/$key"
         return 0
     elif [ -d "$dbdir/$key" ]; then
-        echo "$dbdir/$key"
+        echo "$dbdir/$key/"
         return 2
     else
         echo_log_only "File/symlink for key \"$key\" does not exist"


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description
<!-- Any general story time goes here :) Feel free to add screenshots/recording of your change in action here-->

## Fixes issues: 
- `swizdb` path changing behaviour since the switch from `-e`

<img width="702" alt="image" src="https://user-images.githubusercontent.com/23618693/119404079-96e12b00-bcdf-11eb-8269-937fc3f950fd.png">

## Proposed Changes:
- Add exit code 2 to `swizdb path` when a directory is encountered as key
   - BUT still echo the full path of the dir
   - rest of the functions continue to work as intended
- Add trailing slash to the return of `swizdb path` when a directory is encountered.

## Change Categories
<!-- DELETE WHICHEVER BULLET DOES NOT APPLY -->
- Bug fix <!-- non-breaking change which fixes an issue -->
- Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->


## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Docs have been made OR are not necessary
    - PR link: 
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have functionally tested the changes being introduced

## Test scenarios
<!-- Please let us know what has been done or anything else that works/doesn't. Feel free to copy-paste the examples at the bottom of this section -->

### Architectures
<!--
Please use these emojis here to fill the table below. It will nicely auto-format with spacing, don't worry. Leave empty wherever you do not know / have not tested
✅ = Works successfully
❎ = Does not work BUT is handled gracefully
🛠 = Still WIP
❌ = Broken / not working
-->
|   			| `amd64` 	| `armhf` 	| `arm64` 	| Unspecified 	|
|--------		|-------- 	|-------- 	|-------- 	|----------		|
| Focal 		|			|			|	✅ 		|				|
| Bionic		|			|			|			|				|
| Buster		|			|			|			|				|
| Stretch		|			|			|			|				|
| Raspbian  	|	⚫️		|			|	⚫️		|	⚫️			|

### ✅❎ Passed
<img width="543" alt="image" src="https://user-images.githubusercontent.com/23618693/119404616-559d4b00-bce0-11eb-861c-e090473ed63d.png">

<img width="382" alt="image" src="https://user-images.githubusercontent.com/23618693/119404790-94330580-bce0-11eb-8929-ea6379225415.png">

### 🛠🛠 TODO

### ❌❌ Currently failing

<!-- EXAMPLES :
- Fresh app install without nginx
    - With only one user
    - With multiple users present
- Fresh Install with nginx present nginx
    - With only one user
    - With multiple users present
- Fresh install and nginx install afterwards
    - With only one user
    - With multiple users present
- Update from version in master
- Upgrade from version in master
- Password gets changed from `box` in app
- User removal from `box` acting on app
- New user in `box` gets added to app
- Sysinfo compatibility
    - Info washed
    - Content available
-->

