### PR TITLE
fix(autodl/rutorrent): update ruTorrent and pull autodl upstream into swizzin org w/ fixes

### DIFF
--- a/scripts/install/autodl.sh
+++ b/scripts/install/autodl.sh
@@ -84,6 +84,7 @@ users=($(cut -d: -f1 < /etc/htpasswd))
 if [[ -n $1 ]]; then
     users=($1)
     _autoconf
+    systemctl enable --now irssi@${users[0]}
     exit 0
 fi
 

--- a/scripts/install/nginx.sh
+++ b/scripts/install/nginx.sh
@@ -187,6 +187,7 @@ FIC
 sed -i 's/href="\/[^\/]*/href="\/fancyindex/g' /srv/fancyindex/header.html
 sed -i 's/src="\/[^\/]*/src="\/fancyindex/g' /srv/fancyindex/footer.html
 
+#Some ruTorrent plugins need to bypass htpasswd, so we stuff the php for this here
 cat > /etc/nginx/apps/fancyindex.conf << FIAC
 location /fancyindex {
     location ~ \.php {
@@ -197,7 +198,7 @@ location /fancyindex {
 
         # Make sure the script exists.
         try_files \$fastcgi_script_name =404;
-        fastcgi_pass unix:/run/${sock}.sock;
+        fastcgi_pass unix:/run/php/${sock}.sock;
         fastcgi_param SCRIPT_FILENAME \$request_filename;
         include fastcgi_params;
         fastcgi_index index.php;

--- a/scripts/install/nginx.sh
+++ b/scripts/install/nginx.sh
@@ -190,7 +190,7 @@ sed -i 's/src="\/[^\/]*/src="\/fancyindex/g' /srv/fancyindex/footer.html
 #Some ruTorrent plugins need to bypass htpasswd, so we stuff the php for this here
 cat > /etc/nginx/apps/fancyindex.conf << FIAC
 location /fancyindex {
-    location ~ \.php {
+    location ~ \.php($|/) {
         fastcgi_split_path_info ^(.+?\.php)(/.+)$;
         # Work around annoying nginx "feature" (https://trac.nginx.org/nginx/ticket/321)
         # Don't think this is necessary, but saving for posterity

--- a/scripts/install/nginx.sh
+++ b/scripts/install/nginx.sh
@@ -193,8 +193,9 @@ location /fancyindex {
     location ~ \.php {
         fastcgi_split_path_info ^(.+?\.php)(/.+)$;
         # Work around annoying nginx "feature" (https://trac.nginx.org/nginx/ticket/321)
-        set \$path_info \$fastcgi_path_info;
-        fastcgi_param PATH_INFO \$path_info;
+        # Don't think this is necessary, but saving for posterity
+        #set \$path_info \$fastcgi_path_info;
+        #fastcgi_param PATH_INFO \$path_info;
 
         # Make sure the script exists.
         try_files \$fastcgi_script_name =404;

--- a/scripts/install/nginx.sh
+++ b/scripts/install/nginx.sh
@@ -112,10 +112,6 @@ server {
   location ~ /\.ht {
     deny all;
   }
-
-  location /fancyindex {
-
-  }
 }
 NGC
 
@@ -190,6 +186,24 @@ fancyindex_name_length 255; # Maximum file name length in bytes, change as you l
 FIC
 sed -i 's/href="\/[^\/]*/href="\/fancyindex/g' /srv/fancyindex/header.html
 sed -i 's/src="\/[^\/]*/src="\/fancyindex/g' /srv/fancyindex/footer.html
+
+cat > /etc/nginx/apps/fancyindex.conf << FIAC
+location /fancyindex {
+    location ~ \.php {
+        fastcgi_split_path_info ^(.+?\.php)(/.+)$;
+        # Work around annoying nginx "feature" (https://trac.nginx.org/nginx/ticket/321)
+        set \$path_info \$fastcgi_path_info;
+        fastcgi_param PATH_INFO \$path_info;
+
+        # Make sure the script exists.
+        try_files \$fastcgi_script_name =404;
+        fastcgi_pass unix:/run/${sock}.sock;
+        fastcgi_param SCRIPT_FILENAME \$request_filename;
+        include fastcgi_params;
+        fastcgi_index index.php;
+    }
+}
+FIAC
 echo_progress_done "Fancyindex installed"
 
 locks=($(find /usr/local/bin/swizzin/nginx -type f -printf "%f\n" | cut -d "." -f 1 | sort -d -r))

--- a/scripts/nginx/autodl.sh
+++ b/scripts/nginx/autodl.sh
@@ -12,7 +12,7 @@ users=($(cut -d: -f1 < /etc/htpasswd))
 if [[ -f /install/.rutorrent.lock ]]; then
     cd /srv/rutorrent/plugins/
     if [[ ! -d /srv/rutorrent/plugins/autodl-irssi ]]; then
-        git clone https://github.com/swizzin/autodl-rutorrent.git autodl-irssi > /dev/null 2>&1 || { echo_error "git of autodl plugin to main plugins seems to have failed"; }
+        git clone https://github.com/swizzin/autodl-rutorrent.git autodl-irssi > ${log} 2>&1 || { echo_error "git of autodl plugin to main plugins seems to have failed"; }
         chown -R www-data:www-data autodl-irssi/
     fi
     for u in "${users[@]}"; do

--- a/scripts/nginx/autodl.sh
+++ b/scripts/nginx/autodl.sh
@@ -12,7 +12,7 @@ users=($(cut -d: -f1 < /etc/htpasswd))
 if [[ -f /install/.rutorrent.lock ]]; then
     cd /srv/rutorrent/plugins/
     if [[ ! -d /srv/rutorrent/plugins/autodl-irssi ]]; then
-        git clone https://github.com/autodl-community/autodl-rutorrent.git autodl-irssi > /dev/null 2>&1 || { echo_error "git of autodl plugin to main plugins seems to have failed"; }
+        git clone https://github.com/swizzin/autodl-rutorrent.git autodl-irssi > /dev/null 2>&1 || { echo_error "git of autodl plugin to main plugins seems to have failed"; }
         chown -R www-data:www-data autodl-irssi/
     fi
     for u in "${users[@]}"; do

--- a/scripts/nginx/rutorrent.sh
+++ b/scripts/nginx/rutorrent.sh
@@ -47,7 +47,10 @@ function rutorrent_install() {
         perl -pi -e "s/\$defaultTheme \= \"\"\;/\$defaultTheme \= \"club-QuickBox\"\;/g" /srv/rutorrent/plugins/theme/conf.php
     fi
 
-    # TODO: Add new FileManager when it's more stable with new ruTorrent
+    if [[ ! -d /srv/rutorrent/plugins/filemanager ]]; then
+        git clone https://github.com/nelu/rutorrent-filemanager filemanager >> ${log} 2>&1
+        chmod -R +x /srv/rutorrent/plugins/filemanager/scripts
+    fi
 
     if [[ ! -d /srv/rutorrent/plugins/ratiocolor ]]; then
         cd /srv/rutorrent/plugins

--- a/scripts/nginx/rutorrent.sh
+++ b/scripts/nginx/rutorrent.sh
@@ -47,33 +47,7 @@ function rutorrent_install() {
         perl -pi -e "s/\$defaultTheme \= \"\"\;/\$defaultTheme \= \"club-QuickBox\"\;/g" /srv/rutorrent/plugins/theme/conf.php
     fi
 
-    if [[ ! -d /srv/rutorrent/plugins/filemanager ]]; then
-        cd /srv/rutorrent/plugins/
-        svn co https://github.com/nelu/rutorrent-thirdparty-plugins/trunk/filemanager >> "$log" 2>&1
-        chown -R www-data: /srv/rutorrent/plugins/filemanager
-        chmod -R +x /srv/rutorrent/plugins/filemanager/scripts
-
-        cat > /srv/rutorrent/plugins/filemanager/conf.php << FMCONF
-<?php
-
-\$fm['tempdir'] = '/tmp';
-\$fm['mkdperm'] = 755;
-
-// set with fullpath to binary or leave empty
-\$pathToExternals['rar'] = '$(which rar)';
-\$pathToExternals['zip'] = '$(which zip)';
-\$pathToExternals['unzip'] = '$(which unzip)';
-\$pathToExternals['tar'] = '$(which tar)';
-
-// archive mangling, see archiver man page before editing
-\$fm['archive']['types'] = array('rar', 'zip', 'tar', 'gzip', 'bzip2');
-\$fm['archive']['compress'][0] = range(0, 5);
-\$fm['archive']['compress'][1] = array('-0', '-1', '-9');
-\$fm['archive']['compress'][2] = \$fm['archive']['compress'][3] = \$fm['archive']['compress'][4] = array(0);
-
-?>
-FMCONF
-    fi
+    # TODO: Add new FileManager when it's more stable with new ruTorrent
 
     if [[ ! -d /srv/rutorrent/plugins/ratiocolor ]]; then
         cd /srv/rutorrent/plugins

--- a/scripts/nginx/rutorrent.sh
+++ b/scripts/nginx/rutorrent.sh
@@ -81,13 +81,6 @@ FMCONF
         sed -i "s/changeWhat = \"cell-background\";/changeWhat = \"font\";/g" /srv/rutorrent/plugins/ratiocolor/init.js
     fi
 
-    if [[ ! -d /srv/rutorrent/plugins/logoff ]]; then
-        cd /srv/rutorrent/plugins
-        wget -q https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/rutorrent-logoff/logoff-1.3.tar.gz
-        tar xf logoff-1.3.tar.gz
-        rm -rf logoff-1.3.tar.gz
-        chown -R www-data: logoff
-    fi
     echo_progress_done "Plugins downloaded"
 
     if [[ -f /install/.quota.lock ]] && [[ -z $(grep quota /srv/rutorrent/plugins/diskspace/action.php) ]]; then

--- a/scripts/nginx/rutorrent.sh
+++ b/scripts/nginx/rutorrent.sh
@@ -81,9 +81,9 @@ function rutorrent_install() {
     $total = shell_exec("sudo /usr/bin/quota -wu ".$quotaUser."| tail -n 1 | sed -e 's|^[ \t]*||' | awk '{print $3*1024}'");
     $used = shell_exec("sudo /usr/bin/quota -wu ".$quotaUser."| tail -n 1 | sed -e 's|^[ \t]*||' | awk '{print $2*1024}'");
     $free = sprintf($total - $used);
-    cachedEcho('{ "total": '.$total.', "free": '.$free.' }',"application/json");
+    CachedEcho::send('{ "total": '.$total.', "free": '.$free.' }',"application/json");
   } else {
-      cachedEcho('{ "total": '.disk_total_space($topDirectory).', "free": '.disk_free_space($topDirectory).' }',"application/json");
+      CachedEcho::send('{ "total": '.disk_total_space($topDirectory).', "free": '.disk_free_space($topDirectory).' }',"application/json");
   }
 ?>
 DSKSP

--- a/scripts/nginx/rutorrent.sh
+++ b/scripts/nginx/rutorrent.sh
@@ -20,7 +20,9 @@ function rutorrent_install() {
     mkdir -p /srv
     if [[ ! -d /srv/rutorrent ]]; then
         echo_progress_start "Cloning rutorrent"
-        git clone --recurse-submodules https://github.com/Novik/ruTorrent.git /srv/rutorrent >> "$log" 2>&1 || {
+        # Get current stable ruTorrent version
+        release=$(git ls-remote -t --refs https://github.com/novik/ruTorrent.git | awk '{sub("refs/tags/", ""); print $2 }' | sort -Vr | head -n1)
+        git clone --recurse-submodules --depth 1 -b ${release} https://github.com/Novik/ruTorrent.git /srv/rutorrent >> "$log" 2>&1 || {
             echo_error "Failed to clone rutorrent"
             exit 1
         }

--- a/scripts/nginx/rutorrent.sh
+++ b/scripts/nginx/rutorrent.sh
@@ -24,7 +24,6 @@ function rutorrent_install() {
             echo_error "Failed to clone rutorrent"
             exit 1
         }
-        git -C /srv/rutorrent/ checkout 6bffcb1d3fd0a25dcba9100a6bbbc6cb8de7af29 >> "$log" 2>&1
         chown -R www-data:www-data /srv/rutorrent
         rm -rf /srv/rutorrent/plugins/throttle
         rm -rf /srv/rutorrent/plugins/_cloudflare

--- a/scripts/nginx/rutorrent.sh
+++ b/scripts/nginx/rutorrent.sh
@@ -153,7 +153,7 @@ DSKSP
 "localhost",
 );
 
-\$profilePath = '../share'; // Path to user profiles
+\$profilePath = '../../share'; // Path to user profiles
 \$profileMask = 0777; // Mask for files and directory creation in user profiles.
 // Both Webserver and rtorrent users must have read-write access to it.
 // For example, if Webserver and rtorrent users are in the same group then the value may be 0770.

--- a/scripts/nginx/rutorrent.sh
+++ b/scripts/nginx/rutorrent.sh
@@ -69,7 +69,7 @@ function rutorrent_install() {
 ##  [Quick Box - action.php modified for quota systems use]
 #################################################################################
 # QUICKLAB REPOS
-# QuickLab _ packages:   https://github.com/QuickBox/quickbox_rutorrent-plugins
+# QuickLab _ packages:   https://github.com/QuickBox/QB/tree/master/rtplugins/diskspace
 # LOCAL REPOS
 # Local _ packages   :   ~/QuickBox/rtplugins
 # Author             :   QuickBox.IO

--- a/scripts/nginx/rutorrent.sh
+++ b/scripts/nginx/rutorrent.sh
@@ -140,14 +140,11 @@ DSKSP
 //\$XMLRPCMountPoint = "/RPC2"; // DO NOT DELETE THIS LINE!!! DO NOT COMMENT THIS LINE!!!
 
 \$pathToExternals = array(
-"php" => '/usr/bin/php', // Something like /usr/bin/php. If empty, will be found in PATH.
-"curl" => '/usr/bin/curl', // Something like /usr/bin/curl. If empty, will be found in PATH.
-"gzip" => '/bin/gzip', // Something like /usr/bin/gzip. If empty, will be found in PATH.
-"id" => '/usr/bin/id', // Something like /usr/bin/id. If empty, will be found in PATH.
-"stat" => '/usr/bin/stat', // Something like /usr/bin/stat. If empty, will be found in PATH.
-"bzip2" => '/bin/bzip2',
-"pgrep" => '/usr/bin/pgrep',
-"python" => '/usr/bin/python2',
+    "php" 	=> '',			// Something like /usr/bin/php. If empty, will be found in PATH.
+    "curl"	=> '',			// Something like /usr/bin/curl. If empty, will be found in PATH.
+    "gzip"	=> '',			// Something like /usr/bin/gzip. If empty, will be found in PATH.
+    "id"	=> '',			// Something like /usr/bin/id. If empty, will be found in PATH.
+    "stat"	=> '',			// Something like /usr/bin/stat. If empty, will be found in PATH.
 );
 
 \$localhosts = array( // list of local interfaces

--- a/scripts/nginx/rutorrent.sh
+++ b/scripts/nginx/rutorrent.sh
@@ -58,11 +58,6 @@ function rutorrent_install() {
         sed -i "s/changeWhat = \"cell-background\";/changeWhat = \"font\";/g" /srv/rutorrent/plugins/ratiocolor/init.js || { echo_error "git of autodl plugin to main plugins seems to have failed"; }
     fi
 
-    if [[ -f /install/.autodl.lock && ! -d /srv/rutorrent/plugins/autodl-irssi ]]; then
-        git clone https://github.com/swizzin/autodl-rutorrent.git /srv/rutorrent/plugins/autodl-irssi > ${log} 2>&1 || { echo_error "git of autodl plugin to main plugins seems to have failed"; }
-        chown -R www-data:www-data autodl-irssi/
-    fi
-
     echo_progress_done "Plugins downloaded"
 
     if [[ -f /install/.quota.lock ]] && [[ -z $(grep quota /srv/rutorrent/plugins/diskspace/action.php) ]]; then

--- a/scripts/rtx
+++ b/scripts/rtx
@@ -109,12 +109,12 @@ function _itplugs() {
             filemanager-share)
                 git clone https://github.com/nelu/rutorrent-filemanager-share.git filemanager-share > ${log} 2>&1
                 ln -s /srv/rutorrent/plugins/filemanager-share/share.php /srv/fancyindex/share.php > /dev/null 2>&1
-                sed -i 's/$downloadpath .*/$downloadpath = $_SERVER['"'HTTP_HOST'"'] . '"'\/fancyindex\/share.php'"';/g' /srv/rutorrent/plugins/filemanager-share/conf.php
+                sed -i 's/$downloadpath .*/$downloadpath = '"'https:\/\/'"'.$_SERVER['"'HTTP_HOST'"'] . '"'\/fancyindex\/share.php'"';/g' /srv/rutorrent/plugins/filemanager-share/conf.php
                 ;;
             filemanager-media)
                 git clone https://github.com/nelu/rutorrent-filemanager-media.git filemanager-media > ${log} 2>&1
                 ln -s /srv/rutorrent/plugins/filemanager-media/stream.php /srv/fancyindex/stream.php > /dev/null 2>&1
-                sed -i 's/$streampath .*/$streampath = $_SERVER['"'HTTP_HOST'"'] . '"'\/fancyindex\/stream.php'"';/g' /srv/rutorrent/plugins/filemanager-media/conf.php
+                sed -i 's/$streampath .*/$streampath = '"'https:\/\/'"'.$_SERVER['"'HTTP_HOST'"'] . '"'\/fancyindex\/stream.php'"';/g' /srv/rutorrent/plugins/filemanager-media/conf.php
                 ;;
             #fileupload)
             #svn co https://github.com/nelu/rutorrent-thirdparty-plugins/trunk/fileupload >/dev/null 2>&1
@@ -134,6 +134,9 @@ function _itplugs() {
             ratiocolor)
                 svn co https://github.com/Gyran/rutorrent-ratiocolor.git/trunk ratiocolor > /dev/null 2>&1
                 sed -i "s/changeWhat = \"cell-background\";/changeWhat = \"font\";/g" /srv/rutorrent/plugins/ratiocolor/init.js
+                ;;
+            *)
+                echo_error "$ is invalid"
                 ;;
         esac
     done
@@ -212,6 +215,9 @@ function _itthemes() {
                 ;;
             MaterialDesign)
                 git clone https://github.com/phlooo/ruTorrent-MaterialDesign.git ${result} > /dev/null 2>&1
+                ;;
+            *)
+                echo_error "$i is invalid"
                 ;;
         esac
     done

--- a/scripts/rtx
+++ b/scripts/rtx
@@ -143,11 +143,11 @@ FMCONF
             #fileupload)
             #svn co https://github.com/nelu/rutorrent-thirdparty-plugins/trunk/fileupload >/dev/null 2>&1
             #;;
-            logoff)
-                wget -q https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/rutorrent-logoff/logoff-1.3.tar.gz
-                tar xf logoff-1.3.tar.gz > /dev/null 2>&1
-                rm -rf logoff-1.3.tar.gz
-                ;;
+            #logoff)
+            #    wget -q https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/rutorrent-logoff/logoff-1.3.tar.gz
+            #    tar xf logoff-1.3.tar.gz > /dev/null 2>&1
+            #    rm -rf logoff-1.3.tar.gz
+            #    ;;
             mobile)
                 git clone https://github.com/xombiemp/rutorrentMobile.git mobile > /dev/null 2>&1
                 rm -r /srv/rutorrent/plugins/ipad

--- a/scripts/rtx
+++ b/scripts/rtx
@@ -65,8 +65,12 @@ function _themes() {
 }
 
 function _itplugs() {
+    tag=$(git -C /srv/rutorrent describe --tags | grep -oP 'v\d\.\d+(\-beta\.?\d?+)?([^-]?)')
     installa=()
     plugs=(_getdir _noty _noty2 _task autotools check_port chunks cookies cpuload create data datadir diskspace edit erasedata extratio extsearch feeds filedrop filemanager filemanager-media filemanager-share geoip history httprpc ipad loginmgr lookat mediainfo mobile pausewebui ratio ratiocolor retrackers rpc rss rssurlrewrite rutracker_check scheduler screenshots seedingtime show_peers_like_wtorrent source spectrogram theme throttle tracklabels trafic unpack uploadeta xmpp)
+    if [[ $tag =~ ^v3 ]]; then
+        plugs=("${plugs[@]/filemanager-media/}")
+    fi
     for i in "${plugs[@]}"; do
         plug=${i}
         if [[ ! -d /srv/rutorrent/plugins/${plug} ]]; then
@@ -93,7 +97,7 @@ function _itplugs() {
                         continue
                     fi
                 fi
-                svn co https://github.com/Novik/ruTorrent.git/trunk/plugins/${result} ${result}
+                svn co https://github.com/Novik/ruTorrent.git/tags/${tag}/plugins/${result} ${result}
                 if [[ $result = "create" ]]; then
                     sed -i 's/useExternal = false;/useExternal = "mktorrent";/' /srv/rutorrent/plugins/create/conf.php
                     sed -i 's/pathToCreatetorrent = '\'\''/pathToCreatetorrent = '\''\/usr\/bin\/mktorrent'\''/' /srv/rutorrent/plugins/create/conf.php
@@ -103,11 +107,43 @@ function _itplugs() {
                 fi
                 ;;
             filemanager)
-                git clone https://github.com/nelu/rutorrent-filemanager filemanager >> /dev/null 2>&1
-                chmod -R +x /srv/rutorrent/plugins/filemanager/scripts
+                case $tag in
+                    3.*)
+                        svn co https://github.com/nelu/rutorrent-thirdparty-plugins/trunk/filemanager > /dev/null 2>&1
+                        chmod -R +x /srv/rutorrent/plugins/filemanager/scripts
+                        cat > /srv/rutorrent/plugins/filemanager/conf.php << FMCONF
+<?php
+\$fm['tempdir'] = '/tmp';
+\$fm['mkdperm'] = 755;
+// set with fullpath to binary or leave empty
+\$pathToExternals['rar'] = '$(which rar)';
+\$pathToExternals['zip'] = '$(which zip)';
+\$pathToExternals['unzip'] = '$(which unzip)';
+\$pathToExternals['tar'] = '$(which tar)';
+// archive mangling, see archiver man page before editing
+\$fm['archive']['types'] = array('rar', 'zip', 'tar', 'gzip', 'bzip2');
+\$fm['archive']['compress'][0] = range(0, 5);
+\$fm['archive']['compress'][1] = array('-0', '-1', '-9');
+\$fm['archive']['compress'][2] = \$fm['archive']['compress'][3] = \$fm['archive']['compress'][4] = array(0);
+?>
+FMCONF
+                        ;;
+                    *)
+                        git clone https://github.com/nelu/rutorrent-filemanager filemanager >> /dev/null 2>&1
+                        chmod -R +x /srv/rutorrent/plugins/filemanager/scripts
+                        ;;
+                esac
                 ;;
             filemanager-share)
-                git clone https://github.com/nelu/rutorrent-filemanager-share.git filemanager-share > /dev/null 2>&1
+                case $tag in
+                    3.*)
+                        svn co https://github.com/nelu/rutorrent-thirdparty-plugins/trunk/fileshare > /dev/null 2>&1
+                        ;;
+                    *)
+                        git clone https://github.com/nelu/rutorrent-filemanager-share.git filemanager-share > /dev/null 2>&1
+
+                        ;;
+                esac
                 ln -s /srv/rutorrent/plugins/filemanager-share/share.php /srv/fancyindex/share.php > /dev/null 2>&1
                 sed -i 's/$downloadpath .*/$downloadpath = '"'https:\/\/'"'.$_SERVER['"'HTTP_HOST'"'] . '"'\/fancyindex\/share.php'"';/g' /srv/rutorrent/plugins/filemanager-share/conf.php
                 ;;

--- a/scripts/rtx
+++ b/scripts/rtx
@@ -66,7 +66,7 @@ function _themes() {
 
 function _itplugs() {
     installa=()
-    plugs=(_getdir _noty _noty2 _task autotools check_port chunks cookies cpuload create data datadir diskspace edit erasedata extratio extsearch feeds filedrop filemanager fileshare geoip history httprpc ipad loginmgr logoff lookat mediainfo mobile pausewebui ratio ratiocolor retrackers rpc rss rssurlrewrite rutracker_check scheduler screenshots seedingtime show_peers_like_wtorrent source spectrogram theme throttle tracklabels trafic unpack uploadeta xmpp)
+    plugs=(_getdir _noty _noty2 _task autotools check_port chunks cookies cpuload create data datadir diskspace edit erasedata extratio extsearch feeds filedrop filemanager filemanager-share geoip history httprpc ipad loginmgr lookat mediainfo mobile pausewebui ratio ratiocolor retrackers rpc rss rssurlrewrite rutracker_check scheduler screenshots seedingtime show_peers_like_wtorrent source spectrogram theme throttle tracklabels trafic unpack uploadeta xmpp)
     for i in "${plugs[@]}"; do
         plug=${i}
         if [[ ! -d /srv/rutorrent/plugins/${plug} ]]; then
@@ -103,42 +103,18 @@ function _itplugs() {
                 fi
                 ;;
             filemanager)
-                svn co https://github.com/nelu/rutorrent-thirdparty-plugins/trunk/filemanager > /dev/null 2>&1
+                git clone https://github.com/nelu/rutorrent-filemanager filemanager >> ${log} 2>&1
                 chmod -R +x /srv/rutorrent/plugins/filemanager/scripts
-                cat > /srv/rutorrent/plugins/filemanager/conf.php << FMCONF
-<?php
-
-\$fm['tempdir'] = '/tmp';
-\$fm['mkdperm'] = 755;
-
-// set with fullpath to binary or leave empty
-\$pathToExternals['rar'] = '$(which rar)';
-\$pathToExternals['zip'] = '$(which zip)';
-\$pathToExternals['unzip'] = '$(which unzip)';
-\$pathToExternals['tar'] = '$(which tar)';
-
-
-// archive mangling, see archiver man page before editing
-
-\$fm['archive']['types'] = array('rar', 'zip', 'tar', 'gzip', 'bzip2');
-
-
-
-
-\$fm['archive']['compress'][0] = range(0, 5);
-\$fm['archive']['compress'][1] = array('-0', '-1', '-9');
-\$fm['archive']['compress'][2] = \$fm['archive']['compress'][3] = \$fm['archive']['compress'][4] = array(0);
-
-
-
-
-?>
-FMCONF
                 ;;
-            fileshare)
-                svn co https://github.com/nelu/rutorrent-thirdparty-plugins/trunk/fileshare > /dev/null 2>&1
-                ln -s /srv/rutorrent/plugins/fileshare/share.php /srv/fancyindex/share.php > /dev/null 2>&1
-                sed -i 's/$downloadpath .*/$downloadpath = $_SERVER['"'HTTP_HOST'"'] . '"'\/fancyindex\/share.php'"';/g' /srv/rutorrent/plugins/fileshare/conf.php
+            filemanager-share)
+                git clone https://github.com/nelu/rutorrent-filemanager-share.git filemanager-share > ${log} 2>&1
+                ln -s /srv/rutorrent/plugins/filemanager-share/share.php /srv/fancyindex/share.php > /dev/null 2>&1
+                sed -i 's/$downloadpath .*/$downloadpath = $_SERVER['"'HTTP_HOST'"'] . '"'\/fancyindex\/share.php'"';/g' /srv/rutorrent/plugins/filemanager-share/conf.php
+                ;;
+            filemanager-media)
+                git clone https://github.com/nelu/rutorrent-filemanager-media.git filemanager-media > ${log} 2>&1
+                ln -s /srv/rutorrent/plugins/filemanager-media/stream.php /srv/fancyindex/stream.php > /dev/null 2>&1
+                sed -i 's/$streampath .*/$streampath = $_SERVER['"'HTTP_HOST'"'] . '"'\/fancyindex\/stream.php'"';/g' /srv/rutorrent/plugins/filemanager-media/conf.php
                 ;;
             #fileupload)
             #svn co https://github.com/nelu/rutorrent-thirdparty-plugins/trunk/fileupload >/dev/null 2>&1
@@ -169,7 +145,7 @@ FMCONF
 
 function _rmplugs() {
     removea=()
-    plugs=(autotools checkport chunks cookies cpuload create data datadir diskspace edit erasedata extratio extsearch feeds filedrop filemanager fileshare fileupload geoip getdir history httprpc ipad loginmgr logoff lookat mediainfo mobile noty pausewebui ratio ratiocolor retrackers rpc rss rssurlrewrite rutracker_check scheduler screenshots seedingtime show_peers_like_wtorrent source spectrogram task theme throttle tracklabels trafic unpack uploadeta xmpp)
+    plugs=(autotools checkport chunks cookies cpuload create data datadir diskspace edit erasedata extratio extsearch feeds filedrop filemanager filemanager-share fileshare fileupload geoip getdir history httprpc ipad loginmgr logoff lookat mediainfo mobile noty pausewebui ratio ratiocolor retrackers rpc rss rssurlrewrite rutracker_check scheduler screenshots seedingtime show_peers_like_wtorrent source spectrogram task theme throttle tracklabels trafic unpack uploadeta xmpp)
     for i in "${plugs[@]}"; do
         plug=${i}
         if [[ -d /srv/rutorrent/plugins/$i ]]; then

--- a/scripts/rtx
+++ b/scripts/rtx
@@ -138,14 +138,16 @@ FMCONF
                 case $tag in
                     3.*)
                         svn co https://github.com/nelu/rutorrent-thirdparty-plugins/trunk/fileshare > /dev/null 2>&1
+                        ln -s /srv/rutorrent/plugins/fileshare/share.php /srv/fancyindex/share.php > /dev/null 2>&1
+                        sed -i 's/$downloadpath .*/$downloadpath = '"'https:\/\/'"'.$_SERVER['"'HTTP_HOST'"'] . '"'\/fancyindex\/share.php'"';/g' /srv/rutorrent/plugins/filemanager-share/conf.php
                         ;;
                     *)
                         git clone https://github.com/nelu/rutorrent-filemanager-share.git filemanager-share > /dev/null 2>&1
-
+                        ln -s /srv/rutorrent/plugins/filemanager-share/share.php /srv/fancyindex/share.php > /dev/null 2>&1
+                        sed -i 's/$downloadpath .*/$downloadpath = '"'https:\/\/'"'.$_SERVER['"'HTTP_HOST'"'] . '"'\/fancyindex\/share.php'"';/g' /srv/rutorrent/plugins/filemanager-share/conf.php
                         ;;
                 esac
-                ln -s /srv/rutorrent/plugins/filemanager-share/share.php /srv/fancyindex/share.php > /dev/null 2>&1
-                sed -i 's/$downloadpath .*/$downloadpath = '"'https:\/\/'"'.$_SERVER['"'HTTP_HOST'"'] . '"'\/fancyindex\/share.php'"';/g' /srv/rutorrent/plugins/filemanager-share/conf.php
+
                 ;;
             filemanager-media)
                 git clone https://github.com/nelu/rutorrent-filemanager-media.git filemanager-media > /dev/null 2>&1
@@ -203,9 +205,15 @@ function _rmplugs() {
         result=$(echo $i)
         echo -e "Removing ${result}"
         rm -rf /srv/rutorrent/plugins/${result}
-        if [[ $result = "fileshare" ]]; then
-            rm -f /srv/fancyindex/share.php
-        fi
+        case $result in
+            fileshare | filemanager-share)
+                rm -f /srv/fancyindex/share.php
+                ;;
+            filemanager-media)
+                rm -f /srv/fancyindex/stream.php
+                ;;
+            *) ;;
+        esac
     done
     /usr/local/bin/swizzin/php-fpm-cli -r 'opcache_reset();'
     rm /tmp/results

--- a/scripts/rtx
+++ b/scripts/rtx
@@ -103,16 +103,16 @@ function _itplugs() {
                 fi
                 ;;
             filemanager)
-                git clone https://github.com/nelu/rutorrent-filemanager filemanager >> ${log} 2>&1
+                git clone https://github.com/nelu/rutorrent-filemanager filemanager >> /dev/null 2>&1
                 chmod -R +x /srv/rutorrent/plugins/filemanager/scripts
                 ;;
             filemanager-share)
-                git clone https://github.com/nelu/rutorrent-filemanager-share.git filemanager-share > ${log} 2>&1
+                git clone https://github.com/nelu/rutorrent-filemanager-share.git filemanager-share > /dev/null 2>&1
                 ln -s /srv/rutorrent/plugins/filemanager-share/share.php /srv/fancyindex/share.php > /dev/null 2>&1
                 sed -i 's/$downloadpath .*/$downloadpath = '"'https:\/\/'"'.$_SERVER['"'HTTP_HOST'"'] . '"'\/fancyindex\/share.php'"';/g' /srv/rutorrent/plugins/filemanager-share/conf.php
                 ;;
             filemanager-media)
-                git clone https://github.com/nelu/rutorrent-filemanager-media.git filemanager-media > ${log} 2>&1
+                git clone https://github.com/nelu/rutorrent-filemanager-media.git filemanager-media > /dev/null 2>&1
                 ln -s /srv/rutorrent/plugins/filemanager-media/stream.php /srv/fancyindex/stream.php > /dev/null 2>&1
                 sed -i 's/$streampath .*/$streampath = '"'https:\/\/'"'.$_SERVER['"'HTTP_HOST'"'] . '"'\/fancyindex\/stream.php'"';/g' /srv/rutorrent/plugins/filemanager-media/conf.php
                 ;;

--- a/scripts/rtx
+++ b/scripts/rtx
@@ -66,7 +66,7 @@ function _themes() {
 
 function _itplugs() {
     installa=()
-    plugs=(_getdir _noty _noty2 _task autotools check_port chunks cookies cpuload create data datadir diskspace edit erasedata extratio extsearch feeds filedrop filemanager filemanager-share geoip history httprpc ipad loginmgr lookat mediainfo mobile pausewebui ratio ratiocolor retrackers rpc rss rssurlrewrite rutracker_check scheduler screenshots seedingtime show_peers_like_wtorrent source spectrogram theme throttle tracklabels trafic unpack uploadeta xmpp)
+    plugs=(_getdir _noty _noty2 _task autotools check_port chunks cookies cpuload create data datadir diskspace edit erasedata extratio extsearch feeds filedrop filemanager filemanager-media filemanager-share geoip history httprpc ipad loginmgr lookat mediainfo mobile pausewebui ratio ratiocolor retrackers rpc rss rssurlrewrite rutracker_check scheduler screenshots seedingtime show_peers_like_wtorrent source spectrogram theme throttle tracklabels trafic unpack uploadeta xmpp)
     for i in "${plugs[@]}"; do
         plug=${i}
         if [[ ! -d /srv/rutorrent/plugins/${plug} ]]; then
@@ -148,7 +148,7 @@ function _itplugs() {
 
 function _rmplugs() {
     removea=()
-    plugs=(autotools checkport chunks cookies cpuload create data datadir diskspace edit erasedata extratio extsearch feeds filedrop filemanager filemanager-share fileshare fileupload geoip getdir history httprpc ipad loginmgr logoff lookat mediainfo mobile noty pausewebui ratio ratiocolor retrackers rpc rss rssurlrewrite rutracker_check scheduler screenshots seedingtime show_peers_like_wtorrent source spectrogram task theme throttle tracklabels trafic unpack uploadeta xmpp)
+    plugs=(autotools checkport chunks cookies cpuload create data datadir diskspace edit erasedata extratio extsearch feeds filedrop filemanager filemanager-media filemanager-share fileshare fileupload geoip getdir history httprpc ipad loginmgr logoff lookat mediainfo mobile noty pausewebui ratio ratiocolor retrackers rpc rss rssurlrewrite rutracker_check scheduler screenshots seedingtime show_peers_like_wtorrent source spectrogram task theme throttle tracklabels trafic unpack uploadeta xmpp)
     for i in "${plugs[@]}"; do
         plug=${i}
         if [[ -d /srv/rutorrent/plugins/$i ]]; then

--- a/scripts/update/nginx.sh
+++ b/scripts/update/nginx.sh
@@ -135,13 +135,13 @@ DIN
     if [[ ! -f /etc/nginx/apps/fancyindex.conf ]]; then
         cat > /etc/nginx/apps/fancyindex.conf << FIAC
 location /fancyindex {
-    location ~ \.php {
+    location ~ \.php/ {
         fastcgi_split_path_info ^(.+?\.php)(/.+)$;
         # Work around annoying nginx "feature" (https://trac.nginx.org/nginx/ticket/321)
-        set \$path_info \$fastcgi_path_info;
-        fastcgi_param PATH_INFO \$path_info;
+        # Don't think it's necessary but saving for posterity.
+        #set \$path_info \$fastcgi_path_info;
+        #fastcgi_param PATH_INFO \$path_info;
 
-        # Make sure the script exists.
         try_files \$fastcgi_script_name =404;
         fastcgi_pass unix:/run/php/${sock}.sock;
         fastcgi_param SCRIPT_FILENAME \$request_filename;

--- a/scripts/update/nginx.sh
+++ b/scripts/update/nginx.sh
@@ -135,7 +135,7 @@ DIN
     if [[ ! -f /etc/nginx/apps/fancyindex.conf ]]; then
         cat > /etc/nginx/apps/fancyindex.conf << FIAC
 location /fancyindex {
-    location ~ \.php/ {
+    location ~ \.php($|/) {
         fastcgi_split_path_info ^(.+?\.php)(/.+)$;
         # Work around annoying nginx "feature" (https://trac.nginx.org/nginx/ticket/321)
         # Don't think it's necessary but saving for posterity.

--- a/scripts/update/nginx.sh
+++ b/scripts/update/nginx.sh
@@ -143,7 +143,7 @@ location /fancyindex {
 
         # Make sure the script exists.
         try_files \$fastcgi_script_name =404;
-        fastcgi_pass unix:/run/${sock}.sock;
+        fastcgi_pass unix:/run/php/${sock}.sock;
         fastcgi_param SCRIPT_FILENAME \$request_filename;
         include fastcgi_params;
         fastcgi_index index.php;

--- a/scripts/upgrade/nginx.sh
+++ b/scripts/upgrade/nginx.sh
@@ -35,7 +35,7 @@ if [[ ! -f /etc/nginx/modules-enabled/50-mod-http-fancyindex.conf ]]; then
     ln -s /usr/share/nginx/modules-available/mod-http-fancyindex.conf /etc/nginx/modules-enabled/50-mod-http-fancyindex.conf
 fi
 
-for i in NGC SSC PROX FIC; do
+for i in NGC SSC PROX FIC FIAC; do
     cmd=$(sed -n -e '/'$i'/,/'$i'/ p' /etc/swizzin/scripts/install/nginx.sh)
     eval "$cmd"
 done


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description
Our ruTorrent "quick fix" had reverberating implications on being able to install plugins from head. Basically you can't and installing little things like throttle after the fact is essentially impossible without massive work arounds. This is all due to autodl ruTorrent plugin being out of date.

Since we don't support ruTorrent upgrades, the only official way to "fix" this on a current installation is

```
box remove rutorrent
box install rutorrent
```

## Fixes issues: 
- #811 

## Proposed Changes:
- autodl-irssi plugin upstream has been pulled into the swizzin org with fixes applied for ruTorrent 4.0
- Unpin ruTorrent version
- Deprecate broken plugins
- Fix filemanager plugins to use new version since the are broken/deprecated
- Fix nginx fancyindex to allow php with split paths

## Change Categories
<!-- DELETE WHICHEVER BULLET DOES NOT APPLY -->
- Bug fix <!-- non-breaking change which fixes an issue -->

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [ ] Docs have been made OR are not necessary (some ruTorrent docs could be good here)
    - PR link: 
- [x] Changes to panel have been made OR are not necessary
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Testing was done


## Test scenarios
Only tested under Bullseye could potentially use a bit more coverage before merging

