### PR TITLE
Feature: Improve rTorrent performance

### DIFF
--- a/sources/functions/rtorrent
+++ b/sources/functions/rtorrent
@@ -82,13 +82,13 @@ function build_xmlrpc-c() {
     XMLRPC_REV=2954
     svn co http://svn.code.sf.net/p/xmlrpc-c/code/advanced@$XMLRPC_REV /tmp/xmlrpc-c >> $log 2>&1 || { svn co https://github.com/mirror/xmlrpc-c/trunk/advanced@$XMLRPC_REV /tmp/xmlrpc-c >> $log 2>&1; }
     cd /tmp/xmlrpc-c
-    ./configure --prefix=/usr --disable-cplusplus >> $log 2>&1 || {
+    ./configure --prefix=/usr --disable-cplusplus --disable-wininet-client --disable-libwww-client >> $log 2>&1 || {
         echo_error "Something went wrong while configuring xmlrpc"
         exit 1
     }
     source <(sed 's/ //g' version.mk)
     VERSION=$XMLRPC_MAJOR_RELEASE.$XMLRPC_MINOR_RELEASE.$XMLRPC_POINT_RELEASE
-    make -j$(nproc) >> $log 2>&1
+    make -j$(nproc) CFLAGS="-flto" >> $log 2>&1
     make DESTDIR=/tmp/dist/xmlrpc-c install >> $log 2>&1 || {
         echo_error "Something went wrong while making xmlrpc"
         exit 1
@@ -126,7 +126,7 @@ function build_libtorrent_rakshasa() {
         echo_error "Something went wrong while configuring libtorrent"
         exit 1
     }
-    make -j$(nproc) >> $log 2>&1 || {
+    make -j$(nproc) CXXFLAGS="-O2 -flto" >> $log 2>&1 || {
         echo_error "Something went wrong while making libtorrent"
         exit 1
     }
@@ -161,7 +161,7 @@ function build_rtorrent() {
         echo_error "Something went wrong while configuring rtorrent"
         exit 1
     }
-    make -j$(nproc) >> $log 2>&1 || {
+    make -j$(nproc) CXXFLAGS="-O2 -flto" >> $log 2>&1 || {
         echo_error "Something went wrong while making rtorrent"
         exit 1
     }


### PR DESCRIPTION
## Description

1. Forces xmlrpc-c to use curl transport to reduce overhead and increase disk i/o throughput.
2. Builds rtorrent and libtorrent (rakshasa) with level 2 optimizations for a stable performance increase on all platforms.
3. Builds xmlrpc-c, rtorrent and libtorrent (rakshasa) with Link Time Compile optimizations. The advantage of these is smaller binaries and better performance. The disadvantage is less debugging information and slightly longer compile times. 

## Change Categories
- Bug fix <!-- non-breaking change which fixes an issue -->
- New feature <!-- non-breaking change which adds functionality -->
- Change in `functions` <!-- e.g. `utils`, `os`, `apt`, `ask`, etc. -->

## Checklist
- [X] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [X] Docs have been made OR are not necessary
    - PR link: 
- [X] Changes to panel have been made OR are not necessary
    - PR link: 
- [X] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [X] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [X] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [X] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] Testing was done
   - [X] Tests created or no new tests necessary
   - [X] Tests executed

## Test scenarios
Build tested on Ubuntu 20.04.4 LTS HWE. 
- Special Note: `-flto` is compatible with xmlrpc-c, rtorrent and libtorrent with no changes required.

### Architectures
|   			| `amd64` 	| `armhf` 	| `arm64` 	| Unspecified 	|
|--------		|-------- 	|-------- 	|-------- 	|----------		|
| Focal 		|	✅		|			|			|				|
| Bionic		|			|			|			|				|
| Buster		|			|			|			|				|
| Stretch		|			|			|			|				|
| Raspbian  	|	⚫️		|			|	⚫️		|	⚫️			|

### ✅❎ Passed

### 🛠🛠 TODO

### ❌❌ Currently failing