### PR TITLE
[bazarr] Fix configuration failing for sonarrv3

### DIFF
--- a/scripts/install/bazarr.sh
+++ b/scripts/install/bazarr.sh
@@ -39,9 +39,15 @@ mkdir -p /opt/bazarr/data/config/
 echo_progress_done "Dependencies installed"
 
 if [[ -f /install/.sonarr.lock ]]; then
-    sonarrapi=$(grep -oP "ApiKey>\K[^<]+" /home/${user}/.config/NzbDrone/config.xml)
-    sonarrport=$(grep -oP "\<Port>\K[^<]+" /home/${user}/.config/NzbDrone/config.xml)
-    sonarrbase=$(grep -oP "UrlBase>\K[^<]+" /home/${user}/.config/NzbDrone/config.xml)
+    sonarrConfigFile = /home/${user}/.config/sonarr/config.xml
+
+    if [[ -f ${sonarrConfigFile} ]]; then
+        sonarrapi=$(grep -oP "ApiKey>\K[^<]+" ${sonarrConfigFile})
+        sonarrport=$(grep -oP "\<Port>\K[^<]+" ${sonarrConfigFile})
+        sonarrbase=$(grep -oP "UrlBase>\K[^<]+" ${sonarrConfigFile})
+    else
+        echo_warn "Sonarr configuration was not found in ${sonarrConfigFile}, configure api key, port and url base manually in bazarr"
+    fi
 
     cat >> /opt/bazarr/data/config/config.ini << SONC
 [sonarr]

--- a/scripts/install/bazarr.sh
+++ b/scripts/install/bazarr.sh
@@ -44,9 +44,9 @@ if [[ -f /install/.sonarr.lock ]]; then
     sonarrConfigFile=/home/${user}/.config/sonarr/config.xml
 
     if [[ -f ${sonarrConfigFile} ]]; then
-        sonarrapi=$(grep -oP "ApiKey>\K[^<]+" ${sonarrConfigFile})
-        sonarrport=$(grep -oP "\<Port>\K[^<]+" ${sonarrConfigFile})
-        sonarrbase=$(grep -oP "UrlBase>\K[^<]+" ${sonarrConfigFile})
+        sonarrapi=$(grep -oP "ApiKey>\K[^<]+" "${sonarrConfigFile}")
+        sonarrport=$(grep -oP "\<Port>\K[^<]+" "${sonarrConfigFile}")
+        sonarrbase=$(grep -oP "UrlBase>\K[^<]+" "${sonarrConfigFile}")
     else
         echo_warn "Sonarr configuration was not found in ${sonarrConfigFile}, configure api key, port and url base manually in bazarr"
     fi
@@ -69,9 +69,9 @@ if [[ -f /install/.radarr.lock ]]; then
     radarrConfigFile=/home/${user}/.config/Radarr/config.xml
 
     if [[ -f ${radarrConfigFile} ]]; then
-        radarrapi=$(grep -oP "ApiKey>\K[^<]+" ${radarrConfigFile})
-        radarrport=$(grep -oP "\<Port>\K[^<]+" ${radarrConfigFile})
-        radarrbase=$(grep -oP "UrlBase>\K[^<]+" ${radarrConfigFile})
+        radarrapi=$(grep -oP "ApiKey>\K[^<]+" "${radarrConfigFile}")
+        radarrport=$(grep -oP "\<Port>\K[^<]+" "${radarrConfigFile}")
+        radarrbase=$(grep -oP "UrlBase>\K[^<]+" "${radarrConfigFile}")
     else
         echo_warn "Radarr configuration was not found in ${radarrConfigFile}, configure api key, port and url base manually in bazarr"
     fi

--- a/scripts/install/bazarr.sh
+++ b/scripts/install/bazarr.sh
@@ -64,9 +64,17 @@ SONC
 fi
 
 if [[ -f /install/.radarr.lock ]]; then
-    radarrapi=$(grep -oP "ApiKey>\K[^<]+" /home/${user}/.config/Radarr/config.xml)
-    radarrport=$(grep -oP "\<Port>\K[^<]+" /home/${user}/.config/Radarr/config.xml)
-    radarrbase=$(grep -oP "UrlBase>\K[^<]+" /home/${user}/.config/Radarr/config.xml)
+    echo_info "Configuring bazarr to work with radarr"
+
+    radarrConfigFile=/home/${user}/.config/Radarr/config.xml
+
+    if [[ -f ${radarrConfigFile} ]]; then
+        radarrapi=$(grep -oP "ApiKey>\K[^<]+" ${radarrConfigFile})
+        radarrport=$(grep -oP "\<Port>\K[^<]+" ${radarrConfigFile})
+        radarrbase=$(grep -oP "UrlBase>\K[^<]+" ${radarrConfigFile})
+    else
+        echo_warn "Radarr configuration was not found in ${radarrConfigFile}, configure api key, port and url base manually in bazarr"
+    fi
 
     cat >> /opt/bazarr/data/config/config.ini << RADC
 

--- a/scripts/install/bazarr.sh
+++ b/scripts/install/bazarr.sh
@@ -93,7 +93,7 @@ if [[ -f /install/.nginx.lock ]]; then
     sleep 10
     bash /usr/local/bin/swizzin/nginx/bazarr.sh
     systemctl reload nginx
-    echo_warn "Please ensure during bazarr wizard that baseurl is set to: /bazarr/"
+    echo_warn "If the bazarr wizard comes up, ensure that baseurl is set to: /bazarr/"
 else
     cat >> /opt/bazarr/data/config/config.ini << BAZC
 

--- a/scripts/install/bazarr.sh
+++ b/scripts/install/bazarr.sh
@@ -39,6 +39,8 @@ mkdir -p /opt/bazarr/data/config/
 echo_progress_done "Dependencies installed"
 
 if [[ -f /install/.sonarr.lock ]]; then
+    echo_info "Configuring bazarr to work with sonarr"
+
     sonarrConfigFile=/home/${user}/.config/sonarr/config.xml
 
     if [[ -f ${sonarrConfigFile} ]]; then

--- a/scripts/install/bazarr.sh
+++ b/scripts/install/bazarr.sh
@@ -39,7 +39,7 @@ mkdir -p /opt/bazarr/data/config/
 echo_progress_done "Dependencies installed"
 
 if [[ -f /install/.sonarr.lock ]]; then
-    sonarrConfigFile = /home/${user}/.config/sonarr/config.xml
+    sonarrConfigFile=/home/${user}/.config/sonarr/config.xml
 
     if [[ -f ${sonarrConfigFile} ]]; then
         sonarrapi=$(grep -oP "ApiKey>\K[^<]+" ${sonarrConfigFile})


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description
<!-- Any general story time goes here :) Feel free to add screenshots/recording of your change in action here-->

Primarily fixes the path to the sonarr configuration to make the bazarr installation work as seamlessly as it did previously.

## Fixes issues: 
- When installing bazarr after installing sonarrv3, the configuration was not picked up and grep errors was output into console

## Proposed Changes:
- Fixes path to sonarr configuration 
- Checks if the configuration is there before trying to `grep`, 
  - if file is not there, we show a warning explaining that the config was not found and that the user is on their own in configuring bazarr.
- Does the same check for radarr files

## Change Categories
<!-- DELETE WHICHEVER BULLET DOES NOT APPLY -->
- Bug fix <!-- non-breaking change which fixes an issue -->

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [x] Docs have been made OR are not necessary
- [x] Changes to panel have been made OR are not necessary
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have functionally tested the changes being introduced

## Test scenarios
<!-- Please let us know what has been done or anything else that works/doesn't. Feel free to copy-paste the examples at the bottom of this section -->

### Architectures
<!--
Please use these emojis here to fill the table below. It will nicely auto-format with spacing, don't worry. Leave empty wherever you do not know / have not tested
✅ = Works successfully
❎ = Does not work BUT is handled gracefully
🛠 = Still WIP
❌ = Broken / not working
-->
|   			| `amd64` 	| `armhf` 	| `arm64` 	| Unspecified 	|
|--------		|-------- 	|-------- 	|-------- 	|----------		|
| Focal 		|	✅		|			|			|				|
| Bionic		|			|			|			|				|
| Buster		|			|			|			|				|
| Stretch		|			|			|			|				|
| Raspbian  	|	⚫️		|			|	⚫️		|	⚫️			|

### ✅❎ Passed

- Install bazarr without sonarr/radarr
- Install bazarr with sonarr installed
- Install bazarr with radarr installed
- install bazarr with sonarr and radarr installed
- install bazarr with `/install/.sonarr.lock` but no config file
- install bazarr with `/install/.radarr.lock` but no config file

### 🛠🛠 TODO

### ❌❌ Currently failing

<!-- EXAMPLES :
- Fresh app install without nginx
    - With only one user
    - With multiple users present
- Fresh Install with nginx present nginx
    - With only one user
    - With multiple users present
- Fresh install and nginx install afterwards
    - With only one user
    - With multiple users present
- Update from version in master
- Upgrade from version in master
- Password gets changed from `box` in app
- User removal from `box` acting on app
- New user in `box` gets added to app
- Sysinfo compatibility
    - Info washed
    - Content available
-->

