### PR TITLE
fix(x2go): debian keychain quirk

### DIFF
--- a/scripts/install/x2go.sh
+++ b/scripts/install/x2go.sh
@@ -42,6 +42,7 @@ deb-src [signed-by=/usr/share/keyrings/x2go-archive-keyring.gpg] http://packages
 #deb-src [signed-by=/usr/share/keyrings/x2go-archive-keyring.gpg] http://packages.x2go.org/debian ${release} heuler
 EOF
     echo_progress_done "Repo added"
+    mkdir -m 700 /root/.gnupg
     gpg --no-default-keyring --keyring /usr/share/keyrings/x2go-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys E1F958385BFE2B6E >> ${log} 2>&1
     apt_update
     apt_install x2go-keyring


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description
Fixes Debian quirk

Weird logging about dirmngr not existing or being able to do stuff to a directory. dirmngr is obviously installed...

Create root dir it complains about not existing and problem goes away.

## Fixes issues: 
- Discord reports:

The x2go script seems to just refuse to import the key
Manually running the import command; 
```
 gpg --no-default-keyring --keyring /usr/share/keyrings/x2go-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys E1F958385BFE2B6E >> ${log} 2>&1
```
As root resolves all of it
The last one I did just now did not have the key in place



