### PR TITLE
hotfix(autodl): use gui-server-port and gui-server-password

### DIFF
--- a/scripts/install/rutorrent.sh
+++ b/scripts/install/rutorrent.sh
@@ -16,6 +16,16 @@ bash /usr/local/bin/swizzin/nginx/rutorrent.sh || {
     exit 1
 }
 
+# This is touched early to the autodl bash script will run.
+touch /install/.rutorrent.lock
+
+if [[ -f /install/.autodl.lock ]]; then
+    echo_progress_start "Configuring Autodl Plugin"
+    bash /usr/local/bin/swizzin/nginx/autodl.sh || {
+        echo_error "Autodl plugin config failed."
+    }
+    echo_progress_done "Autodl Plugin Configured"
+fi
+
 systemctl reload nginx
 echo_success "ruTorrent installed"
-touch /install/.rutorrent.lock

--- a/scripts/install/rutorrent.sh
+++ b/scripts/install/rutorrent.sh
@@ -17,8 +17,6 @@ bash /usr/local/bin/swizzin/nginx/rutorrent.sh || {
 }
 
 # This is touched early to the autodl bash script will run.
-touch /install/.rutorrent.lock
-
 if [[ -f /install/.autodl.lock ]]; then
     echo_progress_start "Configuring Autodl Plugin"
     bash /usr/local/bin/swizzin/nginx/autodl.sh || {

--- a/scripts/install/rutorrent.sh
+++ b/scripts/install/rutorrent.sh
@@ -16,7 +16,6 @@ bash /usr/local/bin/swizzin/nginx/rutorrent.sh || {
     exit 1
 }
 
-# This is touched early to the autodl bash script will run.
 if [[ -f /install/.autodl.lock ]]; then
     echo_progress_start "Configuring Autodl Plugin"
     bash /usr/local/bin/swizzin/nginx/autodl.sh || {

--- a/scripts/nginx/autodl.sh
+++ b/scripts/nginx/autodl.sh
@@ -16,8 +16,8 @@ if [[ -f /install/.rutorrent.lock ]]; then
         chown -R www-data:www-data autodl-irssi/
     fi
     for u in "${users[@]}"; do
-        IRSSI_PORT=$(grep port /home/${u}/.autodl/autodl.cfg | cut -d= -f2 | sed 's/ //g')
-        IRSSI_PASS=$(grep password /home/${u}/.autodl/autodl.cfg | cut -d= -f2 | sed 's/ //g')
+        IRSSI_PORT=$(grep gui-server-port /home/${u}/.autodl/autodl.cfg | cut -d= -f2 | sed 's/ //g')
+        IRSSI_PASS=$(grep gui-server-password /home/${u}/.autodl/autodl.cfg | cut -d= -f2 | sed 's/ //g')
         if [[ -z $(grep autodl /srv/rutorrent/conf/users/${u}/config.php) ]]; then
             sed -i '/?>/d' /srv/rutorrent/conf/users/${u}/config.php
             sed -i '/autodl/d' /srv/rutorrent/conf/users/${u}/config.php


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description
<!-- Any general story time goes here :) Feel free to add screenshots/recording of your change in action here-->

## Fixes issues: 
- Issue https://github.com/swizzin/swizzin/issues/751

## Proposed Changes:
Change from port to gui-server-port to prevent junk ending up in config.
Change from password to gui-server-password to prevent junk in config.

## Change Categories
<!-- DELETE WHICHEVER BULLET DOES NOT APPLY -->
- Bug fix <!-- non-breaking change which fixes an issue -->

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [x] Docs have been made OR are not necessary
    - PR link: 
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Testing was done
   - [x] Tests created or no new tests necessary
   - [x] Tests executed

## Test scenarios
<!-- Please let us know what has been done or anything else that works/doesn't. Feel free to copy-paste the examples at the bottom of this section -->

### Architectures
<!--
Please use these emojis here to fill the table below. It will nicely auto-format with spacing, don't worry. Leave empty wherever you do not know / have not tested
✅ = Works successfully
❎ = Does not work BUT is handled gracefully
🛠 = Still WIP
❌ = Broken / not working
-->
|   			| `amd64` 	| `armhf` 	| `arm64` 	| Unspecified 	|
|--------		|-------- 	|-------- 	|-------- 	|----------		|
| Focal 		|			|			|			|				|
| Bionic		|			|			|			|				|
| Buster		|			|			|			|				|
| Bullseye          |	✅		|			|			|				|
| Stretch		|			|			|			|				|
| Raspbian  	|			|			|			|				|

### ✅❎ Passed

### 🛠🛠 TODO

### ❌❌ Currently failing

<!-- EXAMPLES :
- Fresh app install without nginx
    - With only one user
    - With multiple users present
- Fresh Install with nginx present nginx
    - With only one user
    - With multiple users present
- Fresh install and nginx install afterwards
    - With only one user
    - With multiple users present
- Update from version in master
- Upgrade from version in master
- Password gets changed from `box` in app
- User removal from `box` acting on app
- New user in `box` gets added to app
- Sysinfo compatibility
    - Info washed
    - Content available
-->

