### PR TITLE
feat: equivalent of `apt-get install --only-upgrade`

### DIFF
--- a/scripts/upgrade/calibre.sh
+++ b/scripts/upgrade/calibre.sh
@@ -14,6 +14,7 @@ case "$(os_arch)" in
         fi
         ;;
     *)
-        echo_info "No upgrader yet! Your installation is currently managed by apt. Please use that in the meantime"
+        # echo_info "No upgrader yet! Your installation is currently managed by apt. Please use that in the meantime"
+        apt_install --only-upgrade calibre
         ;;
 esac

--- a/scripts/upgrade/nginx.sh
+++ b/scripts/upgrade/nginx.sh
@@ -55,4 +55,6 @@ for i in "${locks[@]}"; do
     fi
 done
 
+apt_install --only-upgrade nginx
+
 systemctl reload nginx

--- a/sources/functions/apt
+++ b/sources/functions/apt
@@ -260,6 +260,7 @@ apt_install() {
     _apt_update
     _apt_simulate install "${_apt_packages[@]}"
 
+    action_msg="installation"
     #Prepare flags for install
     flags=""
     if [[ $_apt_install_recommends == "true" ]]; then
@@ -270,10 +271,12 @@ apt_install() {
 
     if [[ $_apt_only_upgrade == "true" ]]; then
         flags+="--only-upgrade "
+        action_msg="upgrade"
     fi
 
     # Run the install
-    echo_progress_start "Performing installation of ${#_apt_packages[@]} apt packages\n(${_apt_packages[*]})"
+
+    echo_progress_start "Performing $action_msg of ${#_apt_packages[@]} apt packages\n(${_apt_packages[*]})"
     if [[ $_apt_interactive == "true" ]]; then
         # TODO test the behaviour of this, I haven't had the time yet
         DEBIAN_FRONTEND=readline apt-get install -y $flags "${_apt_packages[@]}" | tee -a $log

--- a/sources/functions/apt
+++ b/sources/functions/apt
@@ -24,6 +24,10 @@ _process_apt_args() {
     _apt_packages=()
     while test $# -gt 0; do
         case "$1" in
+            --only-upgrade)
+                _apt_only_upgrade="true"
+                echo_log_only "APT will not install any packages if they weren't preveiously present"
+                ;;
             --interactive)
                 _apt_interactive=true
                 echo_log_only "APT set to interactive"
@@ -259,9 +263,13 @@ apt_install() {
     #Prepare flags for install
     flags=""
     if [[ $_apt_install_recommends == "true" ]]; then
-        flags="--install-recommends"
+        flags+="--install-recommends "
     elif [[ $_apt_install_recommends == "false" ]]; then
-        flags="--no-install-recommends"
+        flags+="--no-install-recommends "
+    fi
+
+    if [[ $_apt_only_upgrade == "true" ]]; then
+        flags+="--only-upgrade "
     fi
 
     # Run the install


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description
A quick way to upgrade only a specific package and its dependencies without running a "blind" `apt_install pkg`, and without running an entie system upgrade.

Therefore, `apt_install --only-upgrade sonarr` will upgrade **only** sonarr on the condition it has been previously installed, and will not upgrade any other packages.

## Fixes issues: 
- Un-tracked issue...

## Proposed Changes:
Allow for `apt_install --only-upgrade pkg`

## Change Categories
<!-- DELETE WHICHEVER BULLET DOES NOT APPLY -->
- New feature <!-- non-breaking change which adds functionality -->
- Change in `functions` <!-- e.g. `utils`, `os`, `apt`, `ask`, etc. -->

## Checklist
- [x] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [ ] Docs have been made OR are not necessary
    - PR link: 
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Testing was done
   - [x] Tests created or no new tests necessary
   - [x] Tests executed

## Test scenarios
<!-- Please let us know what has been done or anything else that works/doesn't. Feel free to copy-paste the examples at the bottom of this section -->

### Architectures
<!--
Please use these emojis here to fill the table below. It will nicely auto-format with spacing, don't worry. Leave empty wherever you do not know / have not tested
✅ = Works successfully
❎ = Does not work BUT is handled gracefully
🛠 = Still WIP
❌ = Broken / not working
-->
|   			| `amd64` 	| `armhf` 	| `arm64` 	| Unspecified 	|
|--------		|-------- 	|-------- 	|-------- 	|----------		|
| Focal 		|			|			|			|	Yup			|
| Bionic		|			|			|			|				|
| Buster		|			|			|			|				|
| Stretch		|			|			|			|				|
| Raspbian  	|	⚫️		|			|	⚫️		|	⚫️			|

### ✅❎ Passed

### 🛠🛠 TODO

### ❌❌ Currently failing

<!-- EXAMPLES :
- Fresh app install without nginx
    - With only one user
    - With multiple users present
- Fresh Install with nginx present nginx
    - With only one user
    - With multiple users present
- Fresh install and nginx install afterwards
    - With only one user
    - With multiple users present
- Update from version in master
- Upgrade from version in master
- Password gets changed from `box` in app
- User removal from `box` acting on app
- New user in `box` gets added to app
- Sysinfo compatibility
    - Info washed
    - Content available
-->

