### PR TITLE
fix(apt_install): skip installed packages

### DIFF
--- a/scripts/update/10-dependencies.sh
+++ b/scripts/update/10-dependencies.sh
@@ -42,4 +42,4 @@ fi
 dependencies="whiptail git sudo curl wget lsof fail2ban apache2-utils vnstat tcl tcl-dev build-essential dirmngr apt-transport-https bc uuid-runtime jq net-tools gnupg2 cracklib-runtime unzip ccze"
 
 echo_info "Installing missing dependencies"
-apt_install "${dependencies[@]}"
+apt_install ${dependencies[@]}

--- a/scripts/update/10-dependencies.sh
+++ b/scripts/update/10-dependencies.sh
@@ -41,5 +41,4 @@ fi
 #space-separated list of required GLOBAL SWIZZIN dependencies (NOT application specific ones)
 dependencies="whiptail git sudo curl wget lsof fail2ban apache2-utils vnstat tcl tcl-dev build-essential dirmngr apt-transport-https bc uuid-runtime jq net-tools gnupg2 cracklib-runtime unzip ccze"
 
-echo_info "Installing missing dependencies"
 apt_install "${dependencies[@]}"

--- a/scripts/update/10-dependencies.sh
+++ b/scripts/update/10-dependencies.sh
@@ -42,4 +42,4 @@ fi
 dependencies="whiptail git sudo curl wget lsof fail2ban apache2-utils vnstat tcl tcl-dev build-essential dirmngr apt-transport-https bc uuid-runtime jq net-tools gnupg2 cracklib-runtime unzip ccze"
 
 echo_info "Installing missing dependencies"
-apt_install ${dependencies[@]}
+apt_install "${dependencies[@]}"

--- a/scripts/update/10-dependencies.sh
+++ b/scripts/update/10-dependencies.sh
@@ -41,16 +41,5 @@ fi
 #space-separated list of required GLOBAL SWIZZIN dependencies (NOT application specific ones)
 dependencies="whiptail git sudo curl wget lsof fail2ban apache2-utils vnstat tcl tcl-dev build-essential dirmngr apt-transport-https bc uuid-runtime jq net-tools gnupg2 cracklib-runtime unzip ccze"
 
-missing=()
-for dep in $dependencies; do
-    if ! check_installed "$dep"; then
-        missing+=("$dep")
-    fi
-done
-
-if [[ ${missing[0]} != "" ]]; then
-    echo_info "Installing missing dependencies"
-    apt_install "${missing[@]}"
-else
-    echo_log_only "No dependencies required to install"
-fi
+echo_info "Installing missing dependencies"
+apt_install "${dependencies[@]}"

--- a/sources/functions/apt
+++ b/sources/functions/apt
@@ -274,21 +274,31 @@ apt_install() {
         action_msg="upgrade"
     fi
 
-    # Run the install
+    # Check existing packages
+    for package in ${_apt_packages[@]}; do
+        if check_installed $package; then
+            _apt_packages=("${_apt_packages[@]/$package/}")
+        fi
+    done
 
-    echo_progress_start "Performing $action_msg of ${#_apt_packages[@]} apt packages\n(${_apt_packages[*]})"
-    if [[ $_apt_interactive == "true" ]]; then
-        # TODO test the behaviour of this, I haven't had the time yet
-        DEBIAN_FRONTEND=readline apt-get install -y $flags "${_apt_packages[@]}" | tee -a $log
+    if [[ -z ${_apt_packages[*]} ]]; then
+        :
     else
-        for pekkidge in "${_apt_packages[@]}"; do
-            DEBIAN_FRONTEND=noninteractive apt-get install $flags -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y "$pekkidge" >> $log 2>&1
-        done
+        # Run the install
+        echo_progress_start "Performing $action_msg of ${#_apt_packages[@]} apt packages\n(${_apt_packages[*]})"
+        if [[ $_apt_interactive == "true" ]]; then
+            # TODO test the behaviour of this, I haven't had the time yet
+            DEBIAN_FRONTEND=readline apt-get install -y $flags "${_apt_packages[@]}" | tee -a $log
+        else
+            for pekkidge in "${_apt_packages[@]}"; do
+                DEBIAN_FRONTEND=noninteractive apt-get install $flags -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y "$pekkidge" >> $log 2>&1
+            done
+        fi
+
+        _apt_logcheck
+
+        echo_progress_done "Apt install complete"
     fi
-
-    _apt_logcheck
-
-    echo_progress_done "Apt install complete"
 }
 export -f apt_install
 

--- a/sources/functions/apt
+++ b/sources/functions/apt
@@ -254,6 +254,18 @@ export -f apt_upgrade
 apt_install() {
     _apt_logcheck_mark
     _process_apt_args "$@"
+    # Check existing packages
+    apt_uninstalled=()
+    for package in ${_apt_packages[@]}; do
+        if ! check_installed $package; then
+            apt_uninstalled+=($package)
+        fi
+    done
+    _apt_packages=("${apt_uninstalled[@]}")
+    if [[ -z ${_apt_packages[*]} ]]; then
+        return
+    fi
+
     #Do checks
     _check_dpkg_lock
     _apt_check
@@ -274,31 +286,20 @@ apt_install() {
         action_msg="upgrade"
     fi
 
-    # Check existing packages
-    for package in ${_apt_packages[@]}; do
-        if check_installed $package; then
-            _apt_packages=("${_apt_packages[@]/$package/}")
-        fi
-    done
-
-    if [[ -z ${_apt_packages[*]} ]]; then
-        :
+    # Run the install
+    echo_progress_start "Performing $action_msg of ${#_apt_packages[@]} apt packages\n(${_apt_packages[*]})"
+    if [[ $_apt_interactive == "true" ]]; then
+        # TODO test the behaviour of this, I haven't had the time yet
+        DEBIAN_FRONTEND=readline apt-get install -y $flags "${_apt_packages[@]}" | tee -a $log
     else
-        # Run the install
-        echo_progress_start "Performing $action_msg of ${#_apt_packages[@]} apt packages\n(${_apt_packages[*]})"
-        if [[ $_apt_interactive == "true" ]]; then
-            # TODO test the behaviour of this, I haven't had the time yet
-            DEBIAN_FRONTEND=readline apt-get install -y $flags "${_apt_packages[@]}" | tee -a $log
-        else
-            for pekkidge in "${_apt_packages[@]}"; do
-                DEBIAN_FRONTEND=noninteractive apt-get install $flags -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y "$pekkidge" >> $log 2>&1
-            done
-        fi
-
-        _apt_logcheck
-
-        echo_progress_done "Apt install complete"
+        for pekkidge in "${_apt_packages[@]}"; do
+            DEBIAN_FRONTEND=noninteractive apt-get install $flags -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y "$pekkidge" >> $log 2>&1
+        done
     fi
+
+    _apt_logcheck
+
+    echo_progress_done "Apt install complete"
 }
 export -f apt_install
 


### PR DESCRIPTION
Rather than claiming that apt is constantly installing packages, take the deps list and check if anything is missing from it. If yes, then install those packages; otherwise stay quiet and do nothing.

Tested, does what it says on the box.

