### PR TITLE
fix(mango): update config to match upstream version

### DIFF
--- a/scripts/install/mango.sh
+++ b/scripts/install/mango.sh
@@ -43,36 +43,6 @@ function _install_mango() {
 
 }
 
-## Creating config
-function _mkconf_mango() {
-    echo_progress_start "Configuring mango"
-    mkdir -p $mangodir/.config/mango
-    cat > "$mangodir/.config/mango/config.yml" << CONF
-#Please do not edit as swizzin will be replacing this file as updates roll out. 
-port: 9003
-base_url: /
-library_path: $mangodir/library
-db_path: $mangodir/.config/mango/mango.db
-scan_interval_minutes: 5
-log_level: info
-upload_path: $mangodir/uploads
-plugin_path: $mangodir/plugins
-library_cache_path: $mangodir/.config/mango/library.yml.gz
-disable_ellipsis_truncation: false
-mangadex:
-  base_url: https://mangadex.org
-  api_url: https://api.mangadex.org/v2
-  download_wait_seconds: 5
-  download_retries: 4
-  download_queue_db_path: $mangodir/.config/mango/queue.db
-  chapter_rename_rule: '[Vol.{volume} ][Ch.{chapter} ]{title|id}'
-  manga_rename_rule: '{title}'
-CONF
-    chown $mangousr:$mangousr -R $mangodir
-    chmod o-rwx $mangodir/.config
-    echo_progress_done
-}
-
 # Creating systemd unit
 function _mkservice_mango() {
     echo_progress_start "Installing systemd service"
@@ -130,7 +100,11 @@ if [[ -n $1 ]]; then
 fi
 
 _install_mango
+
+# shellcheck source=sources/functions/mango
+. /etc/swizzin/sources/functions/mango
 _mkconf_mango
+
 _addusers_mango
 _mkservice_mango
 

--- a/scripts/install/mango.sh
+++ b/scripts/install/mango.sh
@@ -56,10 +56,12 @@ db_path: $mangodir/.config/mango/mango.db
 scan_interval_minutes: 5
 log_level: info
 upload_path: $mangodir/uploads
+plugin_path: $mangodir/plugins
+library_cache_path: $mangodir/.config/mango/library.yml.gz
 disable_ellipsis_truncation: false
 mangadex:
   base_url: https://mangadex.org
-  api_url: https://mangadex.org/api
+  api_url: https://api.mangadex.org/v2
   download_wait_seconds: 5
   download_retries: 4
   download_queue_db_path: $mangodir/.config/mango/queue.db

--- a/scripts/nginx/mango.sh
+++ b/scripts/nginx/mango.sh
@@ -10,5 +10,4 @@ location /mango/ {
 }
 EOF
 
-sed -i 's=base_url: /=base_url: /mango=' /opt/mango/.config/mango/config.yml
 systemctl restart mango

--- a/scripts/upgrade/mango.sh
+++ b/scripts/upgrade/mango.sh
@@ -31,6 +31,26 @@ wget "${dlurl}" -O $mangodir/mango >> $log 2>&1
 chmod +x "$mangodir"/mango
 echo_progress_done
 
+# Update config to match upstream version
+if [[ -f $mangodir/.config/mango/config.yml ]]; then
+    mango_config_file=$mangodir/.config/mango/config.yml
+    echo_progress_start "Verifying config file"
+
+    if ! grep -q "plugin_path:" $mango_config_file; then
+        echo "plugin_path: $mangodir/plugins" >> $mango_config_file
+    fi
+
+    if ! grep -q "library_cache_path:" $mango_config_file; then
+        echo "library_cache_path: $mangodir/.config/mango/library.yml.gz" >> $mango_config_file
+    fi
+
+    if grep -q "api_url: https://mangadex.org/api" $mango_config_file; then
+        sed -i "s/api_url: https:\\/\\/mangadex.org\\/api/api_url: https:\\/\\/api.mangadex.org\\/v2/g" $mango_config_file
+    fi
+
+    echo_progress_done
+fi
+
 if [[ $wasActive = "true" ]]; then
     echo_progress_start "Restarting Mango ($($mangodir/mango --version))"
     systemctl start mango

--- a/scripts/upgrade/mango.sh
+++ b/scripts/upgrade/mango.sh
@@ -31,25 +31,9 @@ wget "${dlurl}" -O $mangodir/mango >> $log 2>&1
 chmod +x "$mangodir"/mango
 echo_progress_done
 
-# Update config to match upstream version
-if [[ -f $mangodir/.config/mango/config.yml ]]; then
-    mango_config_file=$mangodir/.config/mango/config.yml
-    echo_progress_start "Verifying config file"
-
-    if ! grep -q "plugin_path:" $mango_config_file; then
-        echo "plugin_path: $mangodir/plugins" >> $mango_config_file
-    fi
-
-    if ! grep -q "library_cache_path:" $mango_config_file; then
-        echo "library_cache_path: $mangodir/.config/mango/library.yml.gz" >> $mango_config_file
-    fi
-
-    if grep -q "api_url: https://mangadex.org/api" $mango_config_file; then
-        sed -i "s/api_url: https:\\/\\/mangadex.org\\/api/api_url: https:\\/\\/api.mangadex.org\\/v2/g" $mango_config_file
-    fi
-
-    echo_progress_done
-fi
+# shellcheck source=sources/functions/mango
+. /etc/swizzin/sources/functions/mango
+_mkconf_mango
 
 if [[ $wasActive = "true" ]]; then
     echo_progress_start "Restarting Mango ($($mangodir/mango --version))"

--- a/sources/functions/mango
+++ b/sources/functions/mango
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+function _mkconf_mango() {
+    echo_progress_start "Configuring mango"
+    mangodir="/opt/mango"
+    mangousr="mango"
+    mkdir -p $mangodir/.config/mango
+
+    # Determine base path
+    if [[ -f /install/.nginx.lock ]]; then
+        mangobase="/mango"
+    else
+        mangobase="/"
+    fi
+
+    cat > "$mangodir/.config/mango/config.yml" << CONF
+#Please do not edit as swizzin will be replacing this file as updates roll out. 
+port: 9003
+base_url: $mangobase
+library_path: $mangodir/library
+db_path: $mangodir/.config/mango/mango.db
+scan_interval_minutes: 5
+log_level: info
+upload_path: $mangodir/uploads
+plugin_path: $mangodir/plugins
+library_cache_path: $mangodir/.config/mango/library.yml.gz
+disable_ellipsis_truncation: false
+mangadex:
+  base_url: https://mangadex.org
+  api_url: https://api.mangadex.org/v2
+  download_wait_seconds: 5
+  download_retries: 4
+  download_queue_db_path: $mangodir/.config/mango/queue.db
+  chapter_rename_rule: '[Vol.{volume} ][Ch.{chapter} ]{title|id}'
+  manga_rename_rule: '{title}'
+CONF
+    chown $mangousr:$mangousr -R $mangodir
+    chmod o-rwx $mangodir/.config
+    echo_progress_done
+}


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description
<!-- Any general story time goes here :) Feel free to add screenshots/recording of your change in action here-->

This commit updates Mango config to fix the following errors and warnings:

**New entry:** `plugin_path: $mangodir/plugins`
**Fixes:** `[ERROR] Unable to create directory: '/opt/mango/mango': File exists`

**New entry:** `library_cache_path: $mangodir/.config/mango/library.yml.gz`
**Fixes:**
```
Unhandled exception in spawn: Error opening file with mode 'w': '/opt/mango/mango/library.yml.gz': Not a directory (File::Error)
   from usr/share/crystal/src/crystal/system/unix/file.cr:11:7 in 'open'
   from usr/share/crystal/src/file.cr:112:5 in '->'
   from usr/share/crystal/src/primitives.cr:255:3 in 'run'
   from ???
```

**Update entry:** `mangadex.api_url: https://api.mangadex.org/v2`
**Fixes:** `WARN - It looks like you are using the deprecated MangaDex API v1 in your config file.`


## Fixes issues: 
- Un-tracked issue

## Proposed Changes:
- Always re-create config file upon upgrading to match [upstream version example](https://github.com/hkalexling/Mango#config).
- Update install and upgrade scripts to use a `_mkconf_mango` function to simplify maintainability.

## Change Categories
<!-- DELETE WHICHEVER BULLET DOES NOT APPLY -->
- Bug fix <!-- non-breaking change which fixes an issue -->

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [x] Docs have been made OR are not necessary
    - PR link: 
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Testing was done
   - [x] Tests created or no new tests necessary
   - [ ] Tests executed

## Test scenarios
<!-- Please let us know what has been done or anything else that works/doesn't. Feel free to copy-paste the examples at the bottom of this section -->
I tested these changes on my Swizzin install on Debian 11 (Bullseye) with no errors/warnings.

### Architectures
<!--
Please use these emojis here to fill the table below. It will nicely auto-format with spacing, don't worry. Leave empty wherever you do not know / have not tested
✅ = Works successfully
❎ = Does not work BUT is handled gracefully
🛠 = Still WIP
❌ = Broken / not working
-->
|   			| `amd64` 	| `armhf` 	| `arm64` 	| Unspecified 	|
|--------		|-------- 	|-------- 	|-------- 	|----------		|
| Focal 		|			|			|			|				|
| Bionic		|			|			|			|				|
| Buster		|			|			|			|				|
| Stretch		|			|			|			|				|
| Raspbian  	|	⚫️		|			|	⚫️		|	⚫️			|

### ✅❎ Passed

### 🛠🛠 TODO

### ❌❌ Currently failing

<!-- EXAMPLES :
- Fresh app install without nginx
    - With only one user
    - With multiple users present
- Fresh Install with nginx present nginx
    - With only one user
    - With multiple users present
- Fresh install and nginx install afterwards
    - With only one user
    - With multiple users present
- Update from version in master
- Upgrade from version in master
- Password gets changed from `box` in app
- User removal from `box` acting on app
- New user in `box` gets added to app
- Sysinfo compatibility
    - Info washed
    - Content available
-->

