### PR TITLE
feat(ci): Automatically create PRs from master to develop

### DIFF
--- a/.github/workflows/develop-updating.yml
+++ b/.github/workflows/develop-updating.yml
@@ -1,0 +1,20 @@
+name: Create PR from master to develop
+on:
+  push:
+    branches:
+      - master
+jobs:
+  productionPromotion:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: develop
+      - name: Reset promotion branch
+        run: |
+          git fetch origin master:master
+          git merge master
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          branch: production-promotion


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description
To ensure develop is kept up to date, PRs should be automatically made to merge master into it.

This way we can merge hotfixes into master once, and have them go into develop straight away.

Also, any commits made in release branches will make their way back to develop.

## Fixes issues: 
N/A

## Proposed Changes:
CI

## Change Categories
<!-- DELETE WHICHEVER BULLET DOES NOT APPLY -->
- New feature <!-- non-breaking change which adds functionality -->
- Contribution flow <!-- IDE changes, `.github` dir, etc. -->

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [ ] Docs have been made OR are not necessary
    - PR link: 
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have functionally tested the changes being introduced

## Test scenarios
We can only really see when this is merged to master, sadly...
