### PR TITLE
fix(panel): keep pip up to date in the venv

### DIFF
--- a/scripts/install/panel.sh
+++ b/scripts/install/panel.sh
@@ -57,6 +57,7 @@ git clone https://github.com/liaralabs/swizzin_dashboard.git /opt/swizzin >> ${l
 echo_progress_done "Panel cloned"
 
 echo_progress_start "Installing python dependencies"
+/opt/.venv/swizzin/bin/pip install --upgrade pip wheel >> ${log} 2>&1
 /opt/.venv/swizzin/bin/pip install -r /opt/swizzin/requirements.txt >> ${log} 2>&1
 echo_progress_done
 

--- a/scripts/upgrade/panel.sh
+++ b/scripts/upgrade/panel.sh
@@ -24,6 +24,7 @@ if [[ -f /install/.panel.lock ]]; then
     echo_progress_done "Commits pulled"
     echo_progress_start "Checking pip for new depends"
     if ! /opt/.venv/swizzin/bin/python /opt/swizzin/tests/test_requirements.py >> ${log} 2>&1; then
+        /opt/.venv/swizzin/bin/pip install --upgrade pip wheel >> ${log} 2>&1
         /opt/.venv/swizzin/bin/pip install -r /opt/swizzin/requirements.txt >> ${log} 2>&1
     fi
     echo_progress_done "Depends up-to-date"


### PR DESCRIPTION
Should fix https://github.com/swizzin/swizzin/issues/840

New dependency of authlib fails to download because pip/wheel are out of date and we have installed the deps to build the package ourselves.

Bypass build by making sure we can download the wheel.