### PR TITLE
fix(deluge): don't chmod deluge.UpdateTracker.py in working tree

### DIFF
--- a/sources/functions/deluge
+++ b/sources/functions/deluge
@@ -239,7 +239,6 @@ function build_deluge() {
     mkdir -p /root/dist
     fpm ${args} --python-fix-dependencies --python-bin=${pythonver} --python-package-name-prefix=${pythonver} --python-setup-py-arguments=--install-layout=deb -n deluge-common -f -p /root/dist/deluge-common_VERSION.deb --description "Deluge compiled by swizzin" -s python -t deb /tmp/deluge/setup.py >> "${log}" 2>&1
     dpkg -i /root/dist/deluge-common_${VERSION}.deb >> "${log}" 2>&1
-    chmod 644 /etc/swizzin/scripts/deluge.UpdateTracker.py
     if [[ ${DELUGE_VERSION} == 1.3-stable ]]; then
         #update-tracker is built into v2 (update_tracker)
         cp /etc/swizzin/scripts/deluge.UpdateTracker.py "/usr/lib/${distver}/dist-packages/deluge/ui/console/commands/update-tracker.py"


### PR DESCRIPTION
## Description
The mode on `/etc/swizzin/scripts/deluge.UpdateTracker.py` gets set to 644 during each deluge installation which results in git's working tree being left in a modified state. As far as I can tell this is unnecessary as chmod is always called on the destination file after it's copied, I may have missed something however. It's a slight pain to need to discard the change each time.

```
$ git status -s
 M scripts/deluge.UpdateTracker.py
?? scripts/scripts
$ git diff
diff --git a/scripts/deluge.UpdateTracker.py b/scripts/deluge.UpdateTracker.py
old mode 100755
new mode 100644
```

```
$ grep "deluge.UpdateTracker.py" -Rn . -C 1
./sources/functions/deluge-241-    dpkg -i /root/dist/deluge-common_${VERSION}.deb >> "${log}" 2>&1
./sources/functions/deluge:242:    chmod 644 /etc/swizzin/scripts/deluge.UpdateTracker.py
./sources/functions/deluge-243-    if [[ ${DELUGE_VERSION} == 1.3-stable ]]; then
./sources/functions/deluge-244-        #update-tracker is built into v2 (update_tracker)
./sources/functions/deluge:245:        cp /etc/swizzin/scripts/deluge.UpdateTracker.py "/usr/lib/${distver}/dist-packages/deluge/ui/console/commands/update-tracker.py"
./sources/functions/deluge-246-        chmod 644 /usr/lib/${distver}/dist-packages/deluge/ui/console/commands/update-tracker.py
--
./sources/functions/deluge-278-    if [[ $dver =~ ^1\. ]]; then
./sources/functions/deluge:279:        cp /etc/swizzin/scripts/deluge.UpdateTracker.py /usr/lib/python2.7/dist-packages/deluge/ui/console/commands/update-tracker.py
./sources/functions/deluge-280-        chmod 644 /usr/lib/python2.7/dist-packages/deluge/ui/console/commands/update-tracker.py
```

## Fixes issues: 
- Un-tracked issue

## Proposed Changes:
- Remove the chmod line

## Change Categories
- Bug fix <!-- non-breaking change which fixes an issue -->

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [x] Docs ~~have been made OR~~ are not necessary
- [x] Changes to panel have been made OR are not necessary
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Testing was done
   - [x] ~~Tests created or~~ no new tests necessary

### Architectures
<!--
Please use these emojis here to fill the table below. It will nicely auto-format with spacing, don't worry. Leave empty wherever you do not know / have not tested
✅ = Works successfully
❎ = Does not work BUT is handled gracefully
🛠 = Still WIP
❌ = Broken / not working
-->
|   			| `amd64` 	| `armhf` 	| `arm64` 	| Unspecified 	|
|--------		|-------- 	|-------- 	|-------- 	|----------		|
| Jammy 		|	✅		|			|			|				|
| Focal 		|			|			|			|				|
| Bionic		|			|			|			|				|
| Bullseye		|			|			|			|				|
| Buster		|			|			|			|				|
| Stretch		|			|			|			|				|
| Raspbian  	|	⚫️		|			|	⚫️		|	⚫️			|
