### PR TITLE
update(rtx): DarkBetter and MaterialDesign as ruTorrent submodules

### DIFF
--- a/scripts/rtx
+++ b/scripts/rtx
@@ -285,23 +285,17 @@ function _itthemes() {
         echo_info "Installing ${result}"
         cd /srv/rutorrent/plugins/theme/themes
         case "$result" in
-            Acid | Blue | Dark | Excel | Oblivion)
+            Acid | Blue | Dark | DarkBetter | Excel | MaterialDesign | Oblivion)
                 svn co https://github.com/Novik/ruTorrent.git/trunk/plugins/theme/themes/${result} ${result} > /dev/null 2>&1
                 ;;
             Agent* | OblivionBlue)
                 svn co https://github.com/ArtyumX/ruTorrent-Themes/trunk/${result} ${result} > /dev/null 2>&1
-                ;;
-            DarkBetter)
-                git clone https://github.com/chocolatkey/DarkBetter.git ${result} > /dev/null 2>&1
                 ;;
             club-QuickBox)
                 git clone https://github.com/QuickBox/club-QuickBox.git ${result} > /dev/null 2>&1
                 ;;
             FlatUI*)
                 svn co https://github.com/exetico/FlatUI.git/trunk/${result} ${result} > /dev/null 2>&1
-                ;;
-            MaterialDesign)
-                git clone https://github.com/phlooo/ruTorrent-MaterialDesign.git ${result} > /dev/null 2>&1
                 ;;
             *)
                 echo_error "$result is invalid"
@@ -316,7 +310,7 @@ function _itthemes() {
 
 function _rmthemes() {
     removea=()
-    themes=(Acid Agent34 Agent46 Blue club-QuickBox Dark Excel FlatUI_Dark FlatUI_Light FlatUI_Material MaterialDesign Oblivion OblivionBlue)
+    themes=(Acid Agent34 Agent46 Blue club-QuickBox Dark DarkBetter Excel FlatUI_Dark FlatUI_Light FlatUI_Material MaterialDesign Oblivion OblivionBlue)
     for i in "${themes[@]}"; do
         themes=${i}
         if [[ -d /srv/rutorrent/plugins/theme/themes/$i ]]; then


### PR DESCRIPTION
## Description
DarkBetter & MaterialDesign are supported by ruTorrent now as recurse submodules!

## Change Categories
- Bug fix <!-- non-breaking change which fixes an issue -->

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Branch was made off the `develop` branch and the PR is targeting the `develop` branch
- [x] Docs have been made OR are not necessary
    - PR link: 
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Testing was done
   - [x] Tests created or no new tests necessary
   - [x] Tests executed

### Architectures
<!--
Please use these emojis here to fill the table below. It will nicely auto-format with spacing, don't worry. Leave empty wherever you do not know / have not tested
✅ = Works successfully
❎ = Does not work BUT is handled gracefully
🛠 = Still WIP
❌ = Broken / not working
-->
|   			| `amd64` 	| `armhf` 	| `arm64` 	| Unspecified 	|
|--------		|-------- 	|-------- 	|-------- 	|----------		|
| Jammy 		|	✅		|			|			|				|
| Focal 		|			|			|			|				|
| Bionic		|			|			|			|				|
| Bullseye		|			|			|			|				|
| Buster		|			|			|			|				|
| Stretch		|			|			|			|				|
| Raspbian  	|	⚫️		|			|	⚫️		|	⚫️			|