### PR TITLE
fix(qbit): enable preallocation by default

### DIFF
--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -364,6 +364,7 @@ Bittorrent\MaxConnecs=-1
 Bittorrent\MaxConnecsPerTorrent=-1
 Bittorrent\MaxUploads=-1
 Bittorrent\MaxUploadsPerTorrent=-1
+Downloads\PreAllocation=true
 Downloads\SavePath=/home/${user}/torrents/qbittorrent/
 Queueing\QueueingEnabled=false
 WebUI\Address=*


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description
Pre-allocation wasn't enabled by default, so let's enable it for new installations.

Since settings are personal, do not update current users.

## Fixes issues: 
- lots of extents per file if using XFS storage

## Proposed Changes:
- Enable pre-allocation by default to help prevent fragmentation if using XFS

## Change Categories
<!-- DELETE WHICHEVER BULLET DOES NOT APPLY -->
- Bug fix <!-- non-breaking change which fixes an issue -->