### PR TITLE
feat(box): stay on develop over `box update` runs, allow auto-testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .dev.lock
+.test.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .dev.lock
 .test.lock
+dev.env

--- a/scripts/box
+++ b/scripts/box
@@ -535,7 +535,6 @@ fi
 
 if [[ ! $branch_name =~ ^(master|eol-.*)$ ]]; then
     echo_info "Just FYI, you're not on the $branch_name branch! Remember that you need to mention this when asking for any sort of support."
-    runtests="true"
 fi
 
 if [[ -L /etc/swizzin ]]; then

--- a/scripts/box
+++ b/scripts/box
@@ -524,7 +524,7 @@ _run_tests() {
 
 }
 
-branch_name="$(git symbolic-ref HEAD 2> /dev/null)" || branch_name="(unnamed branch)" # detached HEAD
+branch_name="$(git -C /etc/swizzin symbolic-ref HEAD 2> /dev/null)" || branch_name="(unnamed branch)" # detached HEAD
 branch_name=${branch_name##refs/heads/}
 if [ "$branch_name" == "develop" ]; then
     SWIZ_GIT_REF="develop"

--- a/scripts/box
+++ b/scripts/box
@@ -574,7 +574,6 @@ case "$1" in
             exit 1
         fi
         _cli "$@"
-        # Tests should be ran on non-stables: Test app installed correctly
         ;;
     "remove" | "rm")
         if [[ -z $2 ]]; then
@@ -582,7 +581,6 @@ case "$1" in
             exit 1
         fi
         _clr "$@"
-        # Tests should be ran on non-stables: Check removes didn't bork anything else
         ;;
     "adduser")
         if [[ -n $4 ]]; then
@@ -590,7 +588,6 @@ case "$1" in
             exit 1
         fi
         _adduser "$@"
-        # Tests should be ran on non-stables: this hits many installer scripts
         ;;
     "deluser")
         if [[ -z $2 ]]; then
@@ -602,7 +599,6 @@ case "$1" in
             exit 1
         fi
         _deluser "$@"
-        # Tests should be ran on non-stables: Lot of custom logic in box that needs to be tested
         ;;
     "chpasswd")
         if [[ -z $2 ]]; then
@@ -614,7 +610,6 @@ case "$1" in
             exit 1
         fi
         _chpasswd "$@"
-        # Tests should be ran on non-stables: Password changers are super prone to messing things up
         ;;
     "rmgrsec")
         _nukeovh
@@ -626,7 +621,6 @@ case "$1" in
         ;;
     "update")
         _update "$2"
-        # Tests should be ran on non-stables: Ensure apps installed right
         ;;
     "upgrade")
         if [[ $2 = "--dev" ]]; then

--- a/scripts/box
+++ b/scripts/box
@@ -125,14 +125,6 @@ function _clr() {
 #shellcheck disable=SC2120
 function _update() {
 
-    branch_name="$(git symbolic-ref HEAD 2> /dev/null)" || branch_name="(unnamed branch)" # detached HEAD
-    branch_name=${branch_name##refs/heads/}
-    if [ "$branch_name" == "develop" ]; then
-        SWIZ_GIT_REF="develop"
-        export SWIZ_GIT_REF
-        echo_info "Just FYI, you're on the develop branch! Remember that you need to mention this when asking for any sort of support."
-    fi
-
     case "$(_os_codename)" in
         "bionic" | "focal" | "buster" | "stretch" | "bullseye")
             echo_log_only "OS supported"
@@ -147,13 +139,8 @@ We URGE you to migrate to a supported release if/while you still have the chance
             ;;
     esac
 
-    if [[ -L /etc/swizzin ]]; then
-        echo_warn "Not updating /etc/swizzin as it is a symlink. Please consult your provider/maintainers in case you believe this is an error."
-    elif [[ -e /etc/swizzin/.dev.lock ]]; then
-        echo_warn "Not updating /etc/swizzin as a dev lockfile is present."
-    elif [[ $1 == "--dev" ]]; then
-        echo_warn "Not updating from git due to --dev flag"
-    else
+    echo_log_only "noupdate = $noupdate"
+    if [[ -z $noupdate ]]; then
         echo_progress_start "Updating swizzin local repository"
         git -C /etc/swizzin checkout "${SWIZ_GIT_REF:-master}" >> $log 2>&1 ||
             {
@@ -536,11 +523,33 @@ _run_tests() {
 
 }
 
+branch_name="$(git symbolic-ref HEAD 2> /dev/null)" || branch_name="(unnamed branch)" # detached HEAD
+branch_name=${branch_name##refs/heads/}
+if [ "$branch_name" == "develop" ]; then
+    SWIZ_GIT_REF="develop"
+    export SWIZ_GIT_REF
+    echo_info "Just FYI, you're on the develop branch! Remember that you need to mention this when asking for any sort of support."
+    runtests="true"
+fi
+
+if [[ -L /etc/swizzin ]]; then
+    echo_warn "Not updating /etc/swizzin as it is a symlink. Please consult your provider/maintainers in case you believe this is an error."
+    noupdate="true"
+    runtests="true"
+elif [[ -e /etc/swizzin/.dev.lock ]]; then
+    echo_warn "Not updating /etc/swizzin as a dev lockfile is present."
+    noupdate="true"
+    runtests="true"
+elif [[ $1 == "--dev" ]]; then
+    echo_warn "Not updating from git due to --dev flag"
+    noupdate="true"
+    runtests="true"
+fi
+
 case "$1" in
     "")
         _intro
         _function
-        exit 0
         ;;
     "help" | "-h")
         _help "$0"
@@ -552,7 +561,6 @@ case "$1" in
             exit 1
         fi
         _cli "$@"
-        exit 0
         ;;
     "remove" | "rm")
         if [[ -z $2 ]]; then
@@ -560,7 +568,6 @@ case "$1" in
             exit 1
         fi
         _clr "$@"
-        exit 0
         ;;
     "adduser")
         if [[ -n $4 ]]; then
@@ -568,7 +575,6 @@ case "$1" in
             exit 1
         fi
         _adduser "$@"
-        exit 0
         ;;
     "deluser")
         if [[ -z $2 ]]; then
@@ -580,7 +586,6 @@ case "$1" in
             exit 1
         fi
         _deluser "$@"
-        exit 0
         ;;
     "chpasswd")
         if [[ -z $2 ]]; then
@@ -592,18 +597,15 @@ case "$1" in
             exit 1
         fi
         _chpasswd "$@"
-        exit 0
         ;;
     "rmgrsec")
         _nukeovh
-        exit 0
         ;;
     "rtx")
         /usr/local/bin/swizzin/rtx
         ;;
     "update")
         _update "$2"
-        exit 0
         ;;
     "upgrade")
         if [[ $2 = "--dev" ]]; then
@@ -616,7 +618,6 @@ case "$1" in
         fi
         _update $dev
         _upgrade "$@"
-        exit 0
         ;;
     "list")
         _list
@@ -630,3 +631,7 @@ case "$1" in
         exit 1
         ;;
 esac
+
+if [[ $runtests == "true" ]]; then
+    _run_tests
+fi

--- a/scripts/box
+++ b/scripts/box
@@ -553,10 +553,12 @@ fi
 if [ -f /etc/swizzin/.test.lock ]; then
     echo_info "Tests will be ran at the end of this due to .test.lock"
     runtests="true"
-fi
-
-if [[ "$*" == *--test* ]]; then
+elif [[ "$*" == *--test* ]]; then
     echo_info "Tests will be ran due to --test flag"
+    #Removing `--test` from the arguments
+    for arg in "$@"; do [[ $arg == --test ]] || args+=("$arg"); done
+    set -- "${args[@]}"
+    echo_log_only "Args after cleanup: $(printf "%s\n" "$@")"
     runtests="true"
 fi
 

--- a/scripts/box
+++ b/scripts/box
@@ -124,6 +124,15 @@ function _clr() {
 
 #shellcheck disable=SC2120
 function _update() {
+
+    branch_name="$(git symbolic-ref HEAD 2> /dev/null)" || branch_name="(unnamed branch)" # detached HEAD
+    branch_name=${branch_name##refs/heads/}
+    if [ "$branch_name" == "develop" ]; then
+        SWIZ_GIT_REF="develop"
+        export SWIZ_GIT_REF
+        echo_info "Just FYI, you're on the develop branch! Remember that you need to mention this when asking for any sort of support."
+    fi
+
     case "$(_os_codename)" in
         "bionic" | "focal" | "buster" | "stretch" | "bullseye")
             echo_log_only "OS supported"

--- a/scripts/box
+++ b/scripts/box
@@ -551,15 +551,15 @@ if [[ $branch_name != 'master' ]]; then
 fi
 
 if [ -f /etc/swizzin/.test.lock ]; then
-    echo_info "Tests will be ran at the end of this due to .test.lock"
+    testmsg="Tests will be ran at the end of this due to .test.lock"
     runtests="true"
 elif [[ "$*" == *--test* ]]; then
-    echo_info "Tests will be ran due to --test flag"
+    testmsg="Tests will be ran due to --test flag"
+    runtests="true"
     #Removing `--test` from the arguments
     for arg in "$@"; do [[ $arg == --test ]] || args+=("$arg"); done
     set -- "${args[@]}"
     echo_log_only "Args after cleanup: $(printf "%s\n" "$@")"
-    runtests="true"
 fi
 
 case "$1" in
@@ -654,6 +654,6 @@ esac
 
 if [[ $runtests == "true" ]]; then
     echo
-    echo_warn "We determined you're not in a \"normal\" environment, therefore we're running tests"
+    echo_warn "$testmsg"
     _run_tests
 fi

--- a/scripts/box
+++ b/scripts/box
@@ -551,6 +551,7 @@ case "$1" in
     "")
         _intro
         _function
+        exit 0
         ;;
     "help" | "-h")
         _help "$0"
@@ -562,6 +563,7 @@ case "$1" in
             exit 1
         fi
         _cli "$@"
+        # Tests should be ran on non-stables: Test app installed correctly
         ;;
     "remove" | "rm")
         if [[ -z $2 ]]; then
@@ -569,6 +571,7 @@ case "$1" in
             exit 1
         fi
         _clr "$@"
+        # Tests should be ran on non-stables: Check removes didn't bork anything else
         ;;
     "adduser")
         if [[ -n $4 ]]; then
@@ -576,6 +579,7 @@ case "$1" in
             exit 1
         fi
         _adduser "$@"
+        # Tests should be ran on non-stables: this hits many installer scripts
         ;;
     "deluser")
         if [[ -z $2 ]]; then
@@ -587,6 +591,7 @@ case "$1" in
             exit 1
         fi
         _deluser "$@"
+        # Tests should be ran on non-stables: Lot of custom logic in box that needs to be tested
         ;;
     "chpasswd")
         if [[ -z $2 ]]; then
@@ -598,15 +603,19 @@ case "$1" in
             exit 1
         fi
         _chpasswd "$@"
+        # Tests should be ran on non-stables: Password changers are super prone to messing things up
         ;;
     "rmgrsec")
         _nukeovh
+        exit 0
         ;;
     "rtx")
         /usr/local/bin/swizzin/rtx
+        exit 0
         ;;
     "update")
         _update "$2"
+        # Tests should be ran on non-stables: Ensure apps installed right
         ;;
     "upgrade")
         if [[ $2 = "--dev" ]]; then
@@ -626,6 +635,7 @@ case "$1" in
         ;;
     "test")
         _run_tests "$@"
+        exit 0 # No need to double-run tests
         ;;
     *)
         echo_error "Invalid command: $1"

--- a/scripts/box
+++ b/scripts/box
@@ -495,6 +495,7 @@ _run_tests() {
         . /etc/swizzin/sources/functions/utils
         readarray -t list < <(_get_installed_apps)
         echo_info "Tests to run: ${list[*]}"
+        echo
     fi
 
     export bell=false
@@ -633,5 +634,7 @@ case "$1" in
 esac
 
 if [[ $runtests == "true" ]]; then
+    echo
+    echo_warn "We determined you're not in a \"normal\" environment, therefore we're running tests"
     _run_tests
 fi

--- a/scripts/box
+++ b/scripts/box
@@ -158,6 +158,8 @@ We URGE you to migrate to a supported release if/while you still have the chance
         }
         echo_progress_done "Local repository updated from ${SWIZ_GIT_REF:-master}"
         echo_info "HEAD is now set to $(git -C /etc/swizzin log --pretty=format:'%h' -n1)"
+    else
+        echo_warn "$noupdate_message"
     fi
     export SWIZ_REPO_SCRIPT_RAN=true
 
@@ -534,15 +536,15 @@ if [ "$branch_name" == "develop" ]; then
 fi
 
 if [[ -L /etc/swizzin ]]; then
-    echo_warn "Not updating /etc/swizzin as it is a symlink. Please consult your provider/maintainers in case you believe this is an error."
+    noupdate_message="Not updating /etc/swizzin as it is a symlink. Please consult your provider/maintainers in case you believe this is an error."
     noupdate="true"
     runtests="true"
 elif [[ -e /etc/swizzin/.dev.lock ]]; then
-    echo_warn "Not updating /etc/swizzin as a dev lockfile is present."
+    noupdate_message="Not updating /etc/swizzin as a dev lockfile is present."
     noupdate="true"
     runtests="true"
 elif [[ $1 == "--dev" ]]; then
-    echo_warn "Not updating from git due to --dev flag"
+    noupdate_message="Not updating from git due to --dev flag"
     noupdate="true"
     runtests="true"
 fi

--- a/scripts/box
+++ b/scripts/box
@@ -122,8 +122,23 @@ function _clr() {
     fi
 }
 
-#shellcheck disable=SC2120
 function _update() {
+    # Checking for develop branch
+    if [ "$branch_name" == "develop" ]; then
+        SWIZ_GIT_REF="develop"
+        export SWIZ_GIT_REF
+    fi
+
+    if [[ -L /etc/swizzin ]]; then
+        noupdate_message="Not updating /etc/swizzin as it is a symlink. Please consult your provider/maintainers in case you believe this is an error."
+        noupdate="true"
+    elif [[ -e /etc/swizzin/.dev.lock ]]; then
+        noupdate_message="Not updating /etc/swizzin as a dev lockfile is present."
+        noupdate="true"
+    elif [[ $1 == "--dev" ]]; then
+        noupdate_message="Not updating from git due to --dev flag"
+        noupdate="true"
+    fi
 
     case "$(_os_codename)" in
         "bionic" | "focal" | "buster" | "stretch" | "bullseye")
@@ -528,24 +543,9 @@ _run_tests() {
 
 branch_name="$(git -C /etc/swizzin symbolic-ref HEAD 2> /dev/null)" || branch_name="(unnamed branch)" # detached HEAD
 branch_name=${branch_name##refs/heads/}
-if [ "$branch_name" == "develop" ]; then
-    SWIZ_GIT_REF="develop"
-    export SWIZ_GIT_REF
-fi
 
-if [[ ! $branch_name =~ ^(master|eol-.*)$ ]]; then
-    echo_info "Just FYI, you're not on the $branch_name branch! Remember that you need to mention this when asking for any sort of support."
-fi
-
-if [[ -L /etc/swizzin ]]; then
-    noupdate_message="Not updating /etc/swizzin as it is a symlink. Please consult your provider/maintainers in case you believe this is an error."
-    noupdate="true"
-elif [[ -e /etc/swizzin/.dev.lock ]]; then
-    noupdate_message="Not updating /etc/swizzin as a dev lockfile is present."
-    noupdate="true"
-elif [[ $1 == "--dev" ]]; then
-    noupdate_message="Not updating from git due to --dev flag"
-    noupdate="true"
+if [[ $branch_name != 'master' ]]; then
+    echo_info "Currently on branch: $branch_name"
 fi
 
 if [ -f /etc/swizzin/.test.lock ]; then

--- a/scripts/box
+++ b/scripts/box
@@ -531,7 +531,10 @@ branch_name=${branch_name##refs/heads/}
 if [ "$branch_name" == "develop" ]; then
     SWIZ_GIT_REF="develop"
     export SWIZ_GIT_REF
-    echo_info "Just FYI, you're on the develop branch! Remember that you need to mention this when asking for any sort of support."
+fi
+
+if [[ ! $branch_name =~ ^(master|eol-.*)$ ]]; then
+    echo_info "Just FYI, you're not on the $branch_name branch! Remember that you need to mention this when asking for any sort of support."
     runtests="true"
 fi
 

--- a/scripts/box
+++ b/scripts/box
@@ -140,22 +140,24 @@ function _update() {
         noupdate="true"
     fi
 
+    #Checking for EOL releases
     case "$(_os_codename)" in
         "bionic" | "focal" | "buster" | "stretch" | "bullseye")
             echo_log_only "OS supported"
             ;;
         *)
             name=$(_os_codename)
-            echo_warn "${name^} is no longer a supported by swizzin.
+            echo_warn "${name^} is not supported by swizzin at this stage.
 You will not be receiving any new updates past the last supported commit. Swizzin will continue to run as-is.
 We URGE you to migrate to a supported release if/while you still have the chance."
             SWIZ_GIT_REF="tags/eol-$(_os_codename)"
             export SWIZ_GIT_REF
             ;;
     esac
-
     echo_log_only "noupdate = $noupdate"
+    # If there is nothing blocking the update...
     if [[ -z $noupdate ]]; then
+        # Run the git update procedure
         echo_progress_start "Updating swizzin local repository"
         git -C /etc/swizzin checkout "${SWIZ_GIT_REF:-master}" >> $log 2>&1 ||
             {
@@ -171,7 +173,7 @@ We URGE you to migrate to a supported release if/while you still have the chance
             echo_error "Failed to update from git"
             exit 1
         }
-        echo_progress_done "Local repository updated from ${SWIZ_GIT_REF:-master}"
+        echo_progress_done "Local repository updated using: ${SWIZ_GIT_REF:-master}"
         echo_info "HEAD is now set to $(git -C /etc/swizzin log --pretty=format:'%h' -n1)"
     else
         echo_warn "$noupdate_message"

--- a/scripts/box
+++ b/scripts/box
@@ -541,14 +541,21 @@ fi
 if [[ -L /etc/swizzin ]]; then
     noupdate_message="Not updating /etc/swizzin as it is a symlink. Please consult your provider/maintainers in case you believe this is an error."
     noupdate="true"
-    runtests="true"
 elif [[ -e /etc/swizzin/.dev.lock ]]; then
     noupdate_message="Not updating /etc/swizzin as a dev lockfile is present."
     noupdate="true"
-    runtests="true"
 elif [[ $1 == "--dev" ]]; then
     noupdate_message="Not updating from git due to --dev flag"
     noupdate="true"
+fi
+
+if [ -f /etc/swizzin/.test.lock ]; then
+    echo_info "Tests will be ran at the end of this due to .test.lock"
+    runtests="true"
+fi
+
+if [[ "$*" == *--test* ]]; then
+    echo_info "Tests will be ran due to --test flag"
     runtests="true"
 fi
 


### PR DESCRIPTION
## Description
Users on `develop` should be able to stay there over `box update` runs and not be forced to master. Furthermore, in order for this branch to give us some real beenfit, might as well run tests on these setups by default.

## Fixes issues: 
- More feedback from non-standard users
- Automtaic tests when on "dev" setup

## Proposed Changes:
All previous "not updating" scenarios will now additionally run tests on **all** box functions (help, list and invalid args excluded)

## Change Categories
<!-- DELETE WHICHEVER BULLET DOES NOT APPLY -->
- New feature <!-- non-breaking change which adds functionality -->
- Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
- Change in `functions` <!-- e.g. `utils`, `os`, `apt`, `ask`, etc. -->
- Project structure <!-- major rewrites, large directory changes, etc. -->

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [x] Docs have been made OR are not necessary
    - PR link: https://github.com/liaralabs/docs.swizzin.ltd/pull/93
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Testing was done
   - [x] Tests created or no new tests necessary
   - [x] Tests executed

## Test scenarios
<!-- Please let us know what has been done or anything else that works/doesn't. Feel free to copy-paste the examples at the bottom of this section -->

### Architectures
<!--
Please use these emojis here to fill the table below. It will nicely auto-format with spacing, don't worry. Leave empty wherever you do not know / have not tested
✅ = Works successfully
❎ = Does not work BUT is handled gracefully
🛠 = Still WIP
❌ = Broken / not working
-->
|   			| `amd64` 	| `armhf` 	| `arm64` 	| Unspecified 	|
|--------		|-------- 	|-------- 	|-------- 	|----------		|
| Focal 		|			|			|			|				|
| Bionic		|			|			|			|				|
| Buster		|			|			|			|				|
| Stretch		|			|			|			|				|
| Raspbian  	|	⚫️		|			|	⚫️		|	⚫️			|

### ✅❎ Passed

### 🛠🛠 TODO

### ❌❌ Currently failing

<!-- EXAMPLES :
- Fresh app install without nginx
    - With only one user
    - With multiple users present
- Fresh Install with nginx present nginx
    - With only one user
    - With multiple users present
- Fresh install and nginx install afterwards
    - With only one user
    - With multiple users present
- Update from version in master
- Upgrade from version in master
- Password gets changed from `box` in app
- User removal from `box` acting on app
- New user in `box` gets added to app
- Sysinfo compatibility
    - Info washed
    - Content available
-->

