### PR TITLE
netdata: fix uninstaller

### DIFF
--- a/scripts/remove/netdata.sh
+++ b/scripts/remove/netdata.sh
@@ -7,11 +7,11 @@ if [[ -f /usr/libexec/netdata/netdata-uninstaller.sh ]]; then
         exit 1
     }
 else
-    bash <(curl -Ssf https://my-netdata.io/kickstart.sh 2> ${log} || { echo "exit 1"; }) --uninstall --non-interactive >> $log 2>&1 || {
+    bash <(curl -Ssf https://my-netdata.io/kickstart.sh 2>> ${log} || { echo "exit 1"; }) --uninstall --non-interactive >> $log 2>&1 || {
         echo_error "Netdata remover failed!"
         exit 1
     }
 fi
 rm /etc/nginx/apps/netdata.conf
-systemctl reload nginx ${log} 2>&1
+systemctl reload nginx >> ${log} 2>&1
 rm -rf /install/.netdata.lock

--- a/scripts/remove/netdata.sh
+++ b/scripts/remove/netdata.sh
@@ -1,9 +1,15 @@
 #! /bin/bash
 # Netdata uninstaller for swizzin
 
-/usr/libexec/netdata/netdata-uninstaller.sh --yes --env /etc/netdata/.environment -f >> $log 2>&1 || {
-    echo_error "Netdata remover failed!"
-    exit 1
-}
-
+if [[ -f /usr/libexec/netdata/netdata-uninstaller.sh ]]; then
+    /usr/libexec/netdata/netdata-uninstaller.sh --yes --env /etc/netdata/.environment -f >> $log 2>&1 || {
+        echo_error "Netdata remover failed!"
+        exit 1
+    }
+else
+    bash <(curl -Ssf https://my-netdata.io/kickstart.shaf 2> ${log} || { echo "exit 1"; }) --uninstall --non-interactive >> $log 2>&1 || {
+        echo_error "Netdata remover failed!"
+        exit 1
+    }
+fi
 rm -rf /install/.netdata.lock

--- a/scripts/remove/netdata.sh
+++ b/scripts/remove/netdata.sh
@@ -7,9 +7,11 @@ if [[ -f /usr/libexec/netdata/netdata-uninstaller.sh ]]; then
         exit 1
     }
 else
-    bash <(curl -Ssf https://my-netdata.io/kickstart.shaf 2> ${log} || { echo "exit 1"; }) --uninstall --non-interactive >> $log 2>&1 || {
+    bash <(curl -Ssf https://my-netdata.io/kickstart.sh 2> ${log} || { echo "exit 1"; }) --uninstall --non-interactive >> $log 2>&1 || {
         echo_error "Netdata remover failed!"
         exit 1
     }
 fi
+rm /etc/nginx/apps/netdata.conf
+systemctl reload nginx ${log} 2>&1
 rm -rf /install/.netdata.lock


### PR DESCRIPTION
Fixes #906 

Uninstall netdata as per docs:

https://learn.netdata.cloud/docs/agent/packaging/installer/uninstall

I guess they no longer ship a uninstaller with the installer :woman_facepalming: 