### PR TITLE
fix(completions): stop storing lists in swizdb

### DIFF
--- a/scripts/update/bash_completion.sh
+++ b/scripts/update/bash_completion.sh
@@ -6,23 +6,9 @@ if [[ ! -e /etc/bash_completion.d/box ]]; then
     echo_info "Shell completions for the box command have been installed. They will be applied the next time you log into a bash shell"
 fi
 
-# Create our apps and upgrade lists for the completion arrays. This is fired everytime this script is run to make sure the lists are current.
-swizdb set bash_completion/apps.list "$(find "/etc/swizzin/scripts/install/" -type f -exec basename {} \; | sort)"
-swizdb set bash_completion/upgrade.list "$(find "/etc/swizzin/scripts/upgrade/" -type f -exec basename {} \; | sort)"
-
 # Check to make sure the completion file /etc/swizzin/sources/bash_completion is set to 644
 if [[ $(stat -c '%A' /etc/swizzin/sources/bash_completion) != '-rw-r--r--' ]]; then
     chmod 644 '/etc/swizzin/sources/bash_completion'
 fi
-# Check to make sure the directory $(swizdb path bash_completion) is set to 755
-if [[ $(stat -c '%A' "$(swizdb path bash_completion)") != 'drwxr-xr-x' ]]; then
-    chmod 755 "$(swizdb path bash_completion)"
-fi
-# Add all files in $(swizdb list bash_completion) to the bash_completion_perms array to process in our for below
-readarray -t bash_completion_perms < <(swizdb list bash_completion)
-# Using a for and the bash_completion_perms array check through all files in the $(swizdb path bash_completion) have 644 perms set otherwise do nothing
-for file_names in "${bash_completion_perms[@]}"; do
-    if [[ "$(stat -c '%A' "$(swizdb path "${file_names}")")" != '-rw-r--r--' ]]; then
-        chmod 644 "$(swizdb path "${file_names}")"
-    fi
-done
+
+rm -rf "$(swizdb path bash_completion)"

--- a/sources/bash_completion
+++ b/sources/bash_completion
@@ -7,20 +7,21 @@ _command_complete() {
     cur=${COMP_WORDS[COMP_CWORD]}
     sub_cmd=${COMP_WORDS[1]}
 
-    mapfile -t apps_array < '/var/lib/swizzin/db/bash_completion/apps.list'
-    mapfile -t upgrade_array < '/var/lib/swizzin/db/bash_completion/upgrade.list'
+    mapfile -t install_array < <(find "/etc/swizzin/scripts/install/" -type f -exec basename {} \; | sort)
+    mapfile -t remove_array < <(find "/etc/swizzin/scripts/remove/" -type f -exec basename {} \; | sort)
+    mapfile -t upgrade_array < <(find "/etc/swizzin/scripts/upgrade/" -type f -exec basename {} \; | sort)
 
     case ${COMP_CWORD} in
         1)
-            mapfile -t COMPREPLY < <(compgen -W "install remove adduser deluser chpasswd update upgrade rtx rmgrsec list help" -- "${cur}")
+            mapfile -t COMPREPLY < <(compgen -W "install remove adduser deluser chpasswd update upgrade rtx rmgrsec list help test" -- "${cur}")
             ;;
         *)
             case ${sub_cmd} in
-                install)
-                    mapfile -t COMPREPLY < <(compgen -W "$(printf "%s " "${apps_array[@]%.*}")" -- "${cur}")
+                install | it)
+                    mapfile -t COMPREPLY < <(compgen -W "$(printf "%s " "${install_array[@]%.*}")" -- "${cur}")
                     ;;
-                remove)
-                    mapfile -t COMPREPLY < <(compgen -W "$(printf "%s " "${apps_array[@]%.*}")" -- "${cur}")
+                remove | rm)
+                    mapfile -t COMPREPLY < <(compgen -W "$(printf "%s " "${remove_array[@]%.*}")" -- "${cur}")
                     ;;
                 upgrade)
                     mapfile -t COMPREPLY < <(compgen -W "$(printf "%s " "${upgrade_array[@]%.*}")" -- "${cur}")

--- a/sources/bash_completion
+++ b/sources/bash_completion
@@ -13,7 +13,7 @@ _command_complete() {
 
     case ${COMP_CWORD} in
         1)
-            mapfile -t COMPREPLY < <(compgen -W "install remove adduser deluser chpasswd update upgrade rtx rmgrsec list help test" -- "${cur}")
+            mapfile -t COMPREPLY < <(compgen -W "install it remove rm adduser deluser chpasswd update upgrade rtx rmgrsec list help test" -- "${cur}")
             ;;
         *)
             case ${sub_cmd} in


### PR DESCRIPTION

<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description
Completions were only re-generated on `box update`, now they're just dynamic

## Fixes issues: 
- Storing hardcoded lists

## Proposed Changes:
- missing `box it`, `box rm` and `box test` commands

## Change Categories
<!-- DELETE WHICHEVER BULLET DOES NOT APPLY -->
- Bug fix <!-- non-breaking change which fixes an issue -->
- Change in `functions` <!-- e.g. `utils`, `os`, `apt`, `ask`, etc. -->

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [x] Docs have been made OR are not necessary
    - PR link: 
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Testing was done
   - [x] Tests created or no new tests necessary
   - [x] Tests executed

## Test scenarios
<!-- Please let us know what has been done or anything else that works/doesn't. Feel free to copy-paste the examples at the bottom of this section -->

### Architectures
<!--
Please use these emojis here to fill the table below. It will nicely auto-format with spacing, don't worry. Leave empty wherever you do not know / have not tested
✅ = Works successfully
❎ = Does not work BUT is handled gracefully
🛠 = Still WIP
❌ = Broken / not working
-->
|   			| `amd64` 	| `armhf` 	| `arm64` 	| Unspecified 	|
|--------		|-------- 	|-------- 	|-------- 	|----------		|
| Focal 		|			|			|	yup		|				|
| Bionic		|			|			|			|				|
| Buster		|			|			|			|				|
| Stretch		|			|			|			|				|
| Raspbian  	|	⚫️		|			|	⚫️		|	⚫️			|

### ✅❎ Passed

### 🛠🛠 TODO

### ❌❌ Currently failing

<!-- EXAMPLES :
- Fresh app install without nginx
    - With only one user
    - With multiple users present
- Fresh Install with nginx present nginx
    - With only one user
    - With multiple users present
- Fresh install and nginx install afterwards
    - With only one user
    - With multiple users present
- Update from version in master
- Upgrade from version in master
- Password gets changed from `box` in app
- User removal from `box` acting on app
- New user in `box` gets added to app
- Sysinfo compatibility
    - Info washed
    - Content available
-->

