### PR TITLE
feat(rtorrent): add user patch file support

### DIFF
--- a/sources/functions/rtorrent
+++ b/sources/functions/rtorrent
@@ -112,6 +112,15 @@ function build_libtorrent_rakshasa() {
     tar -xvf /tmp/libtorrent-${libtorrentver}.tar.gz -C /tmp/libtorrent --strip-components=1 >> $log 2>&1
     cd /tmp/libtorrent >> $log 2>&1
 
+    if [[ -f /root/libtorrent-rakshasa-${libtorrentver}.patch ]]; then
+        patch -p1 < /root/libtorrent-rakshasa-${libtorrentver}.patch >> ${log} 2>&1 || {
+            echo _error "Something went wrong when patching libtorrent-rakshasa"
+            exit 1
+        }
+        echo_info "Libtorrent-rakshasa patch found and applied!"
+    else
+        echo_log_only "No libtorrent-rakshasa patch found at /root/libtorrent-rakshasa-${libtorrentver}.patch"
+    fi
     if [[ ${libtorrentver} =~ ^("0.13.6"|"0.13.7")$ ]]; then
         patch -p1 < /etc/swizzin/sources/patches/rtorrent/openssl.patch >> "$log" 2>&1
         if pkg-config --atleast-version=1.14 cppunit && [[ ${libtorrentver} == 0.13.6 ]]; then
@@ -150,6 +159,15 @@ function build_rtorrent() {
     tar -xzvf /tmp/rtorrent-${rtorrentver}.tar.gz -C /tmp/rtorrent --strip-components=1 >> $log 2>&1
     VERSION=$rtorrentver
     cd /tmp/rtorrent
+    if [[ -f /root/rtorrent-${rtorrentver}.patch ]]; then
+        patch -p1 < /root/rtorrent-${rtorrentver}.patch >> ${log} 2>&1 || {
+            echo _error "Something went wrong when patching rTorrent"
+            exit 1
+        }
+        echo_info "rTorrent patch found and applied!"
+    else
+        echo_log_only "No rTorrent patch found at /root/rtorrent-${rtorrentver}.patch"
+    fi
     #apply xmlrpc-fix to all rtorrents
     patch -p1 < /etc/swizzin/sources/patches/rtorrent/xmlrpc-fix.patch >> "$log" 2>&1
     #use pkgconfig for cppunit if 0.9.6


### PR DESCRIPTION
## Description
Adds user-supplied patch file support for libtorrent-rakshasa and rtorrent, in the same fashion as is currently implemented for libtorrent-rasterbar. This makes it easier for users to apply their own bugfix patches to work around the slow pace of rtorrent releases.

Patch files are expected in /root with the following example file names:

```
/root/libtorrent-rakshasa-0.13.8.patch
/root/rtorrent-0.9.8.patch
```

## Fixes issues: 
- Un-tracked issue...

## Proposed Changes:
- Add user-supplied patch file support for libtorrent-rakshasa and rtorrent

## Change Categories
- New feature <!-- non-breaking change which adds functionality -->

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [ ] Docs have been made OR are not necessary
    - I'll submit a docs PR if this gets merged
- [x] Changes to panel have been made OR are not necessary
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Testing was done
   - [x] Tests created or no new tests necessary
   - [x] Tests executed

## Test scenarios
<!-- Please let us know what has been done or anything else that works/doesn't. Feel free to copy-paste the examples at the bottom of this section -->

### Architectures
<!--
Please use these emojis here to fill the table below. It will nicely auto-format with spacing, don't worry. Leave empty wherever you do not know / have not tested
✅ = Works successfully
❎ = Does not work BUT is handled gracefully
🛠 = Still WIP
❌ = Broken / not working
-->
|   			| `amd64` 	| `armhf` 	| `arm64` 	| Unspecified 	|
|--------		|-------- 	|-------- 	|-------- 	|----------		|
| Jammy 		|		✅	|			|			|				|
| Focal 		|			|			|			|				|
| Bionic		|			|			|			|				|
| Bullseye		|			|			|			|				|
| Buster		|			|			|			|				|
| Stretch		|			|			|			|				|
| Raspbian  	|	⚫️		|			|	⚫️		|	⚫️			|

Tested various scenarios including different rtorrent/libtorrent versions and when no patch file is present. The logic for libtorrent-rasterbar is reused so there shouldn't be any differences here.
