### PR TITLE
fix(panel): botched permissions and hardcode reset paths

### DIFF
--- a/scripts/update/panel.sh
+++ b/scripts/update/panel.sh
@@ -38,7 +38,8 @@ if [[ -f /install/.panel.lock ]]; then
             pyenv_create_venv 3.8.6 /opt/.venv/swizzin
             chown -R swizzin: /opt/.venv/swizzin
         fi
-
+        chown -R swizzin: /opt/swizzin
+        chown -R swizzin: /opt/.venv/swizzin
         bash /usr/local/bin/swizzin/upgrade/panel.sh
         echo_progress_done
     fi

--- a/scripts/upgrade/panel.sh
+++ b/scripts/upgrade/panel.sh
@@ -23,6 +23,7 @@ if [[ -f /install/.panel.lock ]]; then
     if ! /opt/.venv/swizzin/bin/python /opt/swizzin/tests/test_requirements.py >> ${log} 2>&1; then
         /opt/.venv/swizzin/bin/pip install --upgrade pip wheel >> ${log} 2>&1
         /opt/.venv/swizzin/bin/pip install -r /opt/swizzin/requirements.txt >> ${log} 2>&1
+        chown -R swizzin: /opt/.venv/swizzin
     fi
     echo_progress_done "Depends up-to-date"
     echo_progress_start "Restarting Panel"

--- a/scripts/upgrade/panel.sh
+++ b/scripts/upgrade/panel.sh
@@ -13,10 +13,10 @@ if [[ -f /install/.panel.lock ]]; then
     if [[ $PANELRESET == 1 ]]; then
         echo_warn "Working around unclean git repo"
         sudo -u swizzin git -C /opt/swizzin fetch origin master >> ${log} 2>&1
-        cp -a core/custom core/custom.tmp
+        cp -a /opt/swizzin/core/custom /opt/swizzin/core/custom.tmp
         sudo -u swizzin git -C /opt/swizzin reset --hard origin/master >> ${log} 2>&1
-        mv core/custom.tmp/* core/custom/ >> ${log} 2>&1
-        rm -rf core/custom.tmp
+        mv /opt/swizzin/core/custom.tmp/* /opt/swizzin/core/custom/ >> ${log} 2>&1
+        rm -rf opt/swizzin/core/custom.tmp
     fi
     echo_progress_done "Commits pulled"
     echo_progress_start "Checking pip for new depends"


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description
<!-- Any general story time goes here :) Feel free to add screenshots/recording of your change in action here-->

## Fixes issues: 
- Discord report

```
INFO    Currently on branch: develop
...     Updating swizzin local repository
        ✔   Local repository updated using: develop
INFO    HEAD is now set to 7629805
...     Setting correct permissions on swizzin files
        ✔   Permissions set
...     Updating panel to latest version
...     Pulling new commits
WARN    Working around unclean git repo
cp: cannot stat 'core/custom': No such file or directory
        ✔   Commits pulled
...     Checking pip for new depends
        ✔   Depends up-to-date
...     Restarting Panel
        ✔   Done!
        ✔   Done
error: cannot open .git/FETCH_HEAD: Permission denied
```