### PR TITLE
fix(mango): update config to mitigate upstream breaking changes

### DIFF
--- a/sources/functions/mango
+++ b/sources/functions/mango
@@ -19,20 +19,13 @@ port: 9003
 base_url: $mangobase
 library_path: $mangodir/library
 db_path: $mangodir/.config/mango/mango.db
+queue_db_path: $mangodir/.config/mango/queue.db
 scan_interval_minutes: 5
 log_level: info
 upload_path: $mangodir/uploads
 plugin_path: $mangodir/plugins
 library_cache_path: $mangodir/.config/mango/library.yml.gz
 disable_ellipsis_truncation: false
-mangadex:
-  base_url: https://mangadex.org
-  api_url: https://api.mangadex.org/v2
-  download_wait_seconds: 5
-  download_retries: 4
-  download_queue_db_path: $mangodir/.config/mango/queue.db
-  chapter_rename_rule: '[Vol.{volume} ][Ch.{chapter} ]{title|id}'
-  manga_rename_rule: '{title}'
 CONF
     chown $mangousr:$mangousr -R $mangodir
     chmod o-rwx $mangodir/.config


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description
<!-- Any general story time goes here :) Feel free to add screenshots/recording of your change in action here-->

Just in time for #827 merge Mango released [v0.25.0](https://github.com/hkalexling/Mango/releases/tag/v0.25.0) today with breaking changes. They removed direct support for Mangadex API and config setting `mangadex.download_queue_db_path` renamed to `queue_db_path` and moved to the root level.

The upstream changes are causing this error on Mango upgrade from Swizzin:

```
Unhandled exception: Unable to create directory: '/opt/mango/mango': File exists (File::AlreadyExistsEr>
   from usr/share/crystal/src/crystal/system/unix/dir.cr:65:13 in 'mkdir_p'
   from __w/Mango/Mango/src/queue.cr:120:7 in 'default'
   from __w/Mango/Mango/src/mango.cr:47:1 in '->'
   from usr/share/crystal/src/primitives.cr:255:3 in 'start_parse'
   from __w/Mango/Mango/src/mango.cr:137:1 in '__crystal_main'
   from usr/share/crystal/src/crystal/main.cr:110:5 in 'main'
   from src/env/__libc_start_main.c:94:2 in 'libc_start_main_stage2'
mango.service: Main process exited, code=exited, status=1/FAILURE
mango.service: Failed with result 'exit-code'.
```

## Fixes issues: 
- Un-tracked issue.

## Proposed Changes:
- Update config to match upstream version.

## Change Categories
<!-- DELETE WHICHEVER BULLET DOES NOT APPLY -->
- Bug fix <!-- non-breaking change which fixes an issue -->

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [x] Docs have been made OR are not necessary
    - PR link: 
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Testing was done
   - [x] Tests created or no new tests necessary
   - [ ] Tests executed

## Test scenarios
<!-- Please let us know what has been done or anything else that works/doesn't. Feel free to copy-paste the examples at the bottom of this section -->
I tested these changes on Debian 11 (Bullseye) with no errors/warnings.

### Architectures
<!--
Please use these emojis here to fill the table below. It will nicely auto-format with spacing, don't worry. Leave empty wherever you do not know / have not tested
✅ = Works successfully
❎ = Does not work BUT is handled gracefully
🛠 = Still WIP
❌ = Broken / not working
-->
|   			| `amd64` 	| `armhf` 	| `arm64` 	| Unspecified 	|
|--------		|-------- 	|-------- 	|-------- 	|----------		|
| Focal 		|			|			|			|				|
| Bionic		|			|			|			|				|
| Buster		|			|			|			|				|
| Stretch		|			|			|			|				|
| Raspbian  	|	⚫️		|			|	⚫️		|	⚫️			|

### ✅❎ Passed

### 🛠🛠 TODO

### ❌❌ Currently failing

<!-- EXAMPLES :
- Fresh app install without nginx
    - With only one user
    - With multiple users present
- Fresh Install with nginx present nginx
    - With only one user
    - With multiple users present
- Fresh install and nginx install afterwards
    - With only one user
    - With multiple users present
- Update from version in master
- Upgrade from version in master
- Password gets changed from `box` in app
- User removal from `box` acting on app
- New user in `box` gets added to app
- Sysinfo compatibility
    - Info washed
    - Content available
-->

