### PR TITLE
fix(jellyfin): bad deb syntax

### DIFF
--- a/scripts/install/jellyfin.sh
+++ b/scripts/install/jellyfin.sh
@@ -91,7 +91,7 @@ CONFIG
 #
 # Add the jellyfin official repository and key to our installation so we can use apt-get to install it jellyfin and jellyfin-ffmepg.
 curl -s "https://repo.jellyfin.org/$DIST_ID/jellyfin_team.gpg.key" | gpg --dearmor > /usr/share/keyrings/jellyfin-archive-keyring.gpg 2>> "${log}"
-echo "deb [signed-by=/usr/share/keyrings/jellyfin-archive-keyring.gpg] [arch=$(dpkg --print-architecture)] https://repo.jellyfin.org/$DIST_ID $DIST_CODENAME main" > /etc/apt/sources.list.d/jellyfin.list
+echo "deb [signed-by=/usr/share/keyrings/jellyfin-archive-keyring.gpg arch=$(dpkg --print-architecture)] https://repo.jellyfin.org/$DIST_ID $DIST_CODENAME main" > /etc/apt/sources.list.d/jellyfin.list
 #
 # install jellyfin and jellyfin-ffmepg using apt functions.
 apt_update #forces apt refresh

--- a/scripts/update/jellyfin.sh
+++ b/scripts/update/jellyfin.sh
@@ -72,7 +72,7 @@ if [[ -f /install/.jellyfin.lock ]]; then
         #
         # Add the jellyfin official repository and key to our installation so we can use apt-get to install it jellyfin and jellyfin-ffmepg.
         curl -s https://repo.jellyfin.org/$DIST_ID/jellyfin_team.gpg.key | gpg --dearmor > /usr/share/keyrings/jellyfin-archive-keyring.gpg 2>> "${log}"
-        echo "deb [signed-by=/usr/share/keyrings/jellyfin-archive-keyring.gpg] [arch=$(dpkg --print-architecture)] https://repo.jellyfin.org/$DIST_ID $DIST_CODENAME main" > /etc/apt/sources.list.d/jellyfin.list
+        echo "deb [signed-by=/usr/share/keyrings/jellyfin-archive-keyring.gpg arch=$(dpkg --print-architecture)] https://repo.jellyfin.org/$DIST_ID $DIST_CODENAME main" > /etc/apt/sources.list.d/jellyfin.list
         #
         # install jellyfin and jellyfin-ffmepg using apt functions.
         apt_update #forces apt refresh


### PR DESCRIPTION
Fix:

```
E: Malformed entry 1 in list file /etc/apt/sources.list.d/jellyfin.list (URI parse)
E: The list of sources could not be read.
ERROR   Apt failed.
```

Can't fix the install missing deps though :disappointed: 