### PR TITLE
fix(setup): arm64, improvements to flags like `--test` and `--env`

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -60,19 +60,16 @@ function _source_setup() {
 _source_setup "$@"
 
 function _arch_check() {
-    if [[ ! $(uname -m) == "x86_64" ]]; then
+    if [[ ! $(uname -m) =~ ("x86_64"|"aarch64") ]]; then
         echo_warn "$(_os_arch) detected!"
-        if [[ $(_os_arch) = "arm64" ]]; then
-            echo_info "We are in the process of bringing arm support to swizzin. Please let us know on github if you find any issues with a PROPERLY filled out issue template.\nAs such, we cannot guarantee everything works 100%, so please don't feel like you need to speak to the manager when things break. You've been warned."
-        else
-            echo_warn "This is an unsupported architecture and THINGS WILL BREAK.\nDO NOT CREATE ISSUES ON GITHUB."
-        fi
+        echo_warn "This is an unsupported architecture and THINGS MIGHT BREAK.\nDO NOT CREATE ISSUES ON GITHUB."
         ask "Agree with the above and continue?" N || exit 1
         echo
+    else
+        echo_log_only "Arch detected as $(_os_arch)"
     fi
 }
 _arch_check
-
 function _option_parse() {
     while test $# -gt 0; do
         case "$1" in

--- a/setup.sh
+++ b/setup.sh
@@ -97,8 +97,8 @@ function _option_parse() {
                 echo_info "Local = $LOCAL"
                 ;;
             --test)
-                export RUN_TESTS=true
-                echo_info "RUN_TESTS = $RUN_TESTS"
+                export test=true
+                echo_info "test = $test"
                 ;;
             --rmgrsec)
                 rmgrsec=yes
@@ -381,7 +381,7 @@ function _post() {
 }
 
 _run_tests() {
-    if [[ $RUN_TESTS = "true" ]]; then
+    if [[ $test = "true" ]]; then
         echo
         echo_info "Running post-install checks"
         bash /etc/swizzin/scripts/box test || return 1

--- a/setup.sh
+++ b/setup.sh
@@ -381,7 +381,7 @@ function _post() {
 }
 
 _run_tests() {
-    if [[ $test = "true" ]]; then
+    if [[ $test = "true" ]] || [ -f /etc/swizzin/.test.lock ]; then
         echo
         echo_info "Running post-install checks"
         bash /etc/swizzin/scripts/box test || return 1

--- a/setup.sh
+++ b/setup.sh
@@ -395,9 +395,9 @@ _run_checks() {
 
 _run_post() {
     if [[ -n $postcommand ]]; then
-        echo_progress_start "Executing post-install commands"
+        echo_info "message" "Executing post-install commands"
         $postcommand
-        echo_progress_done "Post-install commands finished"
+        echo_success "message" "Post-install commands finished"
     fi
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -391,9 +391,9 @@ _run_tests() {
 
 _run_post() {
     if [[ -n $postcommand ]]; then
-        echo_info "message" "Executing post-install commands"
+        echo_info "Executing post-install commands"
         $postcommand
-        echo_success "message" "Post-install commands finished"
+        echo_success "Post-install commands finished"
     fi
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -96,9 +96,9 @@ function _option_parse() {
                 LOCAL=true
                 echo_info "Local = $LOCAL"
                 ;;
-            --run-checks)
-                export RUN_CHECKS=true
-                echo_info "RUN_CHECKS = $RUN_CHECKS"
+            --test)
+                export RUN_TESTS=true
+                echo_info "RUN_TESTS = $RUN_TESTS"
                 ;;
             --rmgrsec)
                 rmgrsec=yes
@@ -380,14 +380,10 @@ function _post() {
     bash /etc/swizzin/scripts/update/bash_completion.sh
 }
 
-_run_checks() {
-    if [[ $RUN_CHECKS = "true" ]]; then
+_run_tests() {
+    if [[ $RUN_TESTS = "true" ]]; then
         echo
         echo_info "Running post-install checks"
-        # echo_progress_start "Checking all failed units"
-        # systemctl list-units --failed
-        # echo_progress_done "listed"
-
         bash /etc/swizzin/scripts/box test || return 1
     fi
 
@@ -426,7 +422,7 @@ _prioritize_results
 _install
 _post
 _run_post
-_run_checks || {
+_run_tests || {
     BAD="true"
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -340,8 +340,7 @@ function _install() {
 }
 
 function _post() {
-    echo
-    echo
+    echo ---------------------------------------------
 
     user=$(_get_master_username)
 
@@ -399,6 +398,12 @@ _run_post() {
         echo_progress_done "Post-install commands finished"
     fi
 }
+
+############################################################
+#
+# Execution time after arguments got parsed
+#
+############################################################
 
 _os
 _preparation

--- a/setup.sh
+++ b/setup.sh
@@ -116,11 +116,20 @@ function _option_parse() {
                     echo_error "File does not exist"
                     exit 1
                 fi
-                echo_info "Parsing env variables from $1\n--->"
-                #shellcheck disable=SC2046
-                export $(grep -v '^#' "$1" | grep '^[A-Z]' | tr '\n' ' ') # anything which begins with a cap is exported
-                #shellcheck disable=SC2091
-                source <(grep -v '^#' "$1" | grep '^[a-z]') # | read -d $'\x04' name -
+                envfile="$1"
+                echo_info "Parsing env variables from $envfile:\n$(grep -v '^#' "$envfile")"
+
+                # anything which begins with a cap is exported
+                if grep -v '^#' "$envfile" | grep '^[A-Z]' -q; then
+                    export $(grep -v '^#' "$envfile" | grep '^[A-Z]' | tr '\n' ' ')
+                fi
+
+                # anything with a lowercase will get sourced
+                if grep -v '^#' "$envfile" | grep '^[a-z]' -q; then
+                    source <(grep -v '^#' "$envfile" | grep '^[a-z]') # | read -d $'\x04' name -
+                fi
+
+                # If packages were in env, make the installArray
                 if [[ -n $packages ]]; then
                     readarray -td: installArray < <(printf '%s' "$packages")
                 fi

--- a/setup.sh
+++ b/setup.sh
@@ -382,8 +382,6 @@ function _post() {
 
 _run_tests() {
     if [[ $test = "true" ]] || [ -f /etc/swizzin/.test.lock ]; then
-        echo
-        echo_info "Running post-install checks"
         bash /etc/swizzin/scripts/box test || return 1
     fi
 
@@ -422,10 +420,4 @@ _prioritize_results
 _install
 _post
 _run_post
-_run_tests || {
-    BAD="true"
-}
-
-if [ "$BAD" == "true" ]; then
-    exit 1
-fi
+_run_tests || exit 1


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description
<!-- Any general story time goes here :) Feel free to add screenshots/recording of your change in action here-->
This was preventing me from unattended installs on amd64 which is well supported now

## Fixes issues:
- fix: add local dev environment to gitignore
- feat: mark arm64 as supported
- fix: change `--test` flag in setup.sh
- fix: run tests when `.test.lock` is present

## Proposed Changes:
- mark amd64 as supported and stop telling people they can't make github issues

## Change Categories
<!-- DELETE WHICHEVER BULLET DOES NOT APPLY -->
- New feature <!-- non-breaking change which adds functionality -->

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [x] Docs have been made OR are not necessary
    - PR link: https://github.com/liaralabs/docs.swizzin.ltd/pull/97
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Testing was done
   - [x] Tests created or no new tests necessary
   - [x] Tests executed

## Test scenarios
<!-- Please let us know what has been done or anything else that works/doesn't. Feel free to copy-paste the examples at the bottom of this section -->

### Architectures
<!--
Please use these emojis here to fill the table below. It will nicely auto-format with spacing, don't worry. Leave empty wherever you do not know / have not tested
✅ = Works successfully
❎ = Does not work BUT is handled gracefully
🛠 = Still WIP
❌ = Broken / not working
-->
|   			| `amd64` 	| `armhf` 	| `arm64` 	| Unspecified 	|
|--------		|-------- 	|-------- 	|-------- 	|----------		|
| Focal 		|			|			|	yup		|				|
| Bionic		|			|			|			|				|
| Buster		|			|			|			|				|
| Stretch		|			|			|			|				|
| Raspbian  	|	⚫️		|			|	⚫️		|	⚫️			|

### ✅❎ Passed

### 🛠🛠 TODO

### ❌❌ Currently failing

<!-- EXAMPLES :
- Fresh app install without nginx
    - With only one user
    - With multiple users present
- Fresh Install with nginx present nginx
    - With only one user
    - With multiple users present
- Fresh install and nginx install afterwards
    - With only one user
    - With multiple users present
- Update from version in master
- Upgrade from version in master
- Password gets changed from `box` in app
- User removal from `box` acting on app
- New user in `box` gets added to app
- Sysinfo compatibility
    - Info washed
    - Content available
-->

