### PR TITLE
Let `nginx` handle SSL and redirect to HTTP

### DIFF
--- a/scripts/nginx/jellyfin.sh
+++ b/scripts/nginx/jellyfin.sh
@@ -24,7 +24,7 @@ fi
 # Create our nginx application conf for jellyfin
 cat > /etc/nginx/apps/jellyfin.conf <<- NGINXCONF
 	location /jellyfin {
-		proxy_pass https://127.0.0.1:8920;
+		proxy_pass http://127.0.0.1:8096;
 		#
 		proxy_pass_request_headers on;
 		#


### PR DESCRIPTION
## Description
Out of the box Jellyfin won't connect unless you connect directly (ie `http://<ip-address>:8096`). `http://<ip-address>/jellyfin` will give a `502` because HTTPS isn't set up by default on Jellyfin (nor should it be Jellyfin's responsibility to handle SSL/HTTPS, that's the job of the reverse proxy). Therefore by referring to the HTTP port of Jellyfin, we can avoid the chicken egg scenario and let `nginx` do what it's designed to do.

## Fixes issues: 
- Issue #810 
- Related to #587 

## Proposed Changes:
- Changed Nginx to proxy to HTTP Jellyfin rather than HTTPS Jellyfin, as we already have HTTPS from Client to Nginx, which makes HTTPS between reverse proxy and Jellyfin redundant.

## Change Categories
- Bug fix <!-- non-breaking change which fixes an issue -->
- I doubt it would be a breaking change, but I suppose it could be if some users have modified their Jellyfin config to only support HTTPS rather than letting `nginx` handling SSL 
- 
## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [x] Docs have been made OR are not necessary
    - PR link: 
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Testing was done
   - [x] Tests created or no new tests necessary
   - [ ] Tests executed

