### PR TITLE
mango: fix dl links and add arm support

### DIFF
--- a/scripts/install/mango.sh
+++ b/scripts/install/mango.sh
@@ -9,16 +9,17 @@ mangousr="mango"
 # Downloading the latest binary
 function _install_mango() {
     echo_progress_start "Downloading binary"
+    mango_latest=$(github_latest_version getmango/Mango)
 
     case "$(_os_arch)" in
-        "arm64" | "arm32")
-            # TODO this needs the build process for amr
-            # dlurl=$(curl -s https://api.github.com/repos/hkalexling/Mango/releases/latest | grep "browser_download_url" | grep "$(_os_arch)" | cut -d\" -f 4)
-            echo_error "Currently unsupported but might be in the future. Please check back later!\nhttps://github.com/hkalexling/Mango/issues/131"
-            exit 1
+        "arm64")
+            dlurl="https://github.com/getmango/Mango/releases/download/${mango_latest}/mango-arm64v8.o"
+            ;;
+        "arm32")
+            dlurl="https://github.com/getmango/Mango/releases/download/${mango_latest}/mango-arm32v7.o"
             ;;
         "amd64")
-            dlurl=$(curl -s https://api.github.com/repos/hkalexling/Mango/releases/latest | grep "browser_download_url" | head -1 | cut -d\" -f 4)
+            dlurl="https://github.com/getmango/Mango/releases/download/${mango_latest}/mango"
             ;;
         *)
             echo_error "Unsupported arch?"


### PR DESCRIPTION
Fixes #895

Uses the new github release version function as this is the "new" method for grabbing release URLs.

Added support for arm binaries since they exist now

Tested and working on Bullseye