### PR TITLE
update(sonarr): use tar ball for installation to prevent unsupported repo issues

### DIFF
--- a/scripts/install/sonarr.sh
+++ b/scripts/install/sonarr.sh
@@ -113,50 +113,89 @@ _sonarrold_flow() {
     fi
 }
 
-_add_sonarr_repos() {
-    echo_progress_start "Adding apt sources for Sonarr v3"
-    codename=$(lsb_release -cs)
-    distribution=$(lsb_release -is)
-
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 2009837CBFFD68F45BC180471F4F90DE2A9B4BF8 >> "$log" 2>&1
-    echo "deb https://apt.sonarr.tv/${distribution,,} ${codename,,} main" | tee /etc/apt/sources.list.d/sonarr.list >> "$log" 2>&1
-
+_install_sonarr() {
     #shellcheck source=sources/functions/mono
     . /etc/swizzin/sources/functions/mono
     mono_repo_setup
-
-    apt_update
-
-    if ! apt-cache policy sonarr | grep -q apt.sonarr.tv; then
-        echo_error "Sonarr was not found from apt.sonarr.tv repository. Please inspect the logs and try again later."
-        exit 1
-    fi
-}
-
-_install_sonarr() {
     mkdir -p "$sonarrv3confdir"
     chown -R "$sonarrv3owner":"$sonarrv3owner" /home/"$sonarrv3owner"/.config
 
     echo_log_only "Setting sonarr v3 owner to $sonarrv3owner"
-    # settings relevant from https://github.com/Sonarr/Sonarr/blob/phantom-develop/distribution/debian/config
-    echo "sonarr sonarr/owning_user string ${sonarrv3owner}" | debconf-set-selections
-    echo "sonarr sonarr/owning_group string ${sonarrv3owner}" | debconf-set-selections
-    echo "sonarr sonarr/config_directory string ${sonarrv3confdir}" | debconf-set-selections
-    apt_install sonarr sqlite3
+    wget -O /tmp/sonarr.tar.gz "https://services.sonarr.tv/v1/download/main/latest?version=3&os=linux" || {
+        echo_error "Sonarr could not be downloaded from sonarr.tv. Exiting"
+        exit 1
+    }
+    tar xf /tmp/sonarr.tar.gz -C /opt >> ${log} 2>&1
+    rm -f /tmp/sonarr.tar.gz
+    chown -R "$sonarrv3owner":"$sonarrv3owner" /opt/Sonarr
+
+    LIST='mono-runtime
+    ca-certificates-mono
+    libmono-system-net-http4.0-cil
+    libmono-corlib4.5-cil
+    libmono-microsoft-csharp4.0-cil
+    libmono-posix4.0-cil
+    libmono-system-componentmodel-dataannotations4.0-cil
+    libmono-system-configuration-install4.0-cil
+    libmono-system-configuration4.0-cil
+    libmono-system-core4.0-cil
+    libmono-system-data-datasetextensions4.0-cil
+    libmono-system-data4.0-cil
+    libmono-system-identitymodel4.0-cil
+    libmono-system-io-compression4.0-cil
+    libmono-system-numerics4.0-cil
+    libmono-system-runtime-serialization4.0-cil
+    libmono-system-security4.0-cil
+    libmono-system-servicemodel4.0a-cil
+    libmono-system-serviceprocess4.0-cil
+    libmono-system-transactions4.0-cil
+    libmono-system-web4.0-cil
+    libmono-system-xml-linq4.0-cil
+    libmono-system-xml4.0-cil
+    libmono-system4.0-cil
+    sqlite3
+    mediainfo'
+
+    apt_install ${LIST}
+
+    cat > /etc/systemd/system/sonarr.service << EOSD
+[Unit]
+Description=Sonarr Daemon
+After=network.target
+
+[Service]
+User=${sonarrv3owner}
+Group=${sonarrv3owner}
+UMask=0002
+
+Type=simple
+ExecStart=/usr/bin/mono --debug /opt/Sonarr/Sonarr.exe -nobrowser -data=${sonarrv3confdir}
+TimeoutStopSec=20
+KillMode=process
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+EOSD
+
+    if [[ ! -f ${sonarrv3confdir}/config.xml ]]; then
+        cat > ${sonarrv3confdir}/config.xml << EOSC
+<Config>
+  <LogLevel>info</LogLevel>
+  <EnableSsl>False</EnableSsl>
+  <Port>8989</Port>
+  <SslPort>9898</SslPort>
+  <UrlBase></UrlBase>
+  <BindAddress>*</BindAddress>
+  <AuthenticationMethod>None</AuthenticationMethod>
+  <UpdateMechanism>BuiltIn</UpdateMechanism>
+  <Branch>main</Branch>
+</Config>
+EOSC
+    fi
+    systemctl enable --now sonarr >> ${log} 2>&1
+
     touch /install/.sonarr.lock
-    sleep 1
-
-    if [[ ! -d /usr/lib/sonarr ]]; then
-        echo_error "The Sonarr v3 pacakge did not install correctly. Please try again. (Is sonarr repo reachable?)"
-        exit 1
-    fi
-
-    echo_progress_start "Sonarr is installing an internal upgrade..."
-    if ! timeout 30 bash -c -- "while ! curl -sIL http://127.0.0.1:8989 >> \"$log\" 2>&1; do sleep 2; done"; then
-        echo_error "The Sonarr web server has taken longer than 30 seconds to start."
-        exit 1
-    fi
-    echo_progress_done "Internal upgrade finished"
 }
 
 # _add2usergroups_sonarrv3 () {
@@ -179,7 +218,6 @@ _nginx_sonarr() {
     if [[ -f /install/.nginx.lock ]]; then
         #TODO what is this sleep here for? See if this can be fixed by doing a check for whatever it needs to
         echo_progress_start "Installing nginx configuration"
-        sleep 10
         bash /usr/local/bin/swizzin/nginx/sonarr.sh
         systemctl reload nginx >> "$log" 2>&1
         echo_progress_done
@@ -189,7 +227,6 @@ _nginx_sonarr() {
 }
 
 _sonarrold_flow
-_add_sonarr_repos
 _install_sonarr
 _nginx_sonarr
 

--- a/scripts/install/sonarr.sh
+++ b/scripts/install/sonarr.sh
@@ -130,31 +130,31 @@ _install_sonarr() {
     chown -R "$sonarrv3owner":"$sonarrv3owner" /opt/Sonarr
 
     LIST='mono-runtime
-    ca-certificates-mono
-    libmono-system-net-http4.0-cil
-    libmono-corlib4.5-cil
-    libmono-microsoft-csharp4.0-cil
-    libmono-posix4.0-cil
-    libmono-system-componentmodel-dataannotations4.0-cil
-    libmono-system-configuration-install4.0-cil
-    libmono-system-configuration4.0-cil
-    libmono-system-core4.0-cil
-    libmono-system-data-datasetextensions4.0-cil
-    libmono-system-data4.0-cil
-    libmono-system-identitymodel4.0-cil
-    libmono-system-io-compression4.0-cil
-    libmono-system-numerics4.0-cil
-    libmono-system-runtime-serialization4.0-cil
-    libmono-system-security4.0-cil
-    libmono-system-servicemodel4.0a-cil
-    libmono-system-serviceprocess4.0-cil
-    libmono-system-transactions4.0-cil
-    libmono-system-web4.0-cil
-    libmono-system-xml-linq4.0-cil
-    libmono-system-xml4.0-cil
-    libmono-system4.0-cil
-    sqlite3
-    mediainfo'
+        ca-certificates-mono
+        libmono-system-net-http4.0-cil
+        libmono-corlib4.5-cil
+        libmono-microsoft-csharp4.0-cil
+        libmono-posix4.0-cil
+        libmono-system-componentmodel-dataannotations4.0-cil
+        libmono-system-configuration-install4.0-cil
+        libmono-system-configuration4.0-cil
+        libmono-system-core4.0-cil
+        libmono-system-data-datasetextensions4.0-cil
+        libmono-system-data4.0-cil
+        libmono-system-identitymodel4.0-cil
+        libmono-system-io-compression4.0-cil
+        libmono-system-numerics4.0-cil
+        libmono-system-runtime-serialization4.0-cil
+        libmono-system-security4.0-cil
+        libmono-system-servicemodel4.0a-cil
+        libmono-system-serviceprocess4.0-cil
+        libmono-system-transactions4.0-cil
+        libmono-system-web4.0-cil
+        libmono-system-xml-linq4.0-cil
+        libmono-system-xml4.0-cil
+        libmono-system4.0-cil
+        sqlite3
+        mediainfo'
 
     apt_install ${LIST}
 

--- a/scripts/install/sonarr.sh
+++ b/scripts/install/sonarr.sh
@@ -125,7 +125,10 @@ _install_sonarr() {
         echo_error "Sonarr could not be downloaded from sonarr.tv. Exiting"
         exit 1
     }
-    tar xf /tmp/sonarr.tar.gz -C /opt >> ${log} 2>&1
+    tar xf /tmp/sonarr.tar.gz -C /opt >> ${log} 2>&1 || {
+        echo_error "Failed to extract archive"
+        exit 1
+    }
     rm -f /tmp/sonarr.tar.gz
     chown -R "$sonarrv3owner":"$sonarrv3owner" /opt/Sonarr
 

--- a/scripts/install/sonarr.sh
+++ b/scripts/install/sonarr.sh
@@ -121,7 +121,7 @@ _install_sonarr() {
     chown -R "$sonarrv3owner":"$sonarrv3owner" /home/"$sonarrv3owner"/.config
 
     echo_log_only "Setting sonarr v3 owner to $sonarrv3owner"
-    wget -O /tmp/sonarr.tar.gz "https://services.sonarr.tv/v1/download/main/latest?version=3&os=linux" || {
+    wget -O /tmp/sonarr.tar.gz "https://services.sonarr.tv/v1/download/main/latest?version=3&os=linux" >> ${log} 2>&1 || {
         echo_error "Sonarr could not be downloaded from sonarr.tv. Exiting"
         exit 1
     }
@@ -192,6 +192,7 @@ EOSD
   <Branch>main</Branch>
 </Config>
 EOSC
+        chown -R ${sonarrv3owner}: ${sonarrv3confdir}/config.xml
     fi
     systemctl enable --now sonarr >> ${log} 2>&1
 

--- a/scripts/install/sonarr.sh
+++ b/scripts/install/sonarr.sh
@@ -11,7 +11,7 @@ if [[ -z $sonarrv3owner ]]; then
     sonarrv3owner=$(_get_master_username)
 fi
 
-sonarrv3confdir="/home/$sonarrv3owner/.config/sonarr"
+sonarrv3confdir="/home/$sonarrv3owner/.config/Sonarr"
 
 #Handles existing v2 instances
 _sonarrold_flow() {

--- a/scripts/nginx/sonarr.sh
+++ b/scripts/nginx/sonarr.sh
@@ -20,7 +20,7 @@ isactive=$(systemctl is-active sonarr)
 if [[ $isactive == "active" ]]; then
     systemctl stop sonarr
 fi
-user=$(grep User= /lib/systemd/system/sonarr.service | cut -d= -f2)
+user=$(grep User= /etc/systemd/system/sonarr.service | cut -d= -f2)
 #shellcheck disable=SC2154
 echo_log_only "Sonarr user detected as $user"
 apikey=$(awk -F '[<>]' '/ApiKey/{print $3}' /home/"$user"/.config/sonarr/config.xml)

--- a/scripts/remove/sonarr.sh
+++ b/scripts/remove/sonarr.sh
@@ -2,7 +2,9 @@
 
 user=$(grep User= /etc/systemd/system/sonarr.service | cut -d= -f2)
 if ask "Would you like to purge the configuration?" Y; then
-    rm_if_exists "/home/${user}/.config/sonarr"
+    if [[-d /home/${user}/.config/sonarr ]]; then
+        rm -rf "/home/${user}/.config/sonarr"
+    fi
 fi
 rm -rf /opt/Sonarr
 if [[ -f /install/.nginx.lock ]]; then

--- a/scripts/remove/sonarr.sh
+++ b/scripts/remove/sonarr.sh
@@ -43,5 +43,6 @@ apt-mark auto ${LIST} >> ${log} 2>&1
 #Remove mono if no longer required
 apt-get autoremove -y >> ${log} 2>&1
 rm -f /etc/apt/sources.list.d/mono-xamarin.list*
+rm -f /etc/systemd/system/sonarr.service
 
 rm /install/.sonarr.lock

--- a/scripts/remove/sonarr.sh
+++ b/scripts/remove/sonarr.sh
@@ -2,7 +2,7 @@
 
 user=$(grep User= /etc/systemd/system/sonarr.service | cut -d= -f2)
 if ask "Would you like to purge the configuration?" Y; then
-    if [[-d /home/${user}/.config/sonarr ]]; then
+    if [[ -d /home/${user}/.config/sonarr ]]; then
         rm -rf "/home/${user}/.config/sonarr"
     fi
 fi

--- a/scripts/remove/sonarr.sh
+++ b/scripts/remove/sonarr.sh
@@ -42,6 +42,6 @@ apt-mark auto ${LIST} >> ${log} 2>&1
 
 #Remove mono if no longer required
 apt-get autoremove -y >> ${log} 2>&1
-rm -f /etc/apt/sources.list.d/mono-xamarin.repo*
+rm -f /etc/apt/sources.list.d/mono-xamarin.list*
 
 rm /install/.sonarr.lock

--- a/scripts/remove/sonarr.sh
+++ b/scripts/remove/sonarr.sh
@@ -2,8 +2,8 @@
 
 user=$(grep User= /etc/systemd/system/sonarr.service | cut -d= -f2)
 if ask "Would you like to purge the configuration?" Y; then
-    if [[ -d /home/${user}/.config/sonarr ]]; then
-        rm -rf "/home/${user}/.config/sonarr"
+    if [[ -d /home/${user}/.config/Sonarr ]]; then
+        rm -rf "/home/${user}/.config/Sonarr"
     fi
 fi
 rm -rf /opt/Sonarr

--- a/scripts/remove/sonarr.sh
+++ b/scripts/remove/sonarr.sh
@@ -1,15 +1,45 @@
 #!/bin/bash
 
+user=$(grep User= /etc/systemd/system/sonarr.service | cut -d= -f2)
 if ask "Would you like to purge the configuration?" Y; then
-    apt_remove --purge sonarr
-    rm -rf /var/lib/sonarr
-    rm -rf /usr/lib/sonarr
-else
-    apt_remove sonarr
+    rm_if_exists "/home/${user}/.config/sonarr"
 fi
+rm -rf /opt/Sonarr
 if [[ -f /install/.nginx.lock ]]; then
     rm /etc/nginx/apps/sonarr.conf
     systemctl reload nginx >> "$log" 2>&1
 fi
+
+#Mark mono depends as automatically installed
+LIST='mono-runtime
+    ca-certificates-mono
+    libmono-system-net-http4.0-cil
+    libmono-corlib4.5-cil
+    libmono-microsoft-csharp4.0-cil
+    libmono-posix4.0-cil
+    libmono-system-componentmodel-dataannotations4.0-cil
+    libmono-system-configuration-install4.0-cil
+    libmono-system-configuration4.0-cil
+    libmono-system-core4.0-cil
+    libmono-system-data-datasetextensions4.0-cil
+    libmono-system-data4.0-cil
+    libmono-system-identitymodel4.0-cil
+    libmono-system-io-compression4.0-cil
+    libmono-system-numerics4.0-cil
+    libmono-system-runtime-serialization4.0-cil
+    libmono-system-security4.0-cil
+    libmono-system-servicemodel4.0a-cil
+    libmono-system-serviceprocess4.0-cil
+    libmono-system-transactions4.0-cil
+    libmono-system-web4.0-cil
+    libmono-system-xml-linq4.0-cil
+    libmono-system-xml4.0-cil
+    libmono-system4.0-cil'
+
+apt-mark auto ${LIST} >> ${log} 2>&1
+
+#Remove mono if no longer required
+apt-get autoremove -y >> ${log} 2>&1
+rm -f /etc/apt/sources.list.d/mono-xamarin.repo*
 
 rm /install/.sonarr.lock

--- a/scripts/update/sonarr.sh
+++ b/scripts/update/sonarr.sh
@@ -34,6 +34,7 @@ fi
 if [[ -f /install/.sonarr.lock ]] && dpkg -l | grep sonarr | grep ^ii > /dev/null 2>&1; then
     echo_info "Migrating Sonarr away from apt management"
     isActive=$(systemctl is-active sonarr)
+    isEnabled=$(systemctl is-enabled sonarr)
     cp -a /usr/lib/sonarr/bin /opt/Sonarr
     cp /usr/lib/systemd/system/sonarr.service /etc/systemd/system
     user=$(grep User= /etc/systemd/system/sonarr.service | cut -d= -f2)
@@ -88,7 +89,7 @@ if [[ -f /install/.sonarr.lock ]] && dpkg -l | grep sonarr | grep ^ii > /dev/nul
     fi
 
     #Update broken symlink to old service
-    if systemctl is-enabled sonarr > /dev/null 2>&1; then
+    if [[ $isEnabled == "enabed" ]]; then
         systemctl enable sonarr >> ${log} 2>&1
     fi
 

--- a/scripts/update/sonarr.sh
+++ b/scripts/update/sonarr.sh
@@ -5,17 +5,6 @@ if [[ -f /install/.sonarr.lock ]]; then
     . /etc/swizzin/sources/functions/mono
     mono_repo_update
     systemctl try-restart sonarr
-
-    #Ensure Sonarr repo key is up-to-date
-    if ! apt-key adv --list-public-keys 2> /dev/null | grep -q A236C58F409091A18ACA53CBEBFF6B99D9B78493 >> $log 2>&1; then
-        distribution=$(_os_distro)
-        if [[ $distribution == "ubuntu" ]]; then
-            apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xA236C58F409091A18ACA53CBEBFF6B99D9B78493 > /dev/null 2>&1
-        elif [[ $distribution == "debian" ]]; then
-            #buster friendly
-            apt-key --keyring /etc/apt/trusted.gpg.d/nzbdrone.gpg adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xA236C58F409091A18ACA53CBEBFF6B99D9B78493
-        fi
-    fi
 fi
 
 if dpkg -l | grep nzbdrone > /dev/null 2>&1; then

--- a/scripts/update/sonarr.sh
+++ b/scripts/update/sonarr.sh
@@ -74,6 +74,7 @@ if [[ -f /install/.sonarr.lock ]] && dpkg -l | grep sonarr > /dev/null 2>&1; the
     apt_remove sonarr
     rm -rf /var/lib/sonarr
     rm -rf /usr/lib/sonarr
+    rm -f /etc/apt/sources.list.d/sonarr.list*
     systemctl daemon-reload
     systemctl try-restart sonarr
 fi

--- a/scripts/update/sonarr.sh
+++ b/scripts/update/sonarr.sh
@@ -71,7 +71,9 @@ if [[ -f /install/.sonarr.lock ]] && dpkg -l | grep sonarr > /dev/null 2>&1; the
 
     apt_install ${LIST}
 
-    apt_remove --purge sonarr
+    apt_remove sonarr
+    rm -rf /var/lib/sonarr
+    rm -rf /usr/lib/sonarr
     systemctl daemon-reload
     systemctl try-restart sonarr
 fi

--- a/scripts/update/sonarr.sh
+++ b/scripts/update/sonarr.sh
@@ -33,6 +33,7 @@ if [[ -f /install/.sonarrv3.lock ]]; then
 fi
 if [[ -f /install/.sonarr.lock ]] && dpkg -l | grep sonarr > /dev/null 2>&1; then
     echo_info "Migrating Sonarr away from apt management"
+    isActive=$(systemctl is-active sonarr)
     cp -a /usr/lib/sonarr/bin /opt/Sonarr
     cp /usr/lib/systemd/system/sonarr.service /etc/systemd/system
 
@@ -76,5 +77,15 @@ if [[ -f /install/.sonarr.lock ]] && dpkg -l | grep sonarr > /dev/null 2>&1; the
     rm -rf /usr/lib/sonarr
     rm -f /etc/apt/sources.list.d/sonarr.list*
     systemctl daemon-reload
-    systemctl try-restart sonarr
+
+    #Restart sonarr because apt-removal stops it
+    if [[ $isActive == "active" ]]; then
+        systemctl start sonarr
+    fi
+
+    #Update broken symlink to old service
+    if systemctl is-enabled sonarr > /dev/null 2>&1; then
+        systemctl enable sonarr >> ${log} 2>&1
+    fi
+
 fi

--- a/scripts/update/sonarr.sh
+++ b/scripts/update/sonarr.sh
@@ -44,7 +44,7 @@ if [[ -f /install/.sonarr.lock ]] && dpkg -l | grep sonarr | grep ^ii > /dev/nul
     sed -i '/^#/d' /etc/systemd/system/sonarr.service
     #Update binary location
     sed -i 's|/usr/lib/sonarr/bin|/opt/Sonarr|g' /etc/systemd/system/sonarr.service
-    sed -i 's|.config/sonarr|.config/Sonarr|g' /etc/systemd/system/sonarr.service
+    sed -i 's|/home/${user}/.config/sonarr|/home/${user}/.config/Sonarr|g' /etc/systemd/system/sonarr.service
 
     #Mark depends as manually installed
     LIST='mono-runtime

--- a/scripts/update/sonarr.sh
+++ b/scripts/update/sonarr.sh
@@ -44,7 +44,7 @@ if [[ -f /install/.sonarr.lock ]] && dpkg -l | grep sonarr | grep ^ii > /dev/nul
     sed -i '/^#/d' /etc/systemd/system/sonarr.service
     #Update binary location
     sed -i 's|/usr/lib/sonarr/bin|/opt/Sonarr|g' /etc/systemd/system/sonarr.service
-    sed -i 's|/home/${user}/.config/sonarr|/home/${user}/.config/Sonarr|g' /etc/systemd/system/sonarr.service
+    sed -i "s|/home/${user}/.config/sonarr|/home/${user}/.config/Sonarr|g" /etc/systemd/system/sonarr.service
 
     #Mark depends as manually installed
     LIST='mono-runtime

--- a/scripts/update/sonarr.sh
+++ b/scripts/update/sonarr.sh
@@ -42,3 +42,47 @@ if [[ -f /install/.sonarrv3.lock ]]; then
     rm /install/.sonarrv3.lock
     touch /install/.sonarr.lock
 fi
+if [[ -f /install/.sonarr.lock && $(dpkg -l | grep sonarr > /dev/null 2>&1) ]]; then
+    echo_info "Migrating Sonarr away from apt management"
+    cp -a /usr/lib/sonarr/bin /opt/Sonarr
+    cp /usr/lib/systemd/system/sonarr.service /etc/systemd/system
+
+    #Remove comments
+    sed -i 's/^#/d' /etc/systemd/system/sonarr.service
+    #Update binary location
+    sed -i 's|/usr/lib/sonarr/bin|/opt/Sonarr|' /etc/systemd/system/sonarr.service
+
+    #Mark depends as manually installed
+    LIST='mono-runtime
+    ca-certificates-mono
+    libmono-system-net-http4.0-cil
+    libmono-corlib4.5-cil
+    libmono-microsoft-csharp4.0-cil
+    libmono-posix4.0-cil
+    libmono-system-componentmodel-dataannotations4.0-cil
+    libmono-system-configuration-install4.0-cil
+    libmono-system-configuration4.0-cil
+    libmono-system-core4.0-cil
+    libmono-system-data-datasetextensions4.0-cil
+    libmono-system-data4.0-cil
+    libmono-system-identitymodel4.0-cil
+    libmono-system-io-compression4.0-cil
+    libmono-system-numerics4.0-cil
+    libmono-system-runtime-serialization4.0-cil
+    libmono-system-security4.0-cil
+    libmono-system-servicemodel4.0a-cil
+    libmono-system-serviceprocess4.0-cil
+    libmono-system-transactions4.0-cil
+    libmono-system-web4.0-cil
+    libmono-system-xml-linq4.0-cil
+    libmono-system-xml4.0-cil
+    libmono-system4.0-cil
+    sqlite3
+    mediainfo'
+
+    apt_install ${LIST}
+
+    apt_remove sonarr
+    systemctl daemon-reload
+    systemctl try-restart sonarr
+fi

--- a/scripts/update/sonarr.sh
+++ b/scripts/update/sonarr.sh
@@ -54,35 +54,35 @@ if [[ -f /install/.sonarr.lock && $(dpkg -l | grep sonarr > /dev/null 2>&1) ]]; 
 
     #Mark depends as manually installed
     LIST='mono-runtime
-    ca-certificates-mono
-    libmono-system-net-http4.0-cil
-    libmono-corlib4.5-cil
-    libmono-microsoft-csharp4.0-cil
-    libmono-posix4.0-cil
-    libmono-system-componentmodel-dataannotations4.0-cil
-    libmono-system-configuration-install4.0-cil
-    libmono-system-configuration4.0-cil
-    libmono-system-core4.0-cil
-    libmono-system-data-datasetextensions4.0-cil
-    libmono-system-data4.0-cil
-    libmono-system-identitymodel4.0-cil
-    libmono-system-io-compression4.0-cil
-    libmono-system-numerics4.0-cil
-    libmono-system-runtime-serialization4.0-cil
-    libmono-system-security4.0-cil
-    libmono-system-servicemodel4.0a-cil
-    libmono-system-serviceprocess4.0-cil
-    libmono-system-transactions4.0-cil
-    libmono-system-web4.0-cil
-    libmono-system-xml-linq4.0-cil
-    libmono-system-xml4.0-cil
-    libmono-system4.0-cil
-    sqlite3
-    mediainfo'
+        ca-certificates-mono
+        libmono-system-net-http4.0-cil
+        libmono-corlib4.5-cil
+        libmono-microsoft-csharp4.0-cil
+        libmono-posix4.0-cil
+        libmono-system-componentmodel-dataannotations4.0-cil
+        libmono-system-configuration-install4.0-cil
+        libmono-system-configuration4.0-cil
+        libmono-system-core4.0-cil
+        libmono-system-data-datasetextensions4.0-cil
+        libmono-system-data4.0-cil
+        libmono-system-identitymodel4.0-cil
+        libmono-system-io-compression4.0-cil
+        libmono-system-numerics4.0-cil
+        libmono-system-runtime-serialization4.0-cil
+        libmono-system-security4.0-cil
+        libmono-system-servicemodel4.0a-cil
+        libmono-system-serviceprocess4.0-cil
+        libmono-system-transactions4.0-cil
+        libmono-system-web4.0-cil
+        libmono-system-xml-linq4.0-cil
+        libmono-system-xml4.0-cil
+        libmono-system4.0-cil
+        sqlite3
+        mediainfo'
 
     apt_install ${LIST}
 
-    apt_remove sonarr
+    apt_remove --purge sonarr
     systemctl daemon-reload
     systemctl try-restart sonarr
 fi

--- a/scripts/update/sonarr.sh
+++ b/scripts/update/sonarr.sh
@@ -89,7 +89,7 @@ if [[ -f /install/.sonarr.lock ]] && dpkg -l | grep sonarr | grep ^ii > /dev/nul
     fi
 
     #Update broken symlink to old service
-    if [[ $isEnabled == "enabed" ]]; then
+    if [[ $isEnabled == "enabled" ]]; then
         systemctl enable sonarr >> ${log} 2>&1
     fi
 

--- a/scripts/update/sonarr.sh
+++ b/scripts/update/sonarr.sh
@@ -37,7 +37,7 @@ if [[ -f /install/.sonarr.lock ]] && dpkg -l | grep sonarr > /dev/null 2>&1; the
     cp /usr/lib/systemd/system/sonarr.service /etc/systemd/system
 
     #Remove comments
-    sed -i 's/^#/d' /etc/systemd/system/sonarr.service
+    sed -i '/^#/d' /etc/systemd/system/sonarr.service
     #Update binary location
     sed -i 's|/usr/lib/sonarr/bin|/opt/Sonarr|' /etc/systemd/system/sonarr.service
 

--- a/scripts/update/sonarr.sh
+++ b/scripts/update/sonarr.sh
@@ -31,7 +31,7 @@ if [[ -f /install/.sonarrv3.lock ]]; then
     rm /install/.sonarrv3.lock
     touch /install/.sonarr.lock
 fi
-if [[ -f /install/.sonarr.lock && $(dpkg -l | grep sonarr > /dev/null 2>&1) ]]; then
+if [[ -f /install/.sonarr.lock ]] && dpkg -l | grep sonarr > /dev/null 2>&1; then
     echo_info "Migrating Sonarr away from apt management"
     cp -a /usr/lib/sonarr/bin /opt/Sonarr
     cp /usr/lib/systemd/system/sonarr.service /etc/systemd/system


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description
Moves sonarr to utilizing the tar ball installation as bullseye does not have a repo to install from, yet it shouldn't matter

## Fixes issues: 
- Bullseye cannot install Sonarr

## Change Categories
<!-- DELETE WHICHEVER BULLET DOES NOT APPLY -->
- Bug fix <!-- non-breaking change which fixes an issue -->

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [ ] Docs have been made OR are not necessary
    - PR link: 
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Testing was done
   - [x] Tests created or no new tests necessary
   - [ ] Tests executed

## Test scenarios

### ✅❎ Passed
amd64 on buster:

- Fresh install
- Update install (apt to tarball) -- data is moved to .config/Sonarr to allow purging sonarr to remove it from `dpkg -l`
- Removal

amd64 on bullseye:
- Fresh install
- Remove

### 🛠🛠 TODO
- Test ARM

### ❌❌ Currently failing

- None

