### PR TITLE
Fix: write qBittorrent cookie to correct path

### DIFF
--- a/scripts/nginx/qbittorrent.sh
+++ b/scripts/nginx/qbittorrent.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # nginx setup for qbittorrent
+#shellcheck source=sources/functions/utils
 . /etc/swizzin/sources/functions/utils
 users=($(_get_user_list))
 
@@ -33,7 +34,7 @@ location /qbittorrent/ {
 
     auth_basic_user_file /etc/htpasswd;
     rewrite ^/qbittorrent/(.*) /$1 break;
-
+    proxy_cookie_path / "/qbittorrent/; Secure";
 
     # The following directives effectively nullify Cross-site request forgery (CSRF)
     # protection mechanism in qBittorrent, only use them when you encountered connection problems.

--- a/scripts/update/qbittorrent.sh
+++ b/scripts/update/qbittorrent.sh
@@ -22,7 +22,7 @@ if [[ -f /install/.qbittorrent.lock ]]; then
     #Check for proxy_cookie_path in nginx to prevent writing cookies to /
     if [[ -f /install/.nginx.lock ]]; then
         if ! grep -q proxy_cookie_path /etc/nginx/apps/qbittorrent.conf; then
-            sed -i '/rewrite.* /a \   \ proxy_cookie_path \/ "\/qbittorrent\/\; Secure"\;' /etc/nginx/apps/qbittorrent.conf
+            sed -r 's|(rewrite .*)|\1\n    proxy_cookie_path / "/qbittorrent/; Secure";|g' -i /etc/nginx/apps/qbittorrent.conf
             systemctl reload nginx
         fi
     fi

--- a/scripts/update/qbittorrent.sh
+++ b/scripts/update/qbittorrent.sh
@@ -19,4 +19,11 @@ if [[ -f /install/.qbittorrent.lock ]]; then
         echo_info "qBittorrent systemd services have been updated. Please restart qBittorrent services at your convenience."
     fi
     #End systemd service updates
+    #Check for proxy_cookie_path in nginx to prevent writing cookies to /
+    if [[ -f /install/.nginx.lock ]]; then
+        if ! grep -q proxy_cookie_path /etc/nginx/apps/qbittorrent.conf; then
+            sed -i '/rewrite.* /a \   \ proxy_cookie_path \/ "\/qbittorrent\/\; Secure"\;' /etc/nginx/apps/qbittorrent.conf
+            systemctl reload nginx
+        fi
+    fi
 fi


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description
<!-- Any general story time goes here :) Feel free to add screenshots/recording of your change in action here-->

## Fixes issues: 
- Issue https://github.com/swizzin/swizzin/issues/800

## Proposed Changes:
- Apply proxy_cookie_path to qBittorrent nginx config.

## Change Categories
<!-- DELETE WHICHEVER BULLET DOES NOT APPLY -->
- Bug fix <!-- non-breaking change which fixes an issue -->

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [x] Docs have been made OR are not necessary
    - PR link: 
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Testing was done
   - [x] Tests created or no new tests necessary
   - [x] Tests executed

## Test scenarios
<!-- Please let us know what has been done or anything else that works/doesn't. Feel free to copy-paste the examples at the bottom of this section -->
Install two instances of qBittorrent. Try logging in on both and see if one disconnects or "fails to connect"

### Architectures
<!--
Please use these emojis here to fill the table below. It will nicely auto-format with spacing, don't worry. Leave empty wherever you do not know / have not tested
✅ = Works successfully
❎ = Does not work BUT is handled gracefully
🛠 = Still WIP
❌ = Broken / not working
-->
|   			| `amd64` 	| `armhf` 	| `arm64` 	| Unspecified 	|
|--------		|-------- 	|-------- 	|-------- 	|----------		|
| Focal 		|			|			|			|				|
| Bionic		|			|			|			|				|
| Buster		|			|			|			|				|
| Bullseye		|	✅		|			|			|				|
| Stretch		|			|			|			|				|
| Raspbian  	|	⚫️		|			|	⚫️		|	⚫️			|

### ✅❎ Passed

### 🛠🛠 TODO

### ❌❌ Currently failing

<!-- EXAMPLES :
- Fresh app install without nginx
    - With only one user
    - With multiple users present
- Fresh Install with nginx present nginx
    - With only one user
    - With multiple users present
- Fresh install and nginx install afterwards
    - With only one user
    - With multiple users present
- Update from version in master
- Upgrade from version in master
- Password gets changed from `box` in app
- User removal from `box` acting on app
- New user in `box` gets added to app
- Sysinfo compatibility
    - Info washed
    - Content available
-->

