### PR TITLE
fix(arrs): Ensure sonarr and radarr have populated swizdb owners

### DIFF
--- a/scripts/install/sonarr.sh
+++ b/scripts/install/sonarr.sh
@@ -19,7 +19,7 @@ else
 fi
 
 user="$SONARR_OWNER"
-sonarrv3confdir="/home/$sonarrv3owner/.config/Sonarr"
+sonarrv3confdir="/home/$user/.config/Sonarr"
 
 #Handles existing v2 instances
 _sonarrold_flow() {
@@ -129,7 +129,7 @@ _install_sonarr() {
     chown "$user":"$user" /home/"$user"/.config
     chown "$user":"$user" -R "$sonarrv3confdir"
 
-    echo_log_only "Setting sonarr v3 owner to $sonarrv3owner"
+    echo_log_only "Setting sonarr v3 owner to $user"
     wget -O /tmp/sonarr.tar.gz "https://services.sonarr.tv/v1/download/main/latest?version=3&os=linux" >> ${log} 2>&1 || {
         echo_error "Sonarr could not be downloaded from sonarr.tv. Exiting"
 
@@ -140,7 +140,7 @@ _install_sonarr() {
         exit 1
     }
     rm -f /tmp/sonarr.tar.gz
-    chown -R "$sonarrv3owner":"$sonarrv3owner" /opt/Sonarr
+    chown -R "$user":"$user" /opt/Sonarr
 
     LIST='mono-runtime
         ca-certificates-mono
@@ -177,8 +177,8 @@ Description=Sonarr Daemon
 After=network.target
 
 [Service]
-User=${sonarrv3owner}
-Group=${sonarrv3owner}
+User=${user}
+Group=${user}
 UMask=0002
 
 Type=simple
@@ -192,7 +192,7 @@ WantedBy=multi-user.target
 EOSD
 
     if [[ ! -f ${sonarrv3confdir}/config.xml ]]; then
-        cat > ${sonarrv3confdir}/config.xml << EOSC
+        cat > "${sonarrv3confdir}"/config.xml << EOSC
 <Config>
   <LogLevel>info</LogLevel>
   <EnableSsl>False</EnableSsl>
@@ -205,7 +205,7 @@ EOSD
   <Branch>main</Branch>
 </Config>
 EOSC
-        chown -R ${sonarrv3owner}: ${sonarrv3confdir}/config.xml
+        chown -R "${user}": "${sonarrv3confdir}"/config.xml
     fi
     systemctl enable --now sonarr >> ${log} 2>&1
 

--- a/scripts/install/sonarr.sh
+++ b/scripts/install/sonarr.sh
@@ -5,12 +5,20 @@
 #shellcheck source=sources/functions/utils
 . /etc/swizzin/sources/functions/utils
 
-[[ -z $sonarroldowner ]] && sonarroldowner=$(_get_master_username)
+[[ -z $SONARR_OLD_OWNER ]] && SONARR_OLD_OWNER=$(_get_master_username)
 
-if [[ -z $sonarrv3owner ]]; then
-    sonarrv3owner=$(_get_master_username)
+if [ -z "$SONARR_OWNER" ]; then
+    if ! SONARR_OWNER="$(swizdb get sonarr/owner)"; then
+        SONARR_OWNER=$(_get_master_username)
+        echo_info "Setting sonarr owner = $SONARR_OWNER"
+        swizdb set "sonarr/owner" "$SONARR_OWNER"
+    fi
+else
+    echo_info "Setting sonarr owner = $SONARR_OWNER"
+    swizdb set "sonarr/owner" "$SONARR_OWNER"
 fi
 
+user="$SONARR_OWNER"
 sonarrv3confdir="/home/$sonarrv3owner/.config/Sonarr"
 
 #Handles existing v2 instances
@@ -37,13 +45,13 @@ _sonarrold_flow() {
                 address="http://127.0.0.1:8989/api"
             fi
 
-            [[ -z $sonarroldowner ]] && sonarroldowner=$(_get_master_username)
-            if [[ ! -d /home/"${sonarroldowner}"/.config/NzbDrone ]]; then
-                echo_error "No Sonarr config folder found for $sonarroldowner. Exiting"
+            [[ -z $SONARR_OLD_OWNER ]] && SONARR_OLD_OWNER=$(_get_master_username)
+            if [[ ! -d /home/"${SONARR_OLD_OWNER}"/.config/NzbDrone ]]; then
+                echo_error "No Sonarr config folder found for $SONARR_OLD_OWNER. Exiting"
                 exit 1
             fi
 
-            apikey=$(awk -F '[<>]' '/ApiKey/{print $3}' /home/"${sonarroldowner}"/.config/NzbDrone/config.xml)
+            apikey=$(awk -F '[<>]' '/ApiKey/{print $3}' /home/"${SONARR_OLD_OWNER}"/.config/NzbDrone/config.xml)
             echo_log_only "apikey = $apikey"
 
             #This starts a backup on the current Sonarr instance. The logic below waits until the query returns as "completed"
@@ -82,21 +90,21 @@ _sonarrold_flow() {
 
         mkdir -p /root/swizzin/backups/
         echo_progress_start "Copying files to a backup location"
-        cp -R /home/"${sonarroldowner}"/.config/NzbDrone /root/swizzin/backups/sonarrold.bak
+        cp -R /home/"${SONARR_OLD_OWNER}"/.config/NzbDrone /root/swizzin/backups/sonarrold.bak
         echo_progress_done "Backups copied"
 
-        if [[ -d /home/"${sonarrv3owner}"/.config/Sonarr ]]; then
-            if ask "$sonarrv3owner already has a sonarrv3 directory. Overwrite?" Y; then
+        if [[ -d /home/"${user}"/.config/sonarr ]]; then
+            if ask "$user already has a sonarrv3 directory. Overwrite?" Y; then
                 rm -rf
-                cp -R /home/"${sonarroldowner}"/.config/NzbDrone /home/"${sonarrv3owner}"/.config/Sonarr
+                cp -R /home/"${SONARR_OLD_OWNER}"/.config/NzbDrone /home/"${user}"/.config/sonarr
             else
                 echo_info "Leaving v3 dir as is, why did we do any of this..."
             fi
         else
-            cp -R /home/"${sonarroldowner}"/.config/NzbDrone /home/"${sonarrv3owner}"/.config/Sonarr
+            cp -R /home/"${SONARR_OLD_OWNER}"/.config/NzbDrone /home/"${user}"/.config/sonarr
         fi
 
-        systemctl stop sonarr@"${sonarroldowner}"
+        systemctl stop sonarr@"${SONARR_OLD_OWNER}"
 
         # We don't have the debconf configuration yet so we can't migrate the data.
         # Instead we symlink so postinst knows where it's at.
@@ -118,11 +126,12 @@ _install_sonarr() {
     . /etc/swizzin/sources/functions/mono
     mono_repo_setup
     mkdir -p "$sonarrv3confdir"
-    chown -R "$sonarrv3owner":"$sonarrv3owner" /home/"$sonarrv3owner"/.config
+    chown -R "$user":"$user" /home/"$user"/.config
 
     echo_log_only "Setting sonarr v3 owner to $sonarrv3owner"
     wget -O /tmp/sonarr.tar.gz "https://services.sonarr.tv/v1/download/main/latest?version=3&os=linux" >> ${log} 2>&1 || {
         echo_error "Sonarr could not be downloaded from sonarr.tv. Exiting"
+
         exit 1
     }
     tar xf /tmp/sonarr.tar.gz -C /opt >> ${log} 2>&1 || {
@@ -201,22 +210,6 @@ EOSC
 
     touch /install/.sonarr.lock
 }
-
-# _add2usergroups_sonarrv3 () {
-#         if [[ -z $sonarrv3grouplist ]]; then
-#             if ask "Do you want to let Sonarr access other users' home directories?" N; then
-#                 echo "Space separated list of users to give sonarr access to: (e.g. \"user1 user2\")"
-#                 read -r sonarrv3grouplist
-#             fi
-#         fi
-#         if [[ -n $sonarrv3grouplist ]]; then
-#             for u in $sonarrv3grouplist; do
-#                 echo "Adding ${sonarrv3owner} to $u's group"
-#                 usermod -a -G "$u" "$sonarrv3owner"
-#                 chmod g+rwx /home/"$u"
-#             done
-#         fi
-# }
 
 _nginx_sonarr() {
     if [[ -f /install/.nginx.lock ]]; then

--- a/scripts/install/sonarr.sh
+++ b/scripts/install/sonarr.sh
@@ -126,7 +126,8 @@ _install_sonarr() {
     . /etc/swizzin/sources/functions/mono
     mono_repo_setup
     mkdir -p "$sonarrv3confdir"
-    chown -R "$user":"$user" /home/"$user"/.config
+    chown "$user":"$user" /home/"$user"/.config
+    chown "$user":"$user" -R "$sonarrv3confdir"
 
     echo_log_only "Setting sonarr v3 owner to $sonarrv3owner"
     wget -O /tmp/sonarr.tar.gz "https://services.sonarr.tv/v1/download/main/latest?version=3&os=linux" >> ${log} 2>&1 || {

--- a/scripts/install/sonarr.sh
+++ b/scripts/install/sonarr.sh
@@ -10,7 +10,7 @@
 if [ -z "$SONARR_OWNER" ]; then
     if ! SONARR_OWNER="$(swizdb get sonarr/owner)"; then
         SONARR_OWNER=$(_get_master_username)
-        echo_info "Setting sonarr owner = $SONARR_OWNER"
+        echo_log_only "Setting sonarr owner = $SONARR_OWNER"
         swizdb set "sonarr/owner" "$SONARR_OWNER"
     fi
 else

--- a/scripts/remove/radarr.sh
+++ b/scripts/remove/radarr.sh
@@ -2,7 +2,7 @@
 
 if ask "Would you like to purge the configuration?" Y; then
     rm -rf "/home/$(swizdb get radarr/owner)/.config/Radarr"
-    swizdb clear "sonarr/owner"
+    swizdb clear "radarr/owner"
 fi
 
 systemctl disable --now -q radarr

--- a/scripts/remove/radarr.sh
+++ b/scripts/remove/radarr.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+if ask "Would you like to purge the configuration?" Y; then
+    rm -rf "/home/$(swizdb get radarr/owner)/.config/Radarr"
+    swizdb clear "sonarr/owner"
+fi
+
 systemctl disable --now -q radarr
 rm /etc/systemd/system/radarr.service
 systemctl daemon-reload -q

--- a/scripts/update/radarr.sh
+++ b/scripts/update/radarr.sh
@@ -69,7 +69,7 @@ if [[ -f /install/.radarr.lock ]]; then
         if ! RADARR_OWNER="$(swizdb get radarr/owner)"; then
             master=$(_get_master_username)
             if [ ! -d /home/"$master"/.config/Radarr ]; then
-                echo_error "Could not find Radarr config in master's home folder. Please export the \"RADARR_OWNER\" as described below, and run \`box update\` again."
+                echo_error "Config dir /home/$RADARR_OWNER/.config/Radarr does not exist.\nPlease export the \"RADARR_OWNER\" as described below, and run \`box update\` again."
                 echo_docs "applications/radarr#optional-parameters"
                 # Stop the box updater because who knows what could rely on this in the future
                 exit 1
@@ -79,6 +79,11 @@ if [[ -f /install/.radarr.lock ]]; then
             swizdb set "radarr/owner" "$RADARR_OWNER"
         fi
     else
+        if [ ! -d /home/"$RADARR_OWNER"/.config/Radarr ]; then
+            echo_error "Config dir /home/$RADARR_OWNER/.config/Radarr does not exist."
+            # Stop the box updater because who knows what could rely on this in the future
+            exit 1
+        fi
         echo_info "Setting Radarr owner = $RADARR_OWNER"
         swizdb set "radarr/owner" "$RADARR_OWNER"
     fi

--- a/scripts/update/radarr.sh
+++ b/scripts/update/radarr.sh
@@ -64,7 +64,7 @@ if [[ -f /install/.radarr.lock ]]; then
         echo_log_only "Radarr's service is not pointing to mono"
     fi
 
-    # Ensure the sonarr owner is recorded
+    # Ensure the radarr owner is recorded
     if [ -z "$RADARR_OWNER" ]; then
         if ! RADARR_OWNER="$(swizdb get radarr/owner)"; then
             master=$(_get_master_username)

--- a/scripts/update/sonarr.sh
+++ b/scripts/update/sonarr.sh
@@ -11,6 +11,7 @@ if dpkg -l | grep nzbdrone > /dev/null 2>&1; then
     v2present=true
     echo_warn "Sonarr v2 is obsolete and end-of-life. Please upgrade your Sonarr to v3 using \`box upgrade sonarr\`."
 fi
+
 if [[ -f /install/.sonarr.lock ]] && [[ $v2present == "true" ]]; then
     echo_info "box package sonarr is being renamed to sonarrold"
     #update lock file
@@ -21,6 +22,7 @@ if [[ -f /install/.sonarr.lock ]] && [[ $v2present == "true" ]]; then
     fi
     touch /install/.sonarrold.lock
 fi
+
 if [[ -f /install/.sonarrv3.lock ]]; then
     echo_info "box package sonarrv3 is being renamed to sonarr as it has been released as stable"
     #upgrade sonarr v3 lock
@@ -93,4 +95,25 @@ if [[ -f /install/.sonarr.lock ]] && dpkg -l | grep sonarr | grep ^ii > /dev/nul
         systemctl enable sonarr >> ${log} 2>&1
     fi
 
+fi
+
+# If we know we're running v3 Sonarr...
+if [[ -f /install/.sonarr.lock ]] && [[ $v2present != "true" ]]; then
+    # Ensure the sonarr owner is recorded
+    if [ -z "$SONARR_OWNER" ]; then
+        if ! SONARR_OWNER="$(swizdb get sonarr/owner)"; then
+            master=$(_get_master_username)
+            if [ ! -d /home/"$master"/.config/Sonarr ]; then
+                echo_error "Could not find Sonarr config in master's home folder. Please export the variable \"SONARR_OWNER\" and run \`box update\` again."
+                # Stop the box updater because who knows what could rely on this in the future
+                exit 1
+            fi
+            SONARR_OWNER="$master"
+            echo_info "Setting sonarr owner = $SONARR_OWNER"
+            swizdb set "sonarr/owner" "$SONARR_OWNER"
+        fi
+    else
+        echo_info "Setting sonarr owner = $SONARR_OWNER"
+        swizdb set "sonarr/owner" "$SONARR_OWNER"
+    fi
 fi

--- a/scripts/update/sonarr.sh
+++ b/scripts/update/sonarr.sh
@@ -104,17 +104,19 @@ if [[ -f /install/.sonarr.lock ]] && [[ $v2present != "true" ]]; then
         if ! SONARR_OWNER="$(swizdb get sonarr/owner)"; then
             master=$(_get_master_username)
             if [ ! -d /home/"$master"/.config/sonarr ]; then
-                echo_error "Could not find Sonarr config in master's home folder. Please export the \"SONARR_OWNER\" as described below, and run \`box update\` again."
+                echo_error "Config dir /home/$master/.config/Radarr does not exist.\nPlease export the \"SONARR_OWNER\" as described below, and run \`box update\` again."
                 echo_docs "applications/sonarrv3#optional-parameters"
-
-                # Stop the box updater because who knows what could rely on this in the future
-                exit 1
+                exit 1 # Stop the box updater because who knows what could rely on this in the future
             fi
             SONARR_OWNER="$master"
             echo_info "Setting sonarr owner = $SONARR_OWNER"
             swizdb set "sonarr/owner" "$SONARR_OWNER"
         fi
     else
+        if [ ! -d /home/"$SONARR_OWNER"/.config/Radarr ]; then
+            echo_error "Config dir /home/$SONARR_OWNER/.config/Radarr does not exist."
+            exit 1 # Stop the box updater because who knows what could rely on this in the future
+        fi
         echo_info "Setting sonarr owner = $SONARR_OWNER"
         swizdb set "sonarr/owner" "$SONARR_OWNER"
     fi

--- a/scripts/update/sonarr.sh
+++ b/scripts/update/sonarr.sh
@@ -103,8 +103,10 @@ if [[ -f /install/.sonarr.lock ]] && [[ $v2present != "true" ]]; then
     if [ -z "$SONARR_OWNER" ]; then
         if ! SONARR_OWNER="$(swizdb get sonarr/owner)"; then
             master=$(_get_master_username)
-            if [ ! -d /home/"$master"/.config/Sonarr ]; then
-                echo_error "Could not find Sonarr config in master's home folder. Please export the variable \"SONARR_OWNER\" and run \`box update\` again."
+            if [ ! -d /home/"$master"/.config/sonarr ]; then
+                echo_error "Could not find Sonarr config in master's home folder. Please export the \"SONARR_OWNER\" as described below, and run \`box update\` again."
+                echo_docs "applications/sonarrv3#optional-parameters"
+
                 # Stop the box updater because who knows what could rely on this in the future
                 exit 1
             fi


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description
Scope is to ensure that the `swizdb` reliably has the owners from the arr apps

## Fixes issues: 
- N/A

## Proposed Changes:

- fix: ensure sonarr owner is recorded
- fix: remove vars on uninstall
- style: fix echos
- fix: remove double apt update because mono_repo_setup has one
- fix: ensure .config gets right ownership if it exists
- fix: record radarr owner properly on install
- fix: purge config explicitly for radarr
- style: echos and formatting
- fix: rewrite variable recording for radarr updater
- style: echos, formatting, sanity


## Change Categories
<!-- DELETE WHICHEVER BULLET DOES NOT APPLY -->
- Bug fix <!-- non-breaking change which fixes an issue -->

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [x] Docs have been made OR are not necessary
    - PR link: https://github.com/liaralabs/docs.swizzin.ltd/pull/89
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] Testing was done
   - [ ] Tests created or no new tests necessary
   - [ ] Tests executed

## Test scenarios
<!-- Please let us know what has been done or anything else that works/doesn't. Feel free to copy-paste the examples at the bottom of this section -->

### Architectures
<!--
Please use these emojis here to fill the table below. It will nicely auto-format with spacing, don't worry. Leave empty wherever you do not know / have not tested
✅ = Works successfully
❎ = Does not work BUT is handled gracefully
🛠 = Still WIP
❌ = Broken / not working
-->
|   			| `amd64` 	| `armhf` 	| `arm64` 	| Unspecified 	|
|--------		|-------- 	|-------- 	|-------- 	|----------		|
| Focal 		|			|			|	WIP		|				|
| Bionic		|			|			|			|				|
| Buster		|			|			|			|				|
| Stretch		|			|			|			|				|
| Raspbian  	|	⚫️		|			|	⚫️		|	⚫️			|

### ✅❎ Passed

### 🛠🛠 TODO

### ❌❌ Currently failing

<!-- EXAMPLES :
- Fresh app install without nginx
    - With only one user
    - With multiple users present
- Fresh Install with nginx present nginx
    - With only one user
    - With multiple users present
- Fresh install and nginx install afterwards
    - With only one user
    - With multiple users present
- Update from version in master
- Upgrade from version in master
- Password gets changed from `box` in app
- User removal from `box` acting on app
- New user in `box` gets added to app
- Sysinfo compatibility
    - Info washed
    - Content available
-->

