### PR TITLE
hotfix(sabnzbd): bump pyenv version

### DIFF
--- a/scripts/install/sabnzbd.sh
+++ b/scripts/install/sabnzbd.sh
@@ -15,16 +15,16 @@
 
 user=$(_get_master_username)
 password="$(_get_user_password ${user})"
-#latest=$(curl -s https://sabnzbd.org/downloads | grep -m1 Linux | grep download-link-src | grep -oP "href=\"\K[^\"]+")
-latest=$(curl -sL https://api.github.com/repos/sabnzbd/sabnzbd/releases/latest | jq -r '.assets[]?.browser_download_url | select(contains("tar.gz"))') || {
+latestversion=$(github_latest_version sabnzbd/sabnzbd) || {
     echo_error "Failed to query GitHub for latest sabnzbd version"
     exit 1
 }
-latestversion=$(echo $latest | awk -F "/" '{print $NF}' | cut -d- -f2)
+latest="https://github.com/sabnzbd/sabnzbd/archive/refs/tags/${latestversion}.tar.gz"
+
 systempy3_ver=$(get_candidate_version python3)
 
-#Version 3.2 is going to raise the min python version to 3.6 so we have to differentiate whether or not to build a pyenv
-if dpkg --compare-versions ${systempy3_ver} lt 3.6.0 && dpkg --compare-versions ${latestversion} ge 3.2.0; then
+#Version 3.5 is going to raise the min python version to 3.7 so we have to differentiate whether or not to build a pyenv
+if dpkg --compare-versions ${systempy3_ver} lt 3.7.0 && dpkg --compare-versions ${latestversion} ge 3.2.0; then
     LIST='par2 p7zip-full libffi-dev libssl-dev libglib2.0-dev libdbus-1-dev'
     PYENV=True
 else
@@ -37,8 +37,8 @@ install_rar
 case ${PYENV} in
     True)
         pyenv_install
-        pyenv_install_version 3.7.7
-        pyenv_create_venv 3.7.7 /opt/.venv/sabnzbd
+        pyenv_install_version 3.10.2 # As shipping on Windows/macOS.
+        pyenv_create_venv 3.10.2 /opt/.venv/sabnzbd
         chown -R ${user}: /opt/.venv/sabnzbd
         ;;
     *)

--- a/scripts/install/sabnzbd.sh
+++ b/scripts/install/sabnzbd.sh
@@ -24,7 +24,7 @@ latest="https://github.com/sabnzbd/sabnzbd/archive/refs/tags/${latestversion}.ta
 systempy3_ver=$(get_candidate_version python3)
 
 #Version 3.5 is going to raise the min python version to 3.7 so we have to differentiate whether or not to build a pyenv
-if dpkg --compare-versions ${systempy3_ver} lt 3.7.0 && dpkg --compare-versions ${latestversion} ge 3.2.0; then
+if dpkg --compare-versions ${systempy3_ver} lt 3.7.0 && dpkg --compare-versions ${latestversion} ge 3.5.0; then
     LIST='par2 p7zip-full libffi-dev libssl-dev libglib2.0-dev libdbus-1-dev'
     PYENV=True
 else

--- a/scripts/upgrade/sabnzbd.sh
+++ b/scripts/upgrade/sabnzbd.sh
@@ -60,7 +60,7 @@ if dpkg --compare-versions ${localversion:0.0} lt ${latestversion}; then
         echo_progress_start "Upgrading SABnzbd python virtual environment to python3"
         rm -rf /opt/.venv/sabnzbd
         systempy3_ver=$(get_candidate_version python3)
-        if dpkg --compare-versions ${systempy3_ver} lt 3.6.0; then
+        if dpkg --compare-versions ${systempy3_ver} lt 3.7.0; then
             pyenv_install
             pyenv_install_version 3.10.2
             pyenv_create_venv 3.10.2 /opt/.venv/sabnzbd

--- a/scripts/upgrade/sabnzbd.sh
+++ b/scripts/upgrade/sabnzbd.sh
@@ -18,7 +18,7 @@ latest="https://github.com/sabnzbd/sabnzbd/archive/refs/tags/${latestversion}.ta
 
 pyvenv_version=$(/opt/.venv/sabnzbd/bin/python --version | awk '{print $2}')
 
-if dpkg --compare-versions ${pyvenv_version} lt 3.7.0 && dpkg --compare-versions ${latestversion} ge 3.2.0; then
+if dpkg --compare-versions ${pyvenv_version} lt 3.7.0 && dpkg --compare-versions ${latestversion} ge 3.5.0; then
     LIST='par2 p7zip-full libffi-dev libssl-dev libglib2.0-dev libdbus-1-dev'
     PYENV_REBUILD=True
 elif [[ -f /opt/.venv/sabnzbd/bin/python2 ]]; then
@@ -29,7 +29,7 @@ else
 fi
 apt_install $LIST
 
-if dpkg --compare-versions ${localversion} lt ${latestversion}; then
+if dpkg --compare-versions ${localversion:-0.0} lt ${latestversion}; then
     if [[ $PYENV_REBUILD == True ]]; then
         echo_progress_start "Upgrading SABnzbd python virtual environment"
         rm -rf /opt/.venv/sabnzbd

--- a/scripts/upgrade/sabnzbd.sh
+++ b/scripts/upgrade/sabnzbd.sh
@@ -29,7 +29,7 @@ else
 fi
 apt_install $LIST
 
-if dpkg --compare-versions ${localversion:-0.0} lt ${latestversion}; then
+if dpkg --compare-versions ${localversion:0.0} lt ${latestversion}; then
     if [[ $PYENV_REBUILD == True ]]; then
         echo_progress_start "Upgrading SABnzbd python virtual environment"
         rm -rf /opt/.venv/sabnzbd

--- a/scripts/upgrade/sabnzbd.sh
+++ b/scripts/upgrade/sabnzbd.sh
@@ -6,6 +6,7 @@ if [[ ! -f /install/.sabnzbd.lock ]]; then
     exit 1
 fi
 
+. /etc/swizzin/sources/functions/utils
 . /etc/swizzin/sources/functions/pyenv
 localversion=$(/opt/.venv/sabnzbd/bin/python /opt/sabnzbd/SABnzbd.py --version | grep -m1 SABnzbd | cut -d- -f2)
 #latest=$(curl -s https://sabnzbd.org/downloads | grep -m1 Linux | grep download-link-src | grep -oP "href=\"\K[^\"]+")

--- a/scripts/upgrade/sabnzbd.sh
+++ b/scripts/upgrade/sabnzbd.sh
@@ -9,14 +9,15 @@ fi
 . /etc/swizzin/sources/functions/pyenv
 localversion=$(/opt/.venv/sabnzbd/bin/python /opt/sabnzbd/SABnzbd.py --version | grep -m1 SABnzbd | cut -d- -f2)
 #latest=$(curl -s https://sabnzbd.org/downloads | grep -m1 Linux | grep download-link-src | grep -oP "href=\"\K[^\"]+")
-latest=$(curl -sL https://api.github.com/repos/sabnzbd/sabnzbd/releases/latest | jq -r '.assets[]?.browser_download_url | select(contains("tar.gz"))') || {
+latestversion=$(github_latest_version sabnzbd/sabnzbd) || {
     echo_error "Failed to query GitHub for latest sabnzbd version"
     exit 1
 }
-latestversion=$(echo $latest | awk -F "/" '{print $NF}' | cut -d- -f2)
+latest="https://github.com/sabnzbd/sabnzbd/archive/refs/tags/${latestversion}.tar.gz"
+
 pyvenv_version=$(/opt/.venv/sabnzbd/bin/python --version | awk '{print $2}')
 
-if dpkg --compare-versions ${pyvenv_version} lt 3.6.0 && dpkg --compare-versions ${latestversion} ge 3.2.0; then
+if dpkg --compare-versions ${pyvenv_version} lt 3.7.0 && dpkg --compare-versions ${latestversion} ge 3.2.0; then
     LIST='par2 p7zip-full libffi-dev libssl-dev libglib2.0-dev libdbus-1-dev'
     PYENV_REBUILD=True
 elif [[ -f /opt/.venv/sabnzbd/bin/python2 ]]; then
@@ -32,10 +33,10 @@ if dpkg --compare-versions ${localversion} lt ${latestversion}; then
         echo_progress_start "Upgrading SABnzbd python virtual environment"
         rm -rf /opt/.venv/sabnzbd
         systempy3_ver=$(get_candidate_version python3)
-        if dpkg --compare-versions ${systempy3_ver} lt 3.6.0; then
+        if dpkg --compare-versions ${systempy3_ver} lt 3.7.0; then
             pyenv_install
-            pyenv_install_version 3.7.7
-            pyenv_create_venv 3.7.7 /opt/.venv/sabnzbd
+            pyenv_install_version 3.10.2
+            pyenv_create_venv 3.10.2 /opt/.venv/sabnzbd
             chown -R ${user}: /opt/.venv/sabnzbd
         else
             python3_venv ${user} sabnzbd
@@ -60,8 +61,8 @@ if dpkg --compare-versions ${localversion} lt ${latestversion}; then
         systempy3_ver=$(get_candidate_version python3)
         if dpkg --compare-versions ${systempy3_ver} lt 3.6.0; then
             pyenv_install
-            pyenv_install_version 3.7.7
-            pyenv_create_venv 3.7.7 /opt/.venv/sabnzbd
+            pyenv_install_version 3.10.2
+            pyenv_create_venv 3.10.2 /opt/.venv/sabnzbd
             chown -R ${user}: /opt/.venv/sabnzbd
         else
             python3_venv ${user} sabnzbd


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description
<!-- Any general story time goes here :) Feel free to add screenshots/recording of your change in action here-->

## Fixes issues: 
- Un-tracked issue...

## Proposed Changes:
- Set min python version to 3.7.0, 3.6 was dropped by sab upstream. 
- Set pyenv version to 3.10.2 (shipping with windows/macOS builds)
- Use the new `github_latest_version` function to replace grabbing version from GH

## Change Categories
<!-- DELETE WHICHEVER BULLET DOES NOT APPLY -->
- Bug fix <!-- non-breaking change which fixes an issue -->


## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [x] Docs have been made OR are not necessary
    - PR link: 
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Testing was done
   - [x] Tests created or no new tests necessary
   - [x] Tests executed

## Test scenarios
<!-- Please let us know what has been done or anything else that works/doesn't. Feel free to copy-paste the examples at the bottom of this section -->

### Architectures
<!--
Please use these emojis here to fill the table below. It will nicely auto-format with spacing, don't worry. Leave empty wherever you do not know / have not tested
✅ = Works successfully
❎ = Does not work BUT is handled gracefully
🛠 = Still WIP
❌ = Broken / not working
-->
|   			| `amd64` 	| `armhf` 	| `arm64` 	| Unspecified 	|
|--------		|-------- 	|-------- 	|-------- 	|----------		|
| Focal 		|			|			|		✅	|				|
| Bionic		|			|			|			|				|
| Buster		|			|			|			|				|
| Stretch		|			|			|			|				|
| Raspbian  	|	⚫️		|			|	⚫️		|	⚫️			|

### ✅❎ Passed

### 🛠🛠 TODO

### ❌❌ Currently failing

<!-- EXAMPLES :
- Fresh app install without nginx
    - With only one user
    - With multiple users present
- Fresh Install with nginx present nginx
    - With only one user
    - With multiple users present
- Fresh install and nginx install afterwards
    - With only one user
    - With multiple users present
- Update from version in master
- Upgrade from version in master
- Password gets changed from `box` in app
- User removal from `box` acting on app
- New user in `box` gets added to app
- Sysinfo compatibility
    - Info washed
    - Content available
-->

