### PR TITLE
fix: prevent log clobbering

### DIFF
--- a/scripts/nginx/autodl.sh
+++ b/scripts/nginx/autodl.sh
@@ -12,7 +12,7 @@ users=($(cut -d: -f1 < /etc/htpasswd))
 if [[ -f /install/.rutorrent.lock ]]; then
     cd /srv/rutorrent/plugins/
     if [[ ! -d /srv/rutorrent/plugins/autodl-irssi ]]; then
-        git clone https://github.com/swizzin/autodl-rutorrent.git autodl-irssi > ${log} 2>&1 || { echo_error "git of autodl plugin to main plugins seems to have failed"; }
+        git clone https://github.com/swizzin/autodl-rutorrent.git autodl-irssi >> ${log} 2>&1 || { echo_error "git of autodl plugin to main plugins seems to have failed"; }
         chown -R www-data:www-data autodl-irssi/
     fi
     for u in "${users[@]}"; do

--- a/sources/functions/mono
+++ b/sources/functions/mono
@@ -6,7 +6,7 @@ function mono_repo_setup() {
     if [[ ! -f /etc/apt/sources.list.d/mono-xamarin.list ]]; then
         case $(_os_codename) in
             stretch | buster | bionic)
-                gpg --no-default-keyring --keyring /usr/share/keyrings/mono-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF > ${log} 2>&1
+                gpg --no-default-keyring --keyring /usr/share/keyrings/mono-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF >> ${log} 2>&1
                 echo "deb [signed-by=/usr/share/keyrings/mono-archive-keyring.gpg] https://download.mono-project.com/repo/${distribution} ${codename}/snapshots/6.8/. main" > /etc/apt/sources.list.d/mono-xamarin.list
                 apt_update
                 ;;

--- a/sources/functions/pyenv
+++ b/sources/functions/pyenv
@@ -33,7 +33,7 @@ function pyenv_update() {
 # - `$1` = The version necessary
 function pyenv_install_version() {
     version=$1
-    versions=$(/opt/pyenv/bin/pyenv versions 2> "$log")
+    versions=$(/opt/pyenv/bin/pyenv versions 2>> "$log")
     if [[ ! $versions =~ $version ]]; then
         echo_progress_start "Compiling Python $version. This may take some time"
         /opt/pyenv/bin/pyenv install "$version" >> "$log" 2>&1


### PR DESCRIPTION
## Description
Fixes a few instances where swizzin.log would get clobbered due to the use of a single '>' operator.

The following instances were identified:
```
$ grep -E '[^>]>[^>]\s?('\''|")?(\$log|\${log})' -Rn .
./scripts/nginx/autodl.sh:15:        git clone https://github.com/swizzin/autodl-rutorrent.git autodl-irssi > ${log} 2>&1 || { echo_error "git of autodl plugin to main plugins seems to have failed"; }
./sources/functions/mono:9:                gpg --no-default-keyring --keyring /usr/share/keyrings/mono-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF > ${log} 2>&1
./sources/functions/pyenv:36:    versions=$(/opt/pyenv/bin/pyenv versions 2> "$log")
```

## Fixes issues: 
- Un-tracked issue

## Proposed Changes:
- Add an extra '>'

## Change Categories
- Bug fix

## Checklist
- [x] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [x] Docs have been made OR are not necessary
- [x] Changes to panel have been made OR are not necessary
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Testing was done
   - [x] Tests created or no new tests necessary
   - [x] Tests executed

## Test scenarios

### Architectures
<!--
Please use these emojis here to fill the table below. It will nicely auto-format with spacing, don't worry. Leave empty wherever you do not know / have not tested
✅ = Works successfully
❎ = Does not work BUT is handled gracefully
🛠 = Still WIP
❌ = Broken / not working
-->
|   			| `amd64` 	| `armhf` 	| `arm64` 	| Unspecified 	|
|--------		|-------- 	|-------- 	|-------- 	|----------		|
| Jammy 		|			|			|			|				|
| Focal 		|		✅	|			|			|				|
| Bionic		|			|			|			|				|
| Bullseye		|			|			|			|				|
| Buster		|			|			|			|				|
| Stretch		|			|			|			|				|
| Raspbian  	|	⚫️		|			|	⚫️		|	⚫️			|
