### PR TITLE
feat(qbittorrent): Add support for 4.4 (cmake build/qt6/libtorrent 2.0)

### DIFF
--- a/scripts/install/qbittorrent.sh
+++ b/scripts/install/qbittorrent.sh
@@ -33,7 +33,9 @@ case ${QBITTORRENT_VERSION} in
         qbittorrent_version_info
         #check_client_compatibility
         install_fpm
-        install_cmake_swizzin
+        if [[ $build_type == "cmake" ]]; then
+            install_cmake_swizzin
+        fi
         check_swap_on
 
         if ! skip_libtorrent_qbittorrent; then

--- a/scripts/install/qbittorrent.sh
+++ b/scripts/install/qbittorrent.sh
@@ -33,6 +33,7 @@ case ${QBITTORRENT_VERSION} in
         qbittorrent_version_info
         #check_client_compatibility
         install_fpm
+        install_cmake_swizzin
         check_swap_on
 
         if ! skip_libtorrent_qbittorrent; then

--- a/scripts/remove/qbittorrent.sh
+++ b/scripts/remove/qbittorrent.sh
@@ -17,12 +17,11 @@ if [[ ! -f /install/.deluge.lock ]]; then
     dpkg -r python3-libtorrent > /dev/null 2>&1
 fi
 
-if dpkg -s qtbase5-swizzin > /dev/null 2>&1; then
-    dpkg -r qtbase5-swizzin > /dev/null 2>&1
-fi
-if dpkg -s qttools5-swizzin > /dev/null 2>&1; then
-    dpkg -r qttools5-swizzin > /dev/null 2>&1
-fi
+for swizz_dep in qtbase5-swizzin qttools5-swizzin qt6-swizzin cmake-swizzin; do
+    if dpkg-query -W -f='${Status}' ${swizz_dep} 2> /dev/null | grep -c "ok installed" > /dev/null 2>&1; then
+        dpkg -r ${swizz_dep} > /dev/null 2>&1
+    fi
+done
 
 if [[ -f /install/.nginx.lock ]]; then
     systemctl reload nginx

--- a/scripts/remove/qbittorrent.sh
+++ b/scripts/remove/qbittorrent.sh
@@ -18,7 +18,7 @@ if [[ ! -f /install/.deluge.lock ]]; then
 fi
 
 for swizz_dep in qtbase5-swizzin qttools5-swizzin qt6-swizzin cmake-swizzin; do
-    if dpkg-query -W -f='${Status}' ${swizz_dep} 2> /dev/null | grep -c "ok installed" > /dev/null 2>&1; then
+    if check_installed ${swizz_dep}; then
         dpkg -r ${swizz_dep} > /dev/null 2>&1
     fi
 done

--- a/scripts/upgrade/qbittorrent.sh
+++ b/scripts/upgrade/qbittorrent.sh
@@ -28,6 +28,7 @@ case ${QBITTORRENT_VERSION} in
         detect_libtorrent_rasterbar_conflict qbittorrent
         qbittorrent_version_info
         install_fpm
+        install_cmake_swizzin
         check_swap_on
 
         if ! skip_libtorrent_qbittorrent; then

--- a/scripts/upgrade/qbittorrent.sh
+++ b/scripts/upgrade/qbittorrent.sh
@@ -28,7 +28,9 @@ case ${QBITTORRENT_VERSION} in
         detect_libtorrent_rasterbar_conflict qbittorrent
         qbittorrent_version_info
         install_fpm
-        install_cmake_swizzin
+        if [[ $build_type == "cmake" ]]; then
+            install_cmake_swizzin
+        fi
         check_swap_on
 
         if ! skip_libtorrent_qbittorrent; then

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -152,9 +152,9 @@ function install_qt() {
             QT_PREFIX=/opt/local
         else
             build_qt_swizzin
+            QT_SWIZZIN=Qt5_DIR="${QT_PREFIX}"
         fi
         QT_METHOD=swizzin
-        QT_SWIZZIN=QT_QMAKE="${QT_PREFIX}/bin"
     else
         LIST='qtbase5-dev qttools5-dev'
         apt_install --no-recommends $LIST
@@ -300,12 +300,14 @@ function build_libtorrent_qbittorrent() {
     if [[ ${libtorrent_branch} == "RC_1_1" ]]; then
         #Dirty hack to ensure finished library uses `libtorrent-rasterbar` for its name in the deprecated 1.1 branch
         sed -i 's/virtual-target.add-prefix-and-suffix $(name)/virtual-target.add-prefix-and-suffix $(name)-rasterbar/g' Jamfile
+        #Inconsistent boost variables
+        cmakeboost=Boost_INCLUDE_DIR
     fi
     VERSION=$(grep -oP "VERSION\ = \K\d\.\d\.\d+" Jamfile)
     PATH=/opt/local/bin:${PATH} cmake -Wno-dev -Wno-deprecated -G Ninja -B build \
         -D CMAKE_BUILD_TYPE="Release" \
         -D CMAKE_CXX_STANDARD="${stdcver//[^0-9]/}" \
-        -D BOOST_INCLUDEDIR="/opt/boost_${BOOST_VERSION}" \
+        -D ${cmakeboost:=BOOST_INCLUDEDIR}="/opt/boost_${BOOST_VERSION}" \
         -D BUILD_SHARED_LIBS=OFF \
         -D CMAKE_CXX_FLAGS="${CXXFLAGS}" \
         -D CMAKE_C_FLAGS="${CFLAGS}" \
@@ -352,7 +354,7 @@ function build_qbittorrent() {
     tag=" static with ${stdcver} march=native"
     #Ensure boost variables are loaded (i.e. libtorrent skipped)
     booststrap
-    PATH=/opt/local/bin:${PATH} cmake -Wno-dev -Wno-deprecated -G Ninja -B build \
+    ${QT_SWIZZIN} PATH=/opt/local/bin:${PATH} cmake -Wno-dev -Wno-deprecated -G Ninja -B build \
         -D CMAKE_BUILD_TYPE="release" \
         -D CMAKE_CXX_STANDARD="${stdcver//[^0-9]/}" \
         -D QT6="${qbt_use_qt6:=OFF}" \

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -191,7 +191,7 @@ function install_qt_swizzin() {
 function install_cmake_swizzin() {
     latest_cmake_swizzin=$(curl -fsSLI -o /dev/null -w %{url_effective} https://github.com/swizzin/cmake_crossbuild/releases/latest | grep -o '[^/]*$')
     installed_cmake_swizzin=$(dpkg-query --showformat='${Version}' --show cmake-swizzin 2> /dev/null)
-    if [[ -z ${installed_cmake_swizzin} ]] || dpkg --compare-versions ${installed_cmake_swizzin} lt ${latest_cmake_swizzin}; then
+    if [[ -z ${installed_cmake_swizzin} ]] || dpkg --compare-versions ${installed_cmake_swizzin} lt ${latest_cmake_swizzin//_/+}; then
         echo_progress_start "Installing latest cmake-swizzin"
         wget -O /tmp/cmake-swizzin.deb https://github.com/swizzin/cmake_crossbuild/releases/download/${latest_cmake_swizzin}/$(_os_distro)-$(_os_codename)-cmake-swizzin-$(_os_arch).deb >> ${log} 2>&1 || {
             echo_error "cmake-swizzin could not be downloaded from github. Setup will not proceed"

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -187,7 +187,7 @@ function install_cmake_swizzin() {
     installed_cmake_swizzin=$(dpkg-query --showformat='${Version}' --show cmake-swizzin 2> /dev/null)
     if [[ -z ${installed_cmake_swizzin} ]] || dpkg --compare-versions ${installed_cmake_swizzin} lt ${latest_cmake_swizzin}; then
         echo_progress_start "Installing latest cmake-swizzin"
-        wget -O /tmp/qt6-swizzin.deb https://github.com/swizzin/qt6_crossbuild/releases/download/${latest_qt_swizzin}/$(_os_distro)-$(_os_codename)-qt6-swizzin-$(_os_arch).deb >> ${log} 2>&1 || {
+        wget -O /tmp/qt6-swizzin.deb https://github.com/swizzin/qt6_crossbuild/releases/download/${latest_cmake_swizzin}/$(_os_distro)-$(_os_codename)-qt6-swizzin-$(_os_arch).deb >> ${log} 2>&1 || {
             echo_error "cmake-swizzin could not be downloaded from github. Setup will not proceed"
             exit 1
         }

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -293,7 +293,7 @@ function build_libtorrent_qbittorrent() {
     rm_if_exists /tmp/libtorrent
     booststrap
     apt_install libssl-dev
-    git clone -b ${libtorrent_branch} --recurse-submodules https://github.com/arvidn/libtorrent /tmp/libtorrent >> ${log} 2>&1 || {
+    git clone -b ${libtorrent_branch} --depth 1 --recurse-submodules https://github.com/arvidn/libtorrent /tmp/libtorrent >> ${log} 2>&1 || {
         echo_error "Libtorrent could not be cloned from git. Setup will not proceed"
         exit 1
     }

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -9,25 +9,27 @@ function whiptail_qbittorrent() {
         latestv41=$(echo "$releases" | grep -m1 -oP '4\.1\.\d?.?\d')
         latestv42=$(echo "$releases" | grep -m1 -oP '4\.2\.\d?.?\d')
         latestv43=$(echo "$releases" | grep -m1 -oP '4\.3\.\d?.?\d')
+        latestv44=$(echo "$releases" | grep -m1 -oP '4\.4\.\d?.?\d')
         #latestv=$(echo "$releases" | grep -m1 -oP '\d.\d?.?\d?.?\d')
         repov=$(get_candidate_version qbittorrent-nox)
         case ${codename} in
             "stretch")
                 #We can't go past 4.3.1 due to openssl and c++ requirements
                 function=$(
-                    whiptail --title "Install Software" --menu "Choose a qBittorrent version:" --ok-button "Continue" --nocancel 12 50 3 \
+                    whiptail --title "Install Software" --menu "Choose a qBittorrent version:" --ok-button "Continue" --nocancel 12 50 5 \
                         "Repo" "${repov}" \
-                        "4.1" "(${latestv41})" \
+                        "4.3.1" "(4.3.1)" \
                         "4.2" "(${latestv42})" \
-                        "4.3.1" "(4.3.1)" 3>&1 1>&2 2>&3
+                        "4.1" "(${latestv41})" 3>&1 1>&2 2>&3
                 )
                 ;;
             *)
-                function=$(whiptail --title "Install Software" --menu "Choose a qBittorrent version:" --ok-button "Continue" --nocancel 12 50 4 \
+                function=$(whiptail --title "Install Software" --menu "Choose a qBittorrent version:" --ok-button "Continue" --nocancel 12 50 5 \
                     "Repo" "${repov}" \
-                    "4.1" "(${latestv41})" \
+                    "4.4" "(${latestv44})" \
+                    "4.3" "(${latestv43})" \
                     "4.2" "(${latestv42})" \
-                    "4.3" "(${latestv43})" 3>&1 1>&2 2>&3)
+                    "4.1" "(${latestv41})" 3>&1 1>&2 2>&3)
                 #"Latest" "(${latestv})" 3>&1 1>&2 2>&3)
                 ;;
         esac
@@ -47,6 +49,9 @@ function whiptail_qbittorrent() {
             4.3.1)
                 export QBITTORRENT_VERSION=4.3.1
                 ;;
+            4.4)
+                export QBITTORRENT_VERSION=${latestv44}
+                ;;
             Repo)
                 export QBITTORRENT_VERSION=repo
                 ;;
@@ -64,6 +69,8 @@ function qbittorrent_version_info() {
         latestv43=$(echo "$releases" | grep -m1 -oP '4\.3\.\d?.?\d')
         QBITTORRENT_VERSION=${latestv43}
     fi
+    CFLAGS="-march=native"
+    CXXFLAGS="-march=native"
     case $QBITTORRENT_VERSION in
         4.1.*)
             libtorrent_branch=RC_1_1
@@ -105,11 +112,12 @@ function qbittorrent_version_info() {
             libtorrent_branch=RC_2_0
             libtorrent_minimum_version=2.0
             stdcver="c++17"
-            qt_minimum_version=5.12
+            qt_minimum_version=6.0
+            qbt_use_qt6=ON
             cryptography_type=openssl
             ;;
         *)
-            echo_error "qBittorrent version should be between 4.1.*(.*) and 4.3.*(.*) -- Setup will not proceed."
+            echo_error "qBittorrent version should be between 4.1.*(.*) and 4.4.*(.*) -- Setup will not proceed."
             exit 1
             ;;
     esac
@@ -139,7 +147,12 @@ function skip_libtorrent_qbittorrent() {
 function install_qt() {
     qt_repo_version=$(get_candidate_version qtbase5-dev)
     if ! dpkg --compare-versions ${qt_repo_version} ge ${qt_minimum_version}; then
-        build_qt
+        if ${qt_minimum_version} ge 6.0; then
+            install_qt_swizzin
+            QT_PREFIX=/opt/local
+        else
+            build_qt_swizzin
+        fi
         QT_METHOD=swizzin
         QT_SWIZZIN=QT_QMAKE="${QT_PREFIX}/bin"
     else
@@ -150,10 +163,43 @@ function install_qt() {
         dpkg -r qttools5-swizzin > /dev/null 2>&1
         QT_METHOD=repo
     fi
-
 }
 
-function build_qt() {
+function install_qt_swizzin() {
+    latest_qt_swizzin=$(curl -fsSLI -o /dev/null -w %{url_effective} https://github.com/swizzin/qt6_crossbuild/releases/latest | grep -o '[^/]*$')
+    installed_qt_swizzin=$(dpkg-query --showformat='${Version}' --show qt6-swizzin 2> /dev/null)
+    if [[ -z ${installed_qt_swizzin} ]] || dpkg --compare-versions ${installed_qt_swizzin} lt ${latest_qt_swizzin}; then
+        echo_progress_start "Installing latest qt6-swizzin"
+        wget -O /tmp/qt6-swizzin.deb https://github.com/swizzin/qt6_crossbuild/releases/download/${latest_qt_swizzin}/$(_os_distro)-$(_os_codename)-qt6-swizzin-$(_os_arch).deb >> ${log} 2>&1 || {
+            echo_error "qt6-swizzin could not be downloaded from github. Setup will not proceed"
+            exit 1
+        }
+        dpkg -i /tmp/qt6-swizzin.deb >> ${log} 2>&1 || {
+            echo_error "Something went wrong when installing qt6-swizzin. Setup will not proceed"
+        }
+        rm -rf /tmp/qt6-swizzin.deb
+        echo_progress_done "qt6-swizzin installed"
+    fi
+}
+
+function install_cmake_swizzin() {
+    latest_cmake_swizzin=$(curl -fsSLI -o /dev/null -w %{url_effective} https://github.com/swizzin/qt6_crossbuild/releases/latest | grep -o '[^/]*$')
+    installed_cmake_swizzin=$(dpkg-query --showformat='${Version}' --show cmake-swizzin 2> /dev/null)
+    if [[ -z ${installed_cmake_swizzin} ]] || dpkg --compare-versions ${installed_cmake_swizzin} lt ${latest_cmake_swizzin}; then
+        echo_progress_start "Installing latest cmake-swizzin"
+        wget -O /tmp/qt6-swizzin.deb https://github.com/swizzin/qt6_crossbuild/releases/download/${latest_qt_swizzin}/$(_os_distro)-$(_os_codename)-qt6-swizzin-$(_os_arch).deb >> ${log} 2>&1 || {
+            echo_error "cmake-swizzin could not be downloaded from github. Setup will not proceed"
+            exit 1
+        }
+        dpkg -i /tmp/qt6-swizzin.deb >> ${log} 2>&1 || {
+            echo_error "Something went wrong when installing cmake-swizzin. Setup will not proceed"
+        }
+        rm -rf /tmp/qt6-swizzin.deb
+        echo_progress_done "cmake-swizzin installed"
+    fi
+}
+
+function build_qt_swizzin() {
     cd /tmp
     QT_PREFIX=/usr/local/qt
     case $(_os_codename) in
@@ -234,9 +280,9 @@ function whiptail_skip_qt() {
 function build_libtorrent_qbittorrent() {
     rm_if_exists /tmp/libtorrent
     booststrap
-    echo "using gcc : : : <cflags>\"-march=native -std=${stdcver}\" <cxxflags>\"-march=native -std=${stdcver}\" ;" > /root/user-config.jam
+    #echo "using gcc : : : <cflags>\"-march=native -std=${stdcver}\" <cxxflags>\"-march=native -std=${stdcver}\" ;" > /root/user-config.jam
     apt_install libssl-dev
-    git clone -b ${libtorrent_branch} https://github.com/arvidn/libtorrent /tmp/libtorrent >> ${log} 2>&1 || {
+    git clone -b ${libtorrent_branch} --recurse-submodules https://github.com/arvidn/libtorrent /tmp/libtorrent >> ${log} 2>&1 || {
         echo_error "Libtorrent could not be cloned from git. Setup will not proceed"
         exit 1
     }
@@ -255,8 +301,22 @@ function build_libtorrent_qbittorrent() {
         #Dirty hack to ensure finished library uses `libtorrent-rasterbar` for its name in the deprecated 1.1 branch
         sed -i 's/virtual-target.add-prefix-and-suffix $(name)/virtual-target.add-prefix-and-suffix $(name)-rasterbar/g' Jamfile
     fi
-    VERSION=$(grep AC_INIT configure.ac | grep -oP '\d+\.\d+\.\d+')
-    /opt/boost_${BOOST_VERSION}/b2 -j$(nproc) crypto=${cryptography_type} variant=release link=static install --prefix=/tmp/dist/libtorrent/usr/local install >> ${log} 2>&1
+    VERSION=$(grep -oP "VERSION\ = \K\d\.\d\.\d+" Jamfile)
+    PATH=${PATH}:/opt/local/bin cmake -Wno-dev -Wno-deprecated -G Ninja -B build \
+        -D CMAKE_BUILD_TYPE="Release" \
+        -D CMAKE_CXX_STANDARD="${stdcver//[^0-9]/}" \
+        -D BOOST_INCLUDEDIR="/opt/boost_${BOOST_VERSION}" \
+        -D BUILD_SHARED_LIBS=OFF \
+        -D CMAKE_CXX_FLAGS="${CXXFLAGS}" \
+        -D CMAKE_C_FLAGS="${CFLAGS}" \
+        -D CMAKE_INSTALL_PREFIX="/tmp/dist/libtorrent/usr/local"
+    PATH=${PATH}:/opt/local/bin cmake --build build
+    PATH=${PATH}:/opt/local/bin cmake --install build
+    #Fix pkgconfig paths/quirks
+    sed -i 's|/tmp/dist/libtorrent||g' /tmp/dist/libtorrent/usr/local/lib/pkgconfig/libtorrent-rasterbar.pc
+    sed -i 's|-ltorrent-rasterbar|-l:libtorrent-rasterbar.a|g' /tmp/dist/libtorrent/usr/local/lib/pkgconfig/libtorrent-rasterbar.pc
+    #Deprecated boost build command
+    #/opt/boost_${BOOST_VERSION}/b2 -j$(nproc) crypto=${cryptography_type} variant=release link=static fpic=on lto=on install --prefix=/tmp/dist/libtorrent/usr/local install >> ${log} 2>&1
     tag=" static with ${stdcver} march=native"
     mkdir -p /root/dist
     fpm -f -C /tmp/dist/libtorrent -p /root/dist/libtorrent-rasterbar_VERSION.deb -s dir -t deb -n libtorrent-rasterbar --version ${VERSION} --description "Libtorrent rasterbar compiled by swizzin$tag" >> ${log} 2>&1
@@ -292,9 +352,20 @@ function build_qbittorrent() {
     tag=" static with ${stdcver} march=native"
     #Ensure boost variables are loaded (i.e. libtorrent skipped)
     booststrap
-    ./configure --prefix=/usr --disable-gui --with-boost=${BOOST_ROOT} --with-boost-libdir="/usr/local/lib" libtorrent_CFLAGS="-I/usr/local/include -I${BOOST_ROOT}" libtorrent_LIBS="-L/usr/local/lib -l:libtorrent-rasterbar.a -lssl -lcrypto" CXXFLAGS="-march=native -std=${stdcver}" ${QT_SWIZZIN} >> ${log} 2>&1
-    make -j$(nproc) >> $log 2>&1
-    make INSTALL_ROOT=/tmp/dist/qbittorrent install >> ${log} 2>&1
+    PATH=${PATH}:/opt/local/bin cmake -Wno-dev -Wno-deprecated -G Ninja -B build \
+        -D CMAKE_BUILD_TYPE="release" \
+        -D CMAKE_CXX_STANDARD="${stdcver//[^0-9]/}" \
+        -D QT6="${qbt_use_qt6:=OFF}" \
+        -D Boost_NO_BOOST_CMAKE=TRUE \
+        -D CMAKE_CXX_FLAGS="${CXXFLAGS}" \
+        -D CMAKE_C_FLAGS="${CFLAGS}" \
+        -D GUI=OFF \
+        -D CMAKE_INSTALL_PREFIX="/tmp/dist/qbittorrent/usr"
+    PATH=${PATH}:/opt/local/bin cmake --build build
+    PATH=${PATH}:/opt/local/bin cmake --install build
+    #./configure --prefix=/usr --disable-gui --with-boost=${BOOST_ROOT} --with-boost-libdir="/usr/local/lib" libtorrent_CFLAGS="-I/usr/local/include -I${BOOST_ROOT}" libtorrent_LIBS="-L/usr/local/lib -l:libtorrent-rasterbar.a -lssl -lcrypto" CXXFLAGS="-march=native -std=${stdcver}" ${QT_SWIZZIN} >> ${log} 2>&1
+    #make -j$(nproc) >> $log 2>&1
+    #make INSTALL_ROOT=/tmp/dist/qbittorrent install >> ${log} 2>&1
     mkdir -p /root/dist
     fpm -f -C /tmp/dist/qbittorrent -p /root/dist/qbittorrent-nox_VERSION.deb -s dir -t deb -n qbittorrent-nox --version ${VERSION} --description "qbittorrent-nox compiled by swizzin$tag" >> ${log} 2>&1
     dpkg -i /root/dist/qbittorrent-nox_${VERSION}.deb >> ${log} 2>&1 || {

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -316,9 +316,9 @@ function build_libtorrent_qbittorrent() {
                 -D BUILD_SHARED_LIBS=OFF \
                 -D CMAKE_CXX_FLAGS="${CXXFLAGS}" \
                 -D CMAKE_C_FLAGS="${CFLAGS}" \
-                -D CMAKE_INSTALL_PREFIX="/tmp/dist/libtorrent/usr/local"
-            PATH=/opt/local/bin:${PATH} cmake --build build
-            PATH=/opt/local/bin:${PATH} cmake --install build
+                -D CMAKE_INSTALL_PREFIX="/tmp/dist/libtorrent/usr/local" >> ${log} 2>&1
+            PATH=/opt/local/bin:${PATH} cmake --build build >> ${log} 2>&1
+            PATH=/opt/local/bin:${PATH} cmake --install build >> ${log} 2>&1
             #Fix pkgconfig paths/quirks
             sed -i 's|/tmp/dist/libtorrent||g' /tmp/dist/libtorrent/usr/local/lib/pkgconfig/libtorrent-rasterbar.pc
             sed -i 's|-ltorrent-rasterbar|-l:libtorrent-rasterbar.a|g' /tmp/dist/libtorrent/usr/local/lib/pkgconfig/libtorrent-rasterbar.pc
@@ -377,9 +377,9 @@ function build_qbittorrent() {
                 -D CMAKE_CXX_FLAGS="${CXXFLAGS}" \
                 -D CMAKE_C_FLAGS="${CFLAGS}" \
                 -D GUI=OFF \
-                -D CMAKE_INSTALL_PREFIX="/tmp/dist/qbittorrent/usr"
-            PATH=/opt/local/bin:${PATH} cmake --build build
-            PATH=/opt/local/bin:${PATH} cmake --install build
+                -D CMAKE_INSTALL_PREFIX="/tmp/dist/qbittorrent/usr" >> ${log} 2>&1
+            PATH=/opt/local/bin:${PATH} cmake --build build >> ${log} 2>&1
+            PATH=/opt/local/bin:${PATH} cmake --install build >> ${log} 2>&1
             ;;
         autotools)
             ./configure --prefix=/usr --disable-gui --with-boost=${BOOST_ROOT} --with-boost-libdir="/usr/local/lib" libtorrent_CFLAGS="-I/usr/local/include -I${BOOST_ROOT}" libtorrent_LIBS="-L/usr/local/lib -l:libtorrent-rasterbar.a -lssl -lcrypto" CXXFLAGS="-march=native -std=${stdcver}" ${QT_SWIZZIN} >> ${log} 2>&1

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -187,7 +187,7 @@ function install_cmake_swizzin() {
     installed_cmake_swizzin=$(dpkg-query --showformat='${Version}' --show cmake-swizzin 2> /dev/null)
     if [[ -z ${installed_cmake_swizzin} ]] || dpkg --compare-versions ${installed_cmake_swizzin} lt ${latest_cmake_swizzin}; then
         echo_progress_start "Installing latest cmake-swizzin"
-        wget -O /tmp/cmake-swizzin.deb https://github.com/swizzin/cmake_crossbuild/releases/download/${latest_cmake_swizzin}/$(_os_distro)-$(_os_codename)-qt6-swizzin-$(_os_arch).deb >> ${log} 2>&1 || {
+        wget -O /tmp/cmake-swizzin.deb https://github.com/swizzin/cmake_crossbuild/releases/download/${latest_cmake_swizzin}/$(_os_distro)-$(_os_codename)-cmake-swizzin-$(_os_arch).deb >> ${log} 2>&1 || {
             echo_error "cmake-swizzin could not be downloaded from github. Setup will not proceed"
             exit 1
         }

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -65,9 +65,15 @@ function whiptail_qbittorrent() {
 
 function qbittorrent_version_info() {
     if [[ ${QBITTORRENT_VERSION} == "latest" ]]; then
-        releases=$(git ls-remote -t --refs https://github.com/qbittorrent/qBittorrent.git | awk '{sub("refs/tags/release-", ""); print $2 }' | grep -v -e "beta" -e "rc" | sort -Vr)
-        latestv43=$(echo "$releases" | grep -m1 -oP '4\.3\.\d?.?\d')
-        QBITTORRENT_VERSION=${latestv43}
+        case $(_os_codename) in
+            stretch)
+                QBITTORRENT_VERSION=4.3.1
+                ;;
+            *)
+                QBITTORRENT_VERSION=$(git ls-remote -t --refs https://github.com/qbittorrent/qBittorrent.git | awk '{sub("refs/tags/release-", ""); print $2 }' | grep -v -e "beta" -e "rc" | sort -Vr | head -n1)
+                #latestv44=$(echo "$releases" | grep -m1 -oP '4\.4\.\d?.?\d')
+                ;;
+        esac
     fi
     CFLAGS="-march=native"
     CXXFLAGS="-march=native"

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -147,7 +147,7 @@ function skip_libtorrent_qbittorrent() {
 function install_qt() {
     qt_repo_version=$(get_candidate_version qtbase5-dev)
     if ! dpkg --compare-versions ${qt_repo_version} ge ${qt_minimum_version}; then
-        if ${qt_minimum_version} ge 6.0; then
+        if dpkg --compare-versions ${qt_minimum_version} ge 6.0; then
             install_qt_swizzin
             QT_PREFIX=/opt/local
         else

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -183,7 +183,7 @@ function install_qt_swizzin() {
 }
 
 function install_cmake_swizzin() {
-    latest_cmake_swizzin=$(curl -fsSLI -o /dev/null -w %{url_effective} https://github.com/swizzin/qt6_crossbuild/releases/latest | grep -o '[^/]*$')
+    latest_cmake_swizzin=$(curl -fsSLI -o /dev/null -w %{url_effective} https://github.com/swizzin/cmake_crossbuild/releases/latest | grep -o '[^/]*$')
     installed_cmake_swizzin=$(dpkg-query --showformat='${Version}' --show cmake-swizzin 2> /dev/null)
     if [[ -z ${installed_cmake_swizzin} ]] || dpkg --compare-versions ${installed_cmake_swizzin} lt ${latest_cmake_swizzin}; then
         echo_progress_start "Installing latest cmake-swizzin"

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -79,6 +79,7 @@ function qbittorrent_version_info() {
             stdcver="c++14"
             qt_minimum_version=5.5
             cryptography_type=built-in
+            buid_type=autotools
             ;;
         4.2.*)
             libtorrent_branch=RC_1_2
@@ -86,6 +87,7 @@ function qbittorrent_version_info() {
             stdcver="c++14"
             qt_minimum_version=5.9
             cryptography_type=openssl
+            build_type=autotools
             ;;
         4.3.[012]*)
             libtorrent_branch=RC_1_2
@@ -93,6 +95,7 @@ function qbittorrent_version_info() {
             stdcver="c++14"
             qt_minimum_version=5.9
             cryptography_type=openssl
+            build_type=autotools
             ;;
         4.3.3)
             libtorrent_branch=RC_1_2
@@ -100,6 +103,7 @@ function qbittorrent_version_info() {
             stdcver="c++17"
             qt_minimum_version=5.9
             cryptography_type=openssl
+            build_type=autotools
             ;;
         4.3.*)
             libtorrent_branch=RC_1_2
@@ -107,6 +111,7 @@ function qbittorrent_version_info() {
             stdcver="c++17"
             qt_minimum_version=5.12
             cryptography_type=openssl
+            build_type=autotools
             ;;
         4.4.*)
             libtorrent_branch=RC_2_0
@@ -115,6 +120,7 @@ function qbittorrent_version_info() {
             qt_minimum_version=6.0
             qbt_use_qt6=ON
             cryptography_type=openssl
+            build_type=cmake
             ;;
         *)
             echo_error "qBittorrent version should be between 4.1.*(.*) and 4.4.*(.*) -- Setup will not proceed."
@@ -280,7 +286,6 @@ function whiptail_skip_qt() {
 function build_libtorrent_qbittorrent() {
     rm_if_exists /tmp/libtorrent
     booststrap
-    #echo "using gcc : : : <cflags>\"-march=native -std=${stdcver}\" <cxxflags>\"-march=native -std=${stdcver}\" ;" > /root/user-config.jam
     apt_install libssl-dev
     git clone -b ${libtorrent_branch} --recurse-submodules https://github.com/arvidn/libtorrent /tmp/libtorrent >> ${log} 2>&1 || {
         echo_error "Libtorrent could not be cloned from git. Setup will not proceed"
@@ -302,21 +307,31 @@ function build_libtorrent_qbittorrent() {
         sed -i 's/virtual-target.add-prefix-and-suffix $(name)/virtual-target.add-prefix-and-suffix $(name)-rasterbar/g' Jamfile
     fi
     VERSION=$(grep -oP "VERSION\ = \K\d\.\d\.\d+" Jamfile)
-    PATH=/opt/local/bin:${PATH} cmake -Wno-dev -Wno-deprecated -G Ninja -B build \
-        -D CMAKE_BUILD_TYPE="Release" \
-        -D CMAKE_CXX_STANDARD="${stdcver//[^0-9]/}" \
-        -D BOOST_INCLUDEDIR="/opt/boost_${BOOST_VERSION}" \
-        -D BUILD_SHARED_LIBS=OFF \
-        -D CMAKE_CXX_FLAGS="${CXXFLAGS}" \
-        -D CMAKE_C_FLAGS="${CFLAGS}" \
-        -D CMAKE_INSTALL_PREFIX="/tmp/dist/libtorrent/usr/local"
-    PATH=/opt/local/bin:${PATH} cmake --build build
-    PATH=/opt/local/bin:${PATH} cmake --install build
-    #Fix pkgconfig paths/quirks
-    sed -i 's|/tmp/dist/libtorrent||g' /tmp/dist/libtorrent/usr/local/lib/pkgconfig/libtorrent-rasterbar.pc
-    sed -i 's|-ltorrent-rasterbar|-l:libtorrent-rasterbar.a|g' /tmp/dist/libtorrent/usr/local/lib/pkgconfig/libtorrent-rasterbar.pc
-    #Deprecated boost build command
-    #/opt/boost_${BOOST_VERSION}/b2 -j$(nproc) crypto=${cryptography_type} variant=release link=static fpic=on lto=on install --prefix=/tmp/dist/libtorrent/usr/local install >> ${log} 2>&1
+    case $build_type in
+        cmake)
+            PATH=/opt/local/bin:${PATH} cmake -Wno-dev -Wno-deprecated -G Ninja -B build \
+                -D CMAKE_BUILD_TYPE="Release" \
+                -D CMAKE_CXX_STANDARD="${stdcver//[^0-9]/}" \
+                -D BOOST_INCLUDEDIR="/opt/boost_${BOOST_VERSION}" \
+                -D BUILD_SHARED_LIBS=OFF \
+                -D CMAKE_CXX_FLAGS="${CXXFLAGS}" \
+                -D CMAKE_C_FLAGS="${CFLAGS}" \
+                -D CMAKE_INSTALL_PREFIX="/tmp/dist/libtorrent/usr/local"
+            PATH=/opt/local/bin:${PATH} cmake --build build
+            PATH=/opt/local/bin:${PATH} cmake --install build
+            #Fix pkgconfig paths/quirks
+            sed -i 's|/tmp/dist/libtorrent||g' /tmp/dist/libtorrent/usr/local/lib/pkgconfig/libtorrent-rasterbar.pc
+            sed -i 's|-ltorrent-rasterbar|-l:libtorrent-rasterbar.a|g' /tmp/dist/libtorrent/usr/local/lib/pkgconfig/libtorrent-rasterbar.pc
+            ;;
+        autotools)
+            echo "using gcc : : : <cflags>\"-march=native -std=${stdcver}\" <cxxflags>\"-march=native -std=${stdcver}\" ;" > /root/user-config.jam
+            /opt/boost_${BOOST_VERSION}/b2 -j$(nproc) crypto=${cryptography_type} variant=release link=static install --prefix=/tmp/dist/libtorrent/usr/local install >> ${log} 2>&1
+            ;;
+        *)
+            echo_error "Build type must be cmake or autotools"
+            exit 1
+            ;;
+    esac
     tag=" static with ${stdcver} march=native"
     mkdir -p /root/dist
     fpm -f -C /tmp/dist/libtorrent -p /root/dist/libtorrent-rasterbar_VERSION.deb -s dir -t deb -n libtorrent-rasterbar --version ${VERSION} --description "Libtorrent rasterbar compiled by swizzin$tag" >> ${log} 2>&1
@@ -352,20 +367,30 @@ function build_qbittorrent() {
     tag=" static with ${stdcver} march=native"
     #Ensure boost variables are loaded (i.e. libtorrent skipped)
     booststrap
-    PATH=/opt/local/bin:${PATH} cmake -Wno-dev -Wno-deprecated -G Ninja -B build \
-        -D CMAKE_BUILD_TYPE="release" \
-        -D CMAKE_CXX_STANDARD="${stdcver//[^0-9]/}" \
-        -D QT6="${qbt_use_qt6:=OFF}" \
-        -D Boost_NO_BOOST_CMAKE=TRUE \
-        -D CMAKE_CXX_FLAGS="${CXXFLAGS}" \
-        -D CMAKE_C_FLAGS="${CFLAGS}" \
-        -D GUI=OFF \
-        -D CMAKE_INSTALL_PREFIX="/tmp/dist/qbittorrent/usr"
-    PATH=/opt/local/bin:${PATH} cmake --build build
-    PATH=/opt/local/bin:${PATH} cmake --install build
-    #./configure --prefix=/usr --disable-gui --with-boost=${BOOST_ROOT} --with-boost-libdir="/usr/local/lib" libtorrent_CFLAGS="-I/usr/local/include -I${BOOST_ROOT}" libtorrent_LIBS="-L/usr/local/lib -l:libtorrent-rasterbar.a -lssl -lcrypto" CXXFLAGS="-march=native -std=${stdcver}" ${QT_SWIZZIN} >> ${log} 2>&1
-    #make -j$(nproc) >> $log 2>&1
-    #make INSTALL_ROOT=/tmp/dist/qbittorrent install >> ${log} 2>&1
+    case $build_type in
+        cmake)
+            PATH=/opt/local/bin:${PATH} cmake -Wno-dev -Wno-deprecated -G Ninja -B build \
+                -D CMAKE_BUILD_TYPE="release" \
+                -D CMAKE_CXX_STANDARD="${stdcver//[^0-9]/}" \
+                -D QT6="${qbt_use_qt6:=OFF}" \
+                -D Boost_NO_BOOST_CMAKE=TRUE \
+                -D CMAKE_CXX_FLAGS="${CXXFLAGS}" \
+                -D CMAKE_C_FLAGS="${CFLAGS}" \
+                -D GUI=OFF \
+                -D CMAKE_INSTALL_PREFIX="/tmp/dist/qbittorrent/usr"
+            PATH=/opt/local/bin:${PATH} cmake --build build
+            PATH=/opt/local/bin:${PATH} cmake --install build
+            ;;
+        autotools)
+            ./configure --prefix=/usr --disable-gui --with-boost=${BOOST_ROOT} --with-boost-libdir="/usr/local/lib" libtorrent_CFLAGS="-I/usr/local/include -I${BOOST_ROOT}" libtorrent_LIBS="-L/usr/local/lib -l:libtorrent-rasterbar.a -lssl -lcrypto" CXXFLAGS="-march=native -std=${stdcver}" ${QT_SWIZZIN} >> ${log} 2>&1
+            make -j$(nproc) >> $log 2>&1
+            make INSTALL_ROOT=/tmp/dist/qbittorrent install >> ${log} 2>&1
+            ;;
+        *)
+            echo_error "Build type must be cmake or autotools"
+            exit 1
+            ;;
+    esac
     mkdir -p /root/dist
     fpm -f -C /tmp/dist/qbittorrent -p /root/dist/qbittorrent-nox_VERSION.deb -s dir -t deb -n qbittorrent-nox --version ${VERSION} --description "qbittorrent-nox compiled by swizzin$tag" >> ${log} 2>&1
     dpkg -i /root/dist/qbittorrent-nox_${VERSION}.deb >> ${log} 2>&1 || {

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -152,9 +152,9 @@ function install_qt() {
             QT_PREFIX=/opt/local
         else
             build_qt_swizzin
-            QT_SWIZZIN=Qt5_DIR="${QT_PREFIX}"
         fi
         QT_METHOD=swizzin
+        QT_SWIZZIN=QT_QMAKE="${QT_PREFIX}/bin"
     else
         LIST='qtbase5-dev qttools5-dev'
         apt_install --no-recommends $LIST
@@ -300,14 +300,12 @@ function build_libtorrent_qbittorrent() {
     if [[ ${libtorrent_branch} == "RC_1_1" ]]; then
         #Dirty hack to ensure finished library uses `libtorrent-rasterbar` for its name in the deprecated 1.1 branch
         sed -i 's/virtual-target.add-prefix-and-suffix $(name)/virtual-target.add-prefix-and-suffix $(name)-rasterbar/g' Jamfile
-        #Inconsistent boost variables
-        cmakeboost=Boost_INCLUDE_DIR
     fi
     VERSION=$(grep -oP "VERSION\ = \K\d\.\d\.\d+" Jamfile)
     PATH=/opt/local/bin:${PATH} cmake -Wno-dev -Wno-deprecated -G Ninja -B build \
         -D CMAKE_BUILD_TYPE="Release" \
         -D CMAKE_CXX_STANDARD="${stdcver//[^0-9]/}" \
-        -D ${cmakeboost:=BOOST_INCLUDEDIR}="/opt/boost_${BOOST_VERSION}" \
+        -D BOOST_INCLUDEDIR="/opt/boost_${BOOST_VERSION}" \
         -D BUILD_SHARED_LIBS=OFF \
         -D CMAKE_CXX_FLAGS="${CXXFLAGS}" \
         -D CMAKE_C_FLAGS="${CFLAGS}" \
@@ -354,7 +352,7 @@ function build_qbittorrent() {
     tag=" static with ${stdcver} march=native"
     #Ensure boost variables are loaded (i.e. libtorrent skipped)
     booststrap
-    ${QT_SWIZZIN} PATH=/opt/local/bin:${PATH} cmake -Wno-dev -Wno-deprecated -G Ninja -B build \
+    PATH=/opt/local/bin:${PATH} cmake -Wno-dev -Wno-deprecated -G Ninja -B build \
         -D CMAKE_BUILD_TYPE="release" \
         -D CMAKE_CXX_STANDARD="${stdcver//[^0-9]/}" \
         -D QT6="${qbt_use_qt6:=OFF}" \

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -187,14 +187,14 @@ function install_cmake_swizzin() {
     installed_cmake_swizzin=$(dpkg-query --showformat='${Version}' --show cmake-swizzin 2> /dev/null)
     if [[ -z ${installed_cmake_swizzin} ]] || dpkg --compare-versions ${installed_cmake_swizzin} lt ${latest_cmake_swizzin}; then
         echo_progress_start "Installing latest cmake-swizzin"
-        wget -O /tmp/qt6-swizzin.deb https://github.com/swizzin/qt6_crossbuild/releases/download/${latest_cmake_swizzin}/$(_os_distro)-$(_os_codename)-qt6-swizzin-$(_os_arch).deb >> ${log} 2>&1 || {
+        wget -O /tmp/cmake-swizzin.deb https://github.com/swizzin/cmake_crossbuild/releases/download/${latest_cmake_swizzin}/$(_os_distro)-$(_os_codename)-qt6-swizzin-$(_os_arch).deb >> ${log} 2>&1 || {
             echo_error "cmake-swizzin could not be downloaded from github. Setup will not proceed"
             exit 1
         }
-        dpkg -i /tmp/qt6-swizzin.deb >> ${log} 2>&1 || {
+        dpkg -i /tmp/cmake-swizzin.deb >> ${log} 2>&1 || {
             echo_error "Something went wrong when installing cmake-swizzin. Setup will not proceed"
         }
-        rm -rf /tmp/qt6-swizzin.deb
+        rm -rf /tmp/cmake-swizzin.deb
         echo_progress_done "cmake-swizzin installed"
     fi
 }

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -178,7 +178,7 @@ function install_qt() {
 }
 
 function install_qt_swizzin() {
-    latest_qt_swizzin=$(latest_github_version swizzin/qt6_crossbuild)
+    latest_qt_swizzin=$(github_latest_version swizzin/qt6_crossbuild)
     installed_qt_swizzin=$(dpkg-query --showformat='${Version}' --show qt6-swizzin 2> /dev/null)
     if [[ -z ${installed_qt_swizzin} ]] || dpkg --compare-versions ${installed_qt_swizzin} lt ${latest_qt_swizzin}; then
         echo_progress_start "Installing latest qt6-swizzin"
@@ -195,7 +195,7 @@ function install_qt_swizzin() {
 }
 
 function install_cmake_swizzin() {
-    latest_cmake_swizzin=$(latest_github_version swizzin/cmake_crossbuild)
+    latest_cmake_swizzin=$(github_latest_version swizzin/cmake_crossbuild)
     installed_cmake_swizzin=$(dpkg-query --showformat='${Version}' --show cmake-swizzin 2> /dev/null)
     if [[ -z ${installed_cmake_swizzin} ]] || dpkg --compare-versions ${installed_cmake_swizzin} lt ${latest_cmake_swizzin//_/+}; then
         echo_progress_start "Installing latest cmake-swizzin"

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -79,7 +79,7 @@ function qbittorrent_version_info() {
             stdcver="c++14"
             qt_minimum_version=5.5
             cryptography_type=built-in
-            buid_type=autotools
+            build_type=autotools
             ;;
         4.2.*)
             libtorrent_branch=RC_1_2

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -178,7 +178,7 @@ function install_qt() {
 }
 
 function install_qt_swizzin() {
-    latest_qt_swizzin=$(curl -fsSLI -o /dev/null -w %{url_effective} https://github.com/swizzin/qt6_crossbuild/releases/latest | grep -o '[^/]*$')
+    latest_qt_swizzin=$(latest_github_version swizzin/qt6_crossbuild)
     installed_qt_swizzin=$(dpkg-query --showformat='${Version}' --show qt6-swizzin 2> /dev/null)
     if [[ -z ${installed_qt_swizzin} ]] || dpkg --compare-versions ${installed_qt_swizzin} lt ${latest_qt_swizzin}; then
         echo_progress_start "Installing latest qt6-swizzin"
@@ -195,7 +195,7 @@ function install_qt_swizzin() {
 }
 
 function install_cmake_swizzin() {
-    latest_cmake_swizzin=$(curl -fsSLI -o /dev/null -w %{url_effective} https://github.com/swizzin/cmake_crossbuild/releases/latest | grep -o '[^/]*$')
+    latest_cmake_swizzin=$(latest_github_version swizzin/cmake_crossbuild)
     installed_cmake_swizzin=$(dpkg-query --showformat='${Version}' --show cmake-swizzin 2> /dev/null)
     if [[ -z ${installed_cmake_swizzin} ]] || dpkg --compare-versions ${installed_cmake_swizzin} lt ${latest_cmake_swizzin//_/+}; then
         echo_progress_start "Installing latest cmake-swizzin"
@@ -397,6 +397,12 @@ function build_qbittorrent() {
             exit 1
             ;;
     esac
+    #install qbt-cli
+    qbt_cli_version=$(github_latest_version ludviglundgren/qbittorrent-cli)
+    cd /root/dist/qbittorrent/usr/bin
+    wget -O qbtcli.tar.gz https://github.com/ludviglundgren/qbittorrent-cli/releases/download/${qbt_cli_version}/qbittorrent-cli_${qbt_cli_version//v/}_linux_$(_os_arch).tar.gz >> ${log} 2>&1
+    tar xvf qbtcli.tar.gz >> ${log} 2>&1
+    rm -f qbtcli.tar.gz README.md >> ${log} 2>&1
     mkdir -p /root/dist
     fpm -f -C /tmp/dist/qbittorrent -p /root/dist/qbittorrent-nox_VERSION.deb -s dir -t deb -n qbittorrent-nox --version ${VERSION} --description "qbittorrent-nox compiled by swizzin$tag" >> ${log} 2>&1
     dpkg -i /root/dist/qbittorrent-nox_${VERSION}.deb >> ${log} 2>&1 || {

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -399,7 +399,7 @@ function build_qbittorrent() {
     esac
     #install qbt-cli
     qbt_cli_version=$(github_latest_version ludviglundgren/qbittorrent-cli)
-    cd /root/dist/qbittorrent/usr/bin
+    cd /tmp/dist/qbittorrent/usr/bin
     wget -O qbtcli.tar.gz https://github.com/ludviglundgren/qbittorrent-cli/releases/download/${qbt_cli_version}/qbittorrent-cli_${qbt_cli_version//v/}_linux_$(_os_arch).tar.gz >> ${log} 2>&1
     tar xvf qbtcli.tar.gz >> ${log} 2>&1
     rm -f qbtcli.tar.gz README.md >> ${log} 2>&1

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -302,7 +302,7 @@ function build_libtorrent_qbittorrent() {
         sed -i 's/virtual-target.add-prefix-and-suffix $(name)/virtual-target.add-prefix-and-suffix $(name)-rasterbar/g' Jamfile
     fi
     VERSION=$(grep -oP "VERSION\ = \K\d\.\d\.\d+" Jamfile)
-    PATH=${PATH}:/opt/local/bin cmake -Wno-dev -Wno-deprecated -G Ninja -B build \
+    PATH=/opt/local/bin:${PATH} cmake -Wno-dev -Wno-deprecated -G Ninja -B build \
         -D CMAKE_BUILD_TYPE="Release" \
         -D CMAKE_CXX_STANDARD="${stdcver//[^0-9]/}" \
         -D BOOST_INCLUDEDIR="/opt/boost_${BOOST_VERSION}" \
@@ -310,8 +310,8 @@ function build_libtorrent_qbittorrent() {
         -D CMAKE_CXX_FLAGS="${CXXFLAGS}" \
         -D CMAKE_C_FLAGS="${CFLAGS}" \
         -D CMAKE_INSTALL_PREFIX="/tmp/dist/libtorrent/usr/local"
-    PATH=${PATH}:/opt/local/bin cmake --build build
-    PATH=${PATH}:/opt/local/bin cmake --install build
+    PATH=/opt/local/bin:${PATH} cmake --build build
+    PATH=/opt/local/bin:${PATH} cmake --install build
     #Fix pkgconfig paths/quirks
     sed -i 's|/tmp/dist/libtorrent||g' /tmp/dist/libtorrent/usr/local/lib/pkgconfig/libtorrent-rasterbar.pc
     sed -i 's|-ltorrent-rasterbar|-l:libtorrent-rasterbar.a|g' /tmp/dist/libtorrent/usr/local/lib/pkgconfig/libtorrent-rasterbar.pc
@@ -352,7 +352,7 @@ function build_qbittorrent() {
     tag=" static with ${stdcver} march=native"
     #Ensure boost variables are loaded (i.e. libtorrent skipped)
     booststrap
-    PATH=${PATH}:/opt/local/bin cmake -Wno-dev -Wno-deprecated -G Ninja -B build \
+    PATH=/opt/local/bin:${PATH} cmake -Wno-dev -Wno-deprecated -G Ninja -B build \
         -D CMAKE_BUILD_TYPE="release" \
         -D CMAKE_CXX_STANDARD="${stdcver//[^0-9]/}" \
         -D QT6="${qbt_use_qt6:=OFF}" \
@@ -361,8 +361,8 @@ function build_qbittorrent() {
         -D CMAKE_C_FLAGS="${CFLAGS}" \
         -D GUI=OFF \
         -D CMAKE_INSTALL_PREFIX="/tmp/dist/qbittorrent/usr"
-    PATH=${PATH}:/opt/local/bin cmake --build build
-    PATH=${PATH}:/opt/local/bin cmake --install build
+    PATH=/opt/local/bin:${PATH} cmake --build build
+    PATH=/opt/local/bin:${PATH} cmake --install build
     #./configure --prefix=/usr --disable-gui --with-boost=${BOOST_ROOT} --with-boost-libdir="/usr/local/lib" libtorrent_CFLAGS="-I/usr/local/include -I${BOOST_ROOT}" libtorrent_LIBS="-L/usr/local/lib -l:libtorrent-rasterbar.a -lssl -lcrypto" CXXFLAGS="-march=native -std=${stdcver}" ${QT_SWIZZIN} >> ${log} 2>&1
     #make -j$(nproc) >> $log 2>&1
     #make INSTALL_ROOT=/tmp/dist/qbittorrent install >> ${log} 2>&1

--- a/sources/functions/utils
+++ b/sources/functions/utils
@@ -161,3 +161,10 @@ function populate_var() {
     fi
     swizdb get "$1" # Return swizdb key's value
 }
+
+function github_latest_version() {
+    # Argument expects the author/repo format
+    # e.g. swizzin/swizzin
+    repo=$1
+    curl -fsSLI -o /dev/null -w %{url_effective} https://github.com/${repo}/releases/latest | grep -o '[^/]*$'
+}


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description
Add support for qBittorrent 4.4.*

Prep for future with cmake build pipeline and libtorrent 2.0 support

Don't touch old builds because they work perfectly fine and no sense in creating a bunch of work for a problem that doesn't exist.

## Fixes issues: 
- qBittorrent 4.4.0 cannot be installed

## Proposed Changes:
- Support cmake build pipeline and qt6.0 with userdocs cmake/qt swizzin crossbuilds
- Build libtorrent 2.0/qbittorrent4.4.* with cmake
  - Fix a few packaging thingers


## Change Categories
<!-- DELETE WHICHEVER BULLET DOES NOT APPLY -->
- Bug fix <!-- non-breaking change which fixes an issue -->
- New feature <!-- non-breaking change which adds functionality -->

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [ ] Docs have been made OR are not necessary
    - PR link: 
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Testing was done


## Test scenarios
Only qBittorrent 4.4 should be using the new build method, everything else should be using the older boost/autotools toolchain. Thus you should see no regressions when building 4.1->4.3

4.4 should be supported everywhere 4.3 was (i.e. everywhere but stretch)

