### PR TITLE
fix(apt_install): grep mistakes not-installed as ok

### DIFF
--- a/sources/functions/apt
+++ b/sources/functions/apt
@@ -198,7 +198,7 @@ export -f _apt_update
 # $1 the package to check for
 # Returns code 0 in case a package is installed, 1 if missing
 check_installed() {
-    if dpkg-query --showformat='${db:Status-Status}' -W "$1" 2>&1 | grep installed > /dev/null 2>&1; then
+    if dpkg-query --showformat='${db:Status-Status}' -W "$1" 2>&1 | grep "^installed" > /dev/null 2>&1; then
         return 0
     else
         return 1


### PR DESCRIPTION
finally nailed down a fix for the elusive "package is in depends but not getting installed" bug.

Sometimes grep of our status returns a result of "not-installed" instead of an error. The grep code would match this output and think that the package was installed. Change grep code to `^installed` to ensure we don't match `not-installed`