### PR TITLE
qbittorrent: add env variable to support choosing branch in 4.4.x

### DIFF
--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -130,8 +130,10 @@ function qbittorrent_version_info() {
                         ;;
                     *)
                         echo_error "LIBTORRENT_VERSION must be either RC_1_2 or RC_2_0. You entered ${LIBTORRENT_VERSION}."
+                        exit 1
                         ;;
                 esac
+                echo_info "Overriding libtorrent version with ${LIBTORRENT_VERSION}"
             else
                 libtorrent_branch=RC_1_2
             fi

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -120,7 +120,21 @@ function qbittorrent_version_info() {
             build_type=autotools
             ;;
         4.4.*)
-            libtorrent_branch=RC_1_2
+            if [[ -n ${LIBTORRENT_VERSION} ]]; then
+                case $LIBTORRENT_VERSION in
+                    RC_2_0)
+                        libtorrent_branch=RC_2_0
+                        ;;
+                    RC_1_2)
+                        libtorrent_branch=RC_1_2
+                        ;;
+                    *)
+                        echo_error "LIBTORRENT_VERSION must be either RC_1_2 or RC_2_0. You entered ${LIBTORRENT_VERSION}."
+                        ;;
+                esac
+            else
+                libtorrent_branch=RC_1_2
+            fi
             libtorrent_minimum_version=1.2.12
             stdcver="c++17"
             qt_minimum_version=6.0


### PR DESCRIPTION
Following qbit's lead, RC_1_2 is now the default branch for 4.4.x

installer will use branch 2.0 with the `LIBTORRENT_VERSION` env variable, if for some deranged reason you still want to use this branch
```
export LIBTORRENT_VERSION=RC_2_0
box install qbittorrent
```

Also accepts RC_1_2 as a variable, though this is now the default.