### PR TITLE
feat: add bullseye support

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -37,10 +37,11 @@ body:
       label: What OS are you using?
       multiple: false
       options:
-        - Debian 10
-        - Ubuntu 20.04
-        - Debian 9
-        - Ubuntu 18.04
+        - Debian 11 (Bullseye)
+        - Ubuntu 20.04 (Focal)
+        - Debian 10 (Buster)
+        - Ubuntu 18.04 (Xenial)
+        - Debian 9 (Stretch)
     validations:
       required: true
   - type: dropdown

--- a/scripts/box
+++ b/scripts/box
@@ -125,7 +125,7 @@ function _clr() {
 #shellcheck disable=SC2120
 function _update() {
     case "$(_os_codename)" in
-        "bionic" | "focal" | "buster" | "stretch")
+        "bionic" | "focal" | "buster" | "stretch" | "bullseye")
             echo_log_only "OS supported"
             ;;
         *)

--- a/setup.sh
+++ b/setup.sh
@@ -188,11 +188,11 @@ _os() {
     fi
     distribution=$(lsb_release -is)
     codename=$(lsb_release -cs)
-    if [[ ! $distribution =~ ("Debian"|"Ubuntu") ]]; then
+    if [[ ! $distribution =~ ^(Debian|Ubuntu)$ ]]; then
         echo_error "Your distribution ($distribution) is not supported. Swizzin requires Ubuntu or Debian."
         exit 1
     fi
-    if [[ ! $codename =~ ("bionic"|"stretch"|"buster"|"focal") ]]; then
+    if [[ ! $codename =~ ^(bionic|stretch|buster|focal|bullseye)$ ]]; then
         echo_error "Your release ($codename) of $distribution is not supported."
         exit 1
     fi

--- a/sources/functions/deluge
+++ b/sources/functions/deluge
@@ -170,13 +170,13 @@ function build_deluge() {
     fi
     case $DELUGE_VERSION in
         master)
-            LIST='python3 python3-setuptools intltool python3-zope.interface python3-twisted python3-openssl python3-xdg python3-chardet python3-mako python3-setproctitle python3-rencode python3-pil librsvg2-common xdg-utils'
+            LIST='python3 python3-setuptools python3-pip intltool python3-zope.interface python3-twisted python3-openssl python3-xdg python3-chardet python3-mako python3-setproctitle python3-rencode python3-pil librsvg2-common xdg-utils'
             pythonver=python3
             distver=python3
             args="--python-disable-dependency=pyxdg --python-disable-dependency=pyopenssl -d python3-openssl -d python3-xdg"
             ;;
         1.3-stable)
-            if [[ $(_os_codename) == "focal" ]]; then
+            if [[ $(_os_codename) =~ ^(focal|bullseye)$ ]]; then
                 LIST='python2.7-dev intltool xdg-utils librsvg2-common'
                 PIP='twisted pyopenssl setuptools pyxdg chardet notify pygame mako service_identity'
                 pythonver=python2.7
@@ -194,7 +194,7 @@ function build_deluge() {
             exit 1
             ;;
     esac
-    apt_install $LIST
+    apt_install --no-recommends $LIST
 
     if [[ -n $PIP ]]; then
         . /etc/swizzin/sources/functions/pyenv

--- a/sources/functions/mono
+++ b/sources/functions/mono
@@ -13,8 +13,8 @@ function mono_repo_setup() {
                 #gpg --export 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF > /etc/apt/trusted.gpg.d/mono-xamarin.gpg
             fi
         fi
-        if [[ ! $codename =~ ("buster"|"focal") ]]; then
-            echo "deb https://download.mono-project.com/repo/${distribution,,} ${codename}/snapshots/5.18/. main" > /etc/apt/sources.list.d/mono-xamarin.list
+        if [[ $codename =~ ^(stretch|bionic|buster)$ ]]; then
+            echo "deb https://download.mono-project.com/repo/${distribution,,} ${codename}/snapshots/6.8/. main" > /etc/apt/sources.list.d/mono-xamarin.list
         fi
         apt_update
     fi
@@ -24,11 +24,11 @@ function mono_repo_update() {
     distribution=$(lsb_release -is)
     codename=$(lsb_release -cs)
     if [[ -f /etc/apt/sources.list.d/mono-xamarin.list ]]; then
-        if grep -q "5.18" /etc/apt/sources.list.d/mono-xamarin.list; then
+        if grep -q "6.8" /etc/apt/sources.list.d/mono-xamarin.list; then
             :
         else
-            echo "deb https://download.mono-project.com/repo/${distribution,,} ${codename}/snapshots/5.18/. main" > /etc/apt/sources.list.d/mono-xamarin.list
-            echo_log_only "Upgrading to mono 5.18 snapshot"
+            echo "deb https://download.mono-project.com/repo/${distribution,,} ${codename}/snapshots/6.8/. main" > /etc/apt/sources.list.d/mono-xamarin.list
+            echo_log_only "Upgrading to mono 6.8 snapshot"
             apt_upgrade
             apt_autoremove
         fi


### PR DESCRIPTION
## Description
Adds bullseye support
Updates mono installed version to 6.8 to match focal/bullseye
Reduces packages installed with python deps in deluge install

## Fixes issues: 
- bullseye doesn't work

## Proposed Changes:
- make bullseye work

## Change Categories
- Bug fix <!-- non-breaking change which fixes an issue -->
- New feature <!-- non-breaking change which adds functionality -->

## Checklist
- [x] Testing was done

## Test scenarios
Deluge & qbit compile
panel/nginx works
all available rtorrent versions work

php untested (assume it will work as everything installs like focal)


