### PR TITLE
fix: libtorrent versioning & deluge 2.1 support

### DIFF
--- a/scripts/install/qbittorrent.sh
+++ b/scripts/install/qbittorrent.sh
@@ -31,8 +31,10 @@ case ${QBITTORRENT_VERSION} in
     *)
         detect_libtorrent_rasterbar_conflict qbittorrent
         qbittorrent_version_info
-        #check_client_compatibility
         install_fpm
+        if [[ $build_type == "cmake" ]]; then
+            install_cmake_swizzin
+        fi
         check_swap_on
 
         if ! skip_libtorrent_qbittorrent; then

--- a/scripts/install/qbittorrent.sh
+++ b/scripts/install/qbittorrent.sh
@@ -32,9 +32,6 @@ case ${QBITTORRENT_VERSION} in
         detect_libtorrent_rasterbar_conflict qbittorrent
         qbittorrent_version_info
         install_fpm
-        if [[ $build_type == "cmake" ]]; then
-            install_cmake_swizzin
-        fi
         check_swap_on
 
         if ! skip_libtorrent_qbittorrent; then

--- a/scripts/upgrade/qbittorrent.sh
+++ b/scripts/upgrade/qbittorrent.sh
@@ -28,9 +28,6 @@ case ${QBITTORRENT_VERSION} in
         detect_libtorrent_rasterbar_conflict qbittorrent
         qbittorrent_version_info
         install_fpm
-        if [[ $build_type == "cmake" ]]; then
-            install_cmake_swizzin
-        fi
         check_swap_on
 
         if ! skip_libtorrent_qbittorrent; then

--- a/sources/functions/deluge
+++ b/sources/functions/deluge
@@ -126,30 +126,8 @@ function build_libtorrent_deluge() {
     apt_install ${pythonver}-dev libssl-dev
     rm_if_exists /tmp/libtorrent
 
-    libtorrent_github_tags_list=$(git ls-remote -q -t --refs https://github.com/arvidn/libtorrent.git | awk '/\/v/{sub("refs/tags/", "");sub("(.*)(-[^0-9].*)(.*)", ""); print $2 }' | awk '!/^$/' | sort -rV)
-
-    case $libtorrent_branch in
-        RC_1_1)
-            libtorrent_github_tag=RC_1_1
-            ;;
-        RC_1_2)
-            d_libtorrent_version=1.2
-            ;;
-        RC_2_0)
-            d_libtorrent_version=2.0
-            ;;
-        *)
-            d_libtorrent_version=1.2
-            ;;
-    esac
-
-    libtorrent_github_tag_default="$(grep -Eom1 "v${d_libtorrent_version}.([0-9]{1,2})" <<< "${libtorrent_github_tags_list}")"
-    libtorrent_github_tag="${libtorrent_github_tag:-$libtorrent_github_tag_default}"
-
-    git clone --no-tags --single-branch --branch "${libtorrent_github_tag}" --shallow-submodules --recurse-submodules -j"$(nproc)" --depth 1 "https://github.com/arvidn/libtorrent.git" "/tmp/libtorrent" >> ${log} 2>&1 || {
-        echo_error "Libtorrent could not be cloned from git. Setup will not proceed"
-        exit 1
-    }
+    export "${libtorrent_branch}"
+    libtorrent_clone
 
     cd /tmp/libtorrent
     VERSION=$(grep AC_INIT configure.ac | grep -oP '\d+\.\d+\.\d+')

--- a/sources/functions/deluge
+++ b/sources/functions/deluge
@@ -5,7 +5,7 @@ function whiptail_deluge() {
     if [[ -z $DELUGE_VERSION ]]; then
         repov=$(get_candidate_version deluge)
         # todo: add deluge 2.1 to whiptail menu
-        function=$(whiptail --title "Install Software" --menu "Choose a Deluge version:" --ok-button "Continue" --nocancel 12 50 3 \
+        function=$(whiptail --title "Install Software" --menu "Choose a Deluge version:" --ok-button "Continue" --nocancel 12 50 4 \
             "Repo" "${repov}" \
             "Deluge 1.3" "" \
             "Deluge 2.0" "" \

--- a/sources/functions/deluge
+++ b/sources/functions/deluge
@@ -118,6 +118,7 @@ function build_libtorrent_deluge() {
     case $libtorrent_branch in
         RC_1_1)
             d_libtorrent_version=1.1
+            ;;
         RC_1_2)
             d_libtorrent_version=1.2
             ;;

--- a/sources/functions/deluge
+++ b/sources/functions/deluge
@@ -117,8 +117,7 @@ function build_libtorrent_deluge() {
 
     case $libtorrent_branch in
         RC_1_1)
-            libtorrent_github_tag=RC_1_1
-            ;;
+            d_libtorrent_version=1.1
         RC_1_2)
             d_libtorrent_version=1.2
             ;;

--- a/sources/functions/deluge
+++ b/sources/functions/deluge
@@ -79,7 +79,23 @@ function deluge_version_info() {
             ;;
         2.0.x)
             cryptography=openssl
-            libtorrent_branch=RC_1_2
+            if [[ -n ${LIBTORRENT_VERSION} ]]; then
+                case $LIBTORRENT_VERSION in
+                    RC_2_0)
+                        libtorrent_branch=RC_2_0
+                        ;;
+                    RC_1_2)
+                        libtorrent_branch=RC_1_2
+                        ;;
+                    *)
+                        echo_error "LIBTORRENT_VERSION must be either RC_1_2 or RC_2_0. You entered ${LIBTORRENT_VERSION}."
+                        exit 1
+                        ;;
+                esac
+                echo_info "Overriding libtorrent version with ${LIBTORRENT_VERSION}"
+            else
+                libtorrent_branch=RC_1_2
+            fi
             libtorrent_minimum_version=1.2.0
             pythonver=python3
             pythonmajor=$(get_candidate_version python3 | cut -d. -f1-2)
@@ -88,7 +104,23 @@ function deluge_version_info() {
             ;;
         master)
             cryptography=openssl
-            libtorrent_branch=RC_1_2
+            if [[ -n ${LIBTORRENT_VERSION} ]]; then
+                case $LIBTORRENT_VERSION in
+                    RC_2_0)
+                        libtorrent_branch=RC_2_0
+                        ;;
+                    RC_1_2)
+                        libtorrent_branch=RC_1_2
+                        ;;
+                    *)
+                        echo_error "LIBTORRENT_VERSION must be either RC_1_2 or RC_2_0. You entered ${LIBTORRENT_VERSION}."
+                        exit 1
+                        ;;
+                esac
+                echo_info "Overriding libtorrent version with ${LIBTORRENT_VERSION}"
+            else
+                libtorrent_branch=RC_1_2
+            fi
             libtorrent_minimum_version=1.2.0
             pythonver=python3
             pythonmajor=$(get_candidate_version python3 | cut -d. -f1-2)

--- a/sources/functions/deluge
+++ b/sources/functions/deluge
@@ -111,7 +111,7 @@ function build_libtorrent_deluge() {
     echo "using python : ${pythonmajor} : /usr/bin/${pythonver} : /usr/include/python${pythonmajor} : /usr/lib/python${pythonmajor} ;" >> /root/user-config.jam
     apt_install ${pythonver}-dev libssl-dev
     rm_if_exists /tmp/libtorrent
-    
+
     libtorrent_github_url="https://github.com/arvidn/libtorrent.git"
     libtorrent_github_tags_list=$(git ls-remote -q -t --refs https://github.com/arvidn/libtorrent.git | awk '/\/v/{sub("refs/tags/", "");sub("(.*)(-[^0-9].*)(.*)", ""); print $2 }' | awk '!/^$/' | sort -rV)
 
@@ -133,11 +133,11 @@ function build_libtorrent_deluge() {
     libtorrent_github_tag_default="$(grep -Eom1 "v${d_libtorrent_version}.([0-9]{1,2})" <<< "${libtorrent_github_tags_list}")"
     libtorrent_github_tag="${libtorrent_github_tag:-$libtorrent_github_tag_default}"
 
-    git clone --no-tags --single-branch --branch "${libtorrent_github_tag}" --shallow-submodules --recurse-submodules -j"$(nproc)" --depth 1 "https://github.com/arvidn/libtorrent.git" "/tmp/libtorrent">> ${log} 2>&1 || {
+    git clone --no-tags --single-branch --branch "${libtorrent_github_tag}" --shallow-submodules --recurse-submodules -j"$(nproc)" --depth 1 "https://github.com/arvidn/libtorrent.git" "/tmp/libtorrent" >> ${log} 2>&1 || {
         echo_error "Libtorrent could not be cloned from git. Setup will not proceed"
         exit 1
     }
-    
+
     cd /tmp/libtorrent
     VERSION=$(grep AC_INIT configure.ac | grep -oP '\d+\.\d+\.\d+')
 

--- a/sources/functions/deluge
+++ b/sources/functions/deluge
@@ -4,15 +4,20 @@ function whiptail_deluge() {
     echo_progress_start "Choosing Deluge versions"
     if [[ -z $DELUGE_VERSION ]]; then
         repov=$(get_candidate_version deluge)
+        # todo: add deluge 2.1 to whiptail menu
         function=$(whiptail --title "Install Software" --menu "Choose a Deluge version:" --ok-button "Continue" --nocancel 12 50 3 \
             "Repo" "${repov}" \
             "Deluge 1.3" "" \
-            "Deluge 2.0" "" 3>&1 1>&2 2>&3)
+            "Deluge 2.0" "" \
+            "Deluge 2.1" "" 3>&1 1>&2 2>&3)
         case $function in
             "Deluge 1.3")
                 export DELUGE_VERSION=1.3-stable
                 ;;
             "Deluge 2.0")
+                export DELUGE_VERSION=2.0.x
+                ;;
+            "Deluge 2.1")
                 export DELUGE_VERSION=master
                 ;;
             "Repo")
@@ -72,6 +77,15 @@ function deluge_version_info() {
             python=python
             deluge_git_branch=deluge-1.3.15
             ;;
+        2.0.x)
+            cryptography=openssl
+            libtorrent_branch=RC_1_2
+            libtorrent_minimum_version=1.2.0
+            pythonver=python3
+            pythonmajor=$(get_candidate_version python3 | cut -d. -f1-2)
+            python=python3
+            deluge_git_branch=2.0.x
+            ;;
         master)
             cryptography=openssl
             libtorrent_branch=RC_1_2
@@ -112,7 +126,6 @@ function build_libtorrent_deluge() {
     apt_install ${pythonver}-dev libssl-dev
     rm_if_exists /tmp/libtorrent
 
-    libtorrent_github_url="https://github.com/arvidn/libtorrent.git"
     libtorrent_github_tags_list=$(git ls-remote -q -t --refs https://github.com/arvidn/libtorrent.git | awk '/\/v/{sub("refs/tags/", "");sub("(.*)(-[^0-9].*)(.*)", ""); print $2 }' | awk '!/^$/' | sort -rV)
 
     case $libtorrent_branch in
@@ -194,7 +207,7 @@ function build_deluge() {
         noexec=1
     fi
     case $DELUGE_VERSION in
-        master)
+        master | 2.0.x)
             LIST='python3 python3-setuptools python3-pip intltool python3-zope.interface python3-twisted python3-openssl python3-xdg python3-chardet python3-mako python3-setproctitle python3-rencode python3-pil librsvg2-common xdg-utils'
             pythonver=python3
             distver=python3
@@ -361,7 +374,7 @@ function ltconfig() {
             if ls /etc/skel/.config/deluge/plugins/ltConfig-2* > /dev/null 2>&1; then rm -f /etc/skel/.config/deluge/plugins/ltConfig-2*; fi
             if ls /home/${u}/.config/deluge/plugins/ltConfig-2* > /dev/null 2>&1; then rm -f /home/${u}/.config/deluge/plugins/ltConfig-2*; fi
             ;;
-        2.0*)
+        2.0* | 2.1*)
             ltcver=2.0.0
             py=
             if [[ -f /etc/skel/.config/deluge/plugins/ltConfig-0.3.1-py2.7.egg ]]; then rm -f /etc/skel/.config/deluge/plugins/ltConfig-0.3.1-py2.7.egg; fi

--- a/sources/functions/deluge
+++ b/sources/functions/deluge
@@ -111,10 +111,32 @@ function build_libtorrent_deluge() {
     echo "using python : ${pythonmajor} : /usr/bin/${pythonver} : /usr/include/python${pythonmajor} : /usr/lib/python${pythonmajor} ;" >> /root/user-config.jam
     apt_install ${pythonver}-dev libssl-dev
     rm_if_exists /tmp/libtorrent
-    git clone -b ${libtorrent_branch} https://github.com/arvidn/libtorrent /tmp/libtorrent >> ${log} 2>&1 || {
+    
+    libtorrent_github_url="https://github.com/arvidn/libtorrent.git"
+    libtorrent_github_tags_list=$(git ls-remote -q -t --refs https://github.com/arvidn/libtorrent.git | awk '/\/v/{sub("refs/tags/", "");sub("(.*)(-[^0-9].*)(.*)", ""); print $2 }' | awk '!/^$/' | sort -rV)
+
+    case $libtorrent_branch in
+        RC_1_1)
+            d_libtorrent_version=1.1
+        RC_1_2)
+            d_libtorrent_version=1.2
+            ;;
+        RC_2_0)
+            d_libtorrent_version=2.0
+            ;;
+        *)
+            d_libtorrent_version=1.2
+            ;;
+    esac
+
+    libtorrent_github_tag_default="$(grep -Eom1 "v${d_libtorrent_version}.([0-9]{1,2})" <<< "${libtorrent_github_tags_list}")"
+    libtorrent_github_tag="${libtorrent_github_tag:-$libtorrent_github_tag_default}"
+
+    git clone --no-tags --single-branch --branch "${libtorrent_github_tag}" --shallow-submodules --recurse-submodules -j"$(nproc)" --depth 1 "https://github.com/arvidn/libtorrent.git" "/tmp/libtorrent">> ${log} 2>&1 || {
         echo_error "Libtorrent could not be cloned from git. Setup will not proceed"
         exit 1
     }
+    
     cd /tmp/libtorrent
     VERSION=$(grep AC_INIT configure.ac | grep -oP '\d+\.\d+\.\d+')
 

--- a/sources/functions/deluge
+++ b/sources/functions/deluge
@@ -374,7 +374,7 @@ function ltconfig() {
             if ls /etc/skel/.config/deluge/plugins/ltConfig-2* > /dev/null 2>&1; then rm -f /etc/skel/.config/deluge/plugins/ltConfig-2*; fi
             if ls /home/${u}/.config/deluge/plugins/ltConfig-2* > /dev/null 2>&1; then rm -f /home/${u}/.config/deluge/plugins/ltConfig-2*; fi
             ;;
-        2.0* | 2.1*)
+        2.*)
             ltcver=2.0.0
             py=
             if [[ -f /etc/skel/.config/deluge/plugins/ltConfig-0.3.1-py2.7.egg ]]; then rm -f /etc/skel/.config/deluge/plugins/ltConfig-0.3.1-py2.7.egg; fi

--- a/sources/functions/deluge
+++ b/sources/functions/deluge
@@ -117,7 +117,7 @@ function build_libtorrent_deluge() {
 
     case $libtorrent_branch in
         RC_1_1)
-            d_libtorrent_version=1.1
+            libtorrent_github_tag=RC_1_1
             ;;
         RC_1_2)
             d_libtorrent_version=1.2

--- a/sources/functions/deluge
+++ b/sources/functions/deluge
@@ -117,7 +117,8 @@ function build_libtorrent_deluge() {
 
     case $libtorrent_branch in
         RC_1_1)
-            d_libtorrent_version=1.1
+            libtorrent_github_tag=RC_1_1
+            ;;
         RC_1_2)
             d_libtorrent_version=1.2
             ;;

--- a/sources/functions/libtorrent
+++ b/sources/functions/libtorrent
@@ -162,3 +162,30 @@ function booststrap() {
         echo_progress_done "Boost installed!"
     fi
 }
+
+function libtorrent_clone() {
+    libtorrent_github_tags_list=$(git ls-remote -q -t --refs https://github.com/arvidn/libtorrent.git | awk '/\/v/{sub("refs/tags/", "");sub("(.*)(-[^0-9].*)(.*)", ""); print $2 }' | awk '!/^$/' | sort -rV)
+
+    case $libtorrent_branch in
+        RC_1_1)
+            libtorrent_github_tag=RC_1_1
+            ;;
+        RC_1_2)
+            tag_libtorrent_version=1.2
+            ;;
+        RC_2_0)
+            tag_libtorrent_version=2.0
+            ;;
+        *)
+            tag_libtorrent_version=1.2
+            ;;
+    esac
+
+    libtorrent_github_tag_default="$(grep -Eom1 "v${tag_libtorrent_version}.([0-9]{1,2})" <<< "${libtorrent_github_tags_list}")"
+    libtorrent_github_tag="${libtorrent_github_tag:-$libtorrent_github_tag_default}"
+
+    git clone --no-tags --single-branch --branch "${libtorrent_github_tag}" --shallow-submodules --recurse-submodules -j"$(nproc)" --depth 1 "https://github.com/arvidn/libtorrent.git" "/tmp/libtorrent" >> ${log} 2>&1 || {
+        echo_error "Libtorrent could not be cloned from git. Setup will not proceed"
+        exit 1
+    }
+}

--- a/sources/functions/libtorrent
+++ b/sources/functions/libtorrent
@@ -141,7 +141,7 @@ function cleanup_repo_libtorrent() {
 }
 
 function booststrap() {
-    BOOST_VERSION=1_75_0
+    BOOST_VERSION=1_80_0
     export BOOST_ROOT=/opt/boost_${BOOST_VERSION}
     export BOOST_INCLUDEDIR=${BOOST_ROOT}
     export BOOST_BUILD_PATH=${BOOST_ROOT}

--- a/sources/functions/libtorrent
+++ b/sources/functions/libtorrent
@@ -141,7 +141,7 @@ function cleanup_repo_libtorrent() {
 }
 
 function booststrap() {
-    BOOST_VERSION=1_80_0
+    BOOST_VERSION=1_75_0
     export BOOST_ROOT=/opt/boost_${BOOST_VERSION}
     export BOOST_INCLUDEDIR=${BOOST_ROOT}
     export BOOST_BUILD_PATH=${BOOST_ROOT}

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -372,9 +372,19 @@ function build_qbittorrent() {
         noexec=1
     fi
     VERSION=${QBITTORRENT_VERSION}
-    LIST='build-essential automake pkg-config libtool git zlib1g-dev libssl-dev libgeoip-dev python3 zlib1g-dev'
-
-    apt_install --no-recommends $LIST
+    case $(_os_codename) in
+        buster)
+            OS_DEPS='libdouble-conversion1 libdouble-conversion-dev'
+            ;;
+        bullseye | jammy)
+            OS_DEPS='libdouble-conversion3 libdouble-conversion-dev libmd4c0 libmd4c-dev libmd4c-html0 libmd4c-html0-dev'
+            ;;
+        *)
+            OS_DEPS=''
+            ;;
+    esac
+    LIST='build-essential automake pkg-config libtool git zlib1g-dev libssl-dev libgeoip-dev python3 libstdc++-*-dev libicu6* libicu-dev'
+    apt_install --no-recommends "$LIST ${OS_DEPS}"
     rm_if_exists "/tmp/qbittorrent"
     wget -O /tmp/release-${VERSION}.tar.gz https://github.com/qbittorrent/qBittorrent/archive/release-${VERSION}.tar.gz >> "${log}" 2>&1 || {
         echo_error "qBittorrent could not be downloaded. Setup will not proceed"

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -99,156 +99,55 @@ function qbittorrent_version_info() {
             libtorrent_branch=RC_1_2
             libtorrent_minimum_version=1.2.11
             stdcver="c++14"
-#!/bin/bash
-
-function whiptail_qbittorrent() {
-    if [[ -z $QBITTORRENT_VERSION ]]; then
-        . /etc/swizzin/sources/functions/apt
-        codename=$(_os_codename)
-        releases=$(git ls-remote -t --refs https://github.com/qbittorrent/qBittorrent.git | awk '{sub("refs/tags/release-", ""); print $2 }' | grep -v -e "beta" -e "rc" | sort -Vr)
-
-        latestv41=$(echo "$releases" | grep -m1 -oP '^4\.1\.\d?.?\d')
-        latestv42=$(echo "$releases" | grep -m1 -oP '^4\.2\.\d?.?\d')
-        latestv43=$(echo "$releases" | grep -m1 -oP '^4\.3\.\d?.?\d')
-        latestv44=$(echo "$releases" | grep -m1 -oP '^4\.4\.\d?.?\d')
-        #latestv=$(echo "$releases" | grep -m1 -oP '\d.\d?.?\d?.?\d')
-        repov=$(get_candidate_version qbittorrent-nox)
-        case ${codename} in
-        "stretch")
-            #We can't go past 4.3.1 due to openssl and c++ requirements
-            function=$(
-                whiptail --title "Install Software" --menu "Choose a qBittorrent version:" --ok-button "Continue" --nocancel 12 50 5 \
-                    "Repo" "${repov}" \
-                    "4.3.1" "(4.3.1)" \
-                    "4.2" "(${latestv42})" \
-                    "4.1" "(${latestv41})" 3>&1 1>&2 2>&3
-            )
+            qt_minimum_version=5.9
+            cryptography_type=openssl
+            build_type=autotools
+            ;;
+        4.3.3)
+            libtorrent_branch=RC_1_2
+            libtorrent_minimum_version=1.2.11
+            stdcver="c++17"
+            qt_minimum_version=5.9
+            cryptography_type=openssl
+            build_type=autotools
+            ;;
+        4.3.*)
+            libtorrent_branch=RC_1_2
+            libtorrent_minimum_version=1.2.12
+            stdcver="c++17"
+            qt_minimum_version=5.12
+            cryptography_type=openssl
+            build_type=autotools
+            ;;
+        4.4.*)
+            if [[ -n ${LIBTORRENT_VERSION} ]]; then
+                case $LIBTORRENT_VERSION in
+                    RC_2_0)
+                        libtorrent_branch=RC_2_0
+                        ;;
+                    RC_1_2)
+                        libtorrent_branch=RC_1_2
+                        ;;
+                    *)
+                        echo_error "LIBTORRENT_VERSION must be either RC_1_2 or RC_2_0. You entered ${LIBTORRENT_VERSION}."
+                        exit 1
+                        ;;
+                esac
+                echo_info "Overriding libtorrent version with ${LIBTORRENT_VERSION}"
+            else
+                libtorrent_branch=RC_1_2
+            fi
+            libtorrent_minimum_version=1.2.12
+            stdcver="c++17"
+            qt_minimum_version=6.0
+            qbt_use_qt6=ON
+            cryptography_type=openssl
+            build_type=cmake
             ;;
         *)
-            function=$(whiptail --title "Install Software" --menu "Choose a qBittorrent version:" --ok-button "Continue" --nocancel 12 50 5 \
-                "Repo" "${repov}" \
-                "4.4" "(${latestv44})" \
-                "4.3" "(${latestv43})" \
-                "4.2" "(${latestv42})" \
-                "4.1" "(${latestv41})" 3>&1 1>&2 2>&3)
-            #"Latest" "(${latestv})" 3>&1 1>&2 2>&3)
-            ;;
-        esac
-        case $function in
-        #Latest)
-        #export QBITTORRENT_VERSION=${latestv}
-        #;;
-        4.1)
-            export QBITTORRENT_VERSION=${latestv41}
-            ;;
-        4.2)
-            export QBITTORRENT_VERSION=${latestv42}
-            ;;
-        4.3)
-            export QBITTORRENT_VERSION=${latestv43}
-            ;;
-        4.3.1)
-            export QBITTORRENT_VERSION=4.3.1
-            ;;
-        4.4)
-            export QBITTORRENT_VERSION=${latestv44}
-            ;;
-        Repo)
-            export QBITTORRENT_VERSION=repo
-            ;;
-        *)
-            echo_error "Function not supported"
+            echo_error "qBittorrent version should be between 4.1.*(.*) and 4.4.*(.*) -- Setup will not proceed."
             exit 1
             ;;
-        esac
-    fi
-}
-
-function qbittorrent_version_info() {
-    if [[ ${QBITTORRENT_VERSION} == "latest" ]]; then
-        case $(_os_codename) in
-        stretch)
-            QBITTORRENT_VERSION=4.3.1
-            ;;
-        *)
-            QBITTORRENT_VERSION=$(git ls-remote -t --refs https://github.com/qbittorrent/qBittorrent.git | awk '{sub("refs/tags/release-", ""); print $2 }' | grep -v -e "beta" -e "rc" | sort -Vr | head -n1)
-            #latestv44=$(echo "$releases" | grep -m1 -oP '4\.4\.\d?.?\d')
-            ;;
-        esac
-    fi
-    CFLAGS="-march=native"
-    CXXFLAGS="-march=native"
-    case $QBITTORRENT_VERSION in
-    4.1.*)
-        libtorrent_branch=RC_1_1
-        libtorrent_minimum_version=1.1.0
-        libtorrent_maximum_version=1.1.14
-        stdcver="c++14"
-        qt_minimum_version=5.5
-        cryptography_type=built-in
-        build_type=autotools
-        ;;
-    4.2.*)
-        libtorrent_branch=RC_1_2
-        libtorrent_minimum_version=1.2.0
-        stdcver="c++14"
-        qt_minimum_version=5.9
-        cryptography_type=openssl
-        build_type=autotools
-        ;;
-    4.3.[012]*)
-        libtorrent_branch=RC_1_2
-        libtorrent_minimum_version=1.2.11
-        stdcver="c++14"
-        qt_minimum_version=5.9
-        cryptography_type=openssl
-        build_type=autotools
-        ;;
-    4.3.3)
-        libtorrent_branch=RC_1_2
-        libtorrent_minimum_version=1.2.11
-        stdcver="c++17"
-        qt_minimum_version=5.9
-        cryptography_type=openssl
-        build_type=autotools
-        ;;
-    4.3.*)
-        libtorrent_branch=RC_1_2
-        libtorrent_minimum_version=1.2.12
-        stdcver="c++17"
-        qt_minimum_version=5.12
-        cryptography_type=openssl
-        build_type=autotools
-        ;;
-    4.4.*)
-        if [[ -n ${LIBTORRENT_VERSION} ]]; then
-            case $LIBTORRENT_VERSION in
-            RC_2_0)
-                libtorrent_branch=RC_2_0
-                ;;
-            RC_1_2)
-                libtorrent_branch=RC_1_2
-                ;;
-            *)
-                echo_error "LIBTORRENT_VERSION must be either RC_1_2 or RC_2_0. You entered ${LIBTORRENT_VERSION}."
-                exit 1
-                ;;
-            esac
-            echo_info "Overriding libtorrent version with ${LIBTORRENT_VERSION}"
-        else
-            libtorrent_branch=RC_1_2
-        fi
-        libtorrent_minimum_version=1.2.12
-        stdcver="c++17"
-        qt_minimum_version=6.0
-        qbt_use_qt6=ON
-        cryptography_type=openssl
-        build_type=cmake
-        ;;
-    *)
-        echo_error "qBittorrent version should be between 4.1.*(.*) and 4.4.*(.*) -- Setup will not proceed."
-        exit 1
-        ;;
     esac
 }
 
@@ -288,22 +187,22 @@ function install_qt() {
         LIST='qtbase5-dev qttools5-dev'
         apt_install --no-recommends $LIST
         #If we're installing from repo then we can remove these (i.e. dist-upgrade or qbit downgrade)
-        dpkg -r qtbase5-swizzin >/dev/null 2>&1
-        dpkg -r qttools5-swizzin >/dev/null 2>&1
+        dpkg -r qtbase5-swizzin > /dev/null 2>&1
+        dpkg -r qttools5-swizzin > /dev/null 2>&1
         QT_METHOD=repo
     fi
 }
 
 function install_qt_swizzin() {
     latest_qt_swizzin=$(github_latest_version swizzin/qt6_crossbuild)
-    installed_qt_swizzin=$(dpkg-query --showformat='${Version}' --show qt6-swizzin 2>/dev/null)
+    installed_qt_swizzin=$(dpkg-query --showformat='${Version}' --show qt6-swizzin 2> /dev/null)
     if [[ -z ${installed_qt_swizzin} ]] || dpkg --compare-versions ${installed_qt_swizzin} lt ${latest_qt_swizzin}; then
         echo_progress_start "Installing latest qt6-swizzin"
-        wget -O /tmp/qt6-swizzin.deb https://github.com/swizzin/qt6_crossbuild/releases/download/${latest_qt_swizzin}/$(_os_distro)-$(_os_codename)-qt6-swizzin-$(_os_arch).deb >>${log} 2>&1 || {
+        wget -O /tmp/qt6-swizzin.deb https://github.com/swizzin/qt6_crossbuild/releases/download/${latest_qt_swizzin}/$(_os_distro)-$(_os_codename)-qt6-swizzin-$(_os_arch).deb >> ${log} 2>&1 || {
             echo_error "qt6-swizzin could not be downloaded from github. Setup will not proceed"
             exit 1
         }
-        dpkg -i /tmp/qt6-swizzin.deb >>${log} 2>&1 || {
+        dpkg -i /tmp/qt6-swizzin.deb >> ${log} 2>&1 || {
             echo_error "Something went wrong when installing qt6-swizzin. Setup will not proceed"
         }
         rm -rf /tmp/qt6-swizzin.deb
@@ -313,14 +212,14 @@ function install_qt_swizzin() {
 
 function install_cmake_swizzin() {
     latest_cmake_swizzin=$(github_latest_version swizzin/cmake_crossbuild)
-    installed_cmake_swizzin=$(dpkg-query --showformat='${Version}' --show cmake-swizzin 2>/dev/null)
+    installed_cmake_swizzin=$(dpkg-query --showformat='${Version}' --show cmake-swizzin 2> /dev/null)
     if [[ -z ${installed_cmake_swizzin} ]] || dpkg --compare-versions ${installed_cmake_swizzin} lt ${latest_cmake_swizzin//_/+}; then
         echo_progress_start "Installing latest cmake-swizzin"
-        wget -O /tmp/cmake-swizzin.deb https://github.com/swizzin/cmake_crossbuild/releases/download/${latest_cmake_swizzin}/$(_os_distro)-$(_os_codename)-cmake-swizzin-$(_os_arch).deb >>${log} 2>&1 || {
+        wget -O /tmp/cmake-swizzin.deb https://github.com/swizzin/cmake_crossbuild/releases/download/${latest_cmake_swizzin}/$(_os_distro)-$(_os_codename)-cmake-swizzin-$(_os_arch).deb >> ${log} 2>&1 || {
             echo_error "cmake-swizzin could not be downloaded from github. Setup will not proceed"
             exit 1
         }
-        dpkg -i /tmp/cmake-swizzin.deb >>${log} 2>&1 || {
+        dpkg -i /tmp/cmake-swizzin.deb >> ${log} 2>&1 || {
             echo_error "Something went wrong when installing cmake-swizzin. Setup will not proceed"
         }
         rm -rf /tmp/cmake-swizzin.deb
@@ -332,51 +231,51 @@ function build_qt_swizzin() {
     cd /tmp
     QT_PREFIX=/usr/local/qt
     case $(_os_codename) in
-    stretch)
-        qt_branch=5.12
-        ;;
-    *)
-        #6.0 requires CMake 3.18
-        qt_branch=5.15
-        ;;
+        stretch)
+            qt_branch=5.12
+            ;;
+        *)
+            #6.0 requires CMake 3.18
+            qt_branch=5.15
+            ;;
     esac
     QT_VERSION=$(git ls-remote -t --refs https://github.com/qt/qtbase | awk '{sub("refs/tags/v", ""); print $2}' | grep ${qt_branch} | sort -Vr | grep -m1 -v -e "alpha" -e "beta" -e "rc")
     if ! skip_qt; then
         echo_progress_start "Compiling qtbase5-swizzin v${QT_VERSION}"
-        git clone --depth 1 -b v${QT_VERSION} --recurse-submodules https://github.com/qt/qtbase /tmp/qtbase >>${log} 2>&1 || {
+        git clone --depth 1 -b v${QT_VERSION} --recurse-submodules https://github.com/qt/qtbase /tmp/qtbase >> ${log} 2>&1 || {
             echo_error "qtbase5 could not be cloned from github. Setup will not proceed"
             exit 1
         }
         cd /tmp/qtbase
         apt_install libssl-dev
-        ./configure --prefix=${QT_PREFIX} -opensource -confirm-license -openssl-linked -c++std ${stdcver} -release -qt-pcre -no-iconv -no-feature-glib -no-feature-opengl -no-feature-dbus -no-feature-gui -no-feature-widgets -no-feature-testlib -no-compile-examples >>${log} 2>&1
-        make -j$(nproc) >>${log} 2>&1
-        make INSTALL_ROOT=/tmp/dist/qtbase install >>${log} 2>&1
+        ./configure --prefix=${QT_PREFIX} -opensource -confirm-license -openssl-linked -c++std ${stdcver} -release -qt-pcre -no-iconv -no-feature-glib -no-feature-opengl -no-feature-dbus -no-feature-gui -no-feature-widgets -no-feature-testlib -no-compile-examples >> ${log} 2>&1
+        make -j$(nproc) >> ${log} 2>&1
+        make INSTALL_ROOT=/tmp/dist/qtbase install >> ${log} 2>&1
         tag=" ${stdcver}"
-        fpm -f -C /tmp/dist/qtbase -p /root/dist/qtbase5-swizzin_VERSION.deb -s dir -t deb -n qtbase5-swizzin --version ${QT_VERSION} --description "qtbase5 compiled by swizzin$tag" >>${log} 2>&1
+        fpm -f -C /tmp/dist/qtbase -p /root/dist/qtbase5-swizzin_VERSION.deb -s dir -t deb -n qtbase5-swizzin --version ${QT_VERSION} --description "qtbase5 compiled by swizzin$tag" >> ${log} 2>&1
         cd /tmp
         rm -rf /tmp/qtbase
         rm -rf /tmp/dist/qtbase
-        dpkg -i /root/dist/qtbase5-swizzin_${QT_VERSION}.deb >>${log} 2>&1 || {
+        dpkg -i /root/dist/qtbase5-swizzin_${QT_VERSION}.deb >> ${log} 2>&1 || {
             echo_error "qtbase5-swizzin could not be installed. Setup will not proceed"
             exit 1
         }
         echo_progress_done "qtbase5-swizzin installed"
         echo_progress_start "Compiling qttools5-swizzin v${QT_VERSION}"
-        git clone --depth 1 -b "v${QT_VERSION}" --recurse-submodules https://github.com/qt/qttools /tmp/qttools >>${log} 2>&1 || {
+        git clone --depth 1 -b "v${QT_VERSION}" --recurse-submodules https://github.com/qt/qttools /tmp/qttools >> ${log} 2>&1 || {
             echo_error "qttools5 could not be cloned from github. Setup will not proceed"
             exit 1
         }
         cd /tmp/qttools
-        ${QT_PREFIX}/bin/qmake -set prefix ${QT_PREFIX} >>${log} 2>&1
-        ${QT_PREFIX}/bin/qmake >>${log} 2>&1
-        make -j$(nproc) >>${log} 2>&1
-        make INSTALL_ROOT=/tmp/dist/qttools install >>${log} 2>&1
-        fpm -f -C /tmp/dist/qttools -p /root/dist/qttools5-swizzin_VERSION.deb -s dir -t deb -n qttools5-swizzin --version ${QT_VERSION} --description "qttools5 compiled by swizzin$tag" >>${log} 2>&1
+        ${QT_PREFIX}/bin/qmake -set prefix ${QT_PREFIX} >> ${log} 2>&1
+        ${QT_PREFIX}/bin/qmake >> ${log} 2>&1
+        make -j$(nproc) >> ${log} 2>&1
+        make INSTALL_ROOT=/tmp/dist/qttools install >> ${log} 2>&1
+        fpm -f -C /tmp/dist/qttools -p /root/dist/qttools5-swizzin_VERSION.deb -s dir -t deb -n qttools5-swizzin --version ${QT_VERSION} --description "qttools5 compiled by swizzin$tag" >> ${log} 2>&1
         cd /tmp
         rm -rf /tmp/qttools
         rm -rf /tmp/dist/qttools
-        dpkg -i /root/dist/qttools5-swizzin_${QT_VERSION}.deb >>${log} 2>&1 || {
+        dpkg -i /root/dist/qttools5-swizzin_${QT_VERSION}.deb >> ${log} 2>&1 || {
             echo_error "qttools5-swizzin could not be installed. Setup will not proceed"
             exit 1
         }
@@ -385,7 +284,7 @@ function build_qt_swizzin() {
 }
 
 function skip_qt() {
-    if dpkg -s qtbase5-swizzin 2>/dev/null | grep -q ${stdcver}; then
+    if dpkg -s qtbase5-swizzin 2> /dev/null | grep -q ${stdcver}; then
         qt_local_version=$(dpkg -s qtbase5-swizzin | grep ^Version | grep ^Version | awk '{print $2}')
         if dpkg --compare-versions ${qt_local_version} ge ${QT_VERSION}; then
             return
@@ -410,33 +309,33 @@ function build_libtorrent_qbittorrent() {
     rm_if_exists /tmp/libtorrent
     booststrap
     apt_install libssl-dev
-
+    
     libtorrent_github_url="https://github.com/arvidn/libtorrent.git"
     libtorrent_github_tags_list=$(git ls-remote -q -t --refs https://github.com/arvidn/libtorrent.git | awk '/\/v/{sub("refs/tags/", "");sub("(.*)(-[^0-9].*)(.*)", ""); print $2 }' | awk '!/^$/' | sort -rV)
 
     case $libtorrent_branch in
-    RC_1_2)
-        qbt_libtorrent_version=1.2
-        ;;
-    RC_2_0)
-        qbt_libtorrent_version=2.0
-        ;;
-    *)
-        qbt_libtorrent_version=1.2
-        ;;
+        RC_1_2)
+            qbt_libtorrent_version=1.2
+            ;;
+        RC_2_0)
+            qbt_libtorrent_version=2.0
+            ;;
+        *)
+            qbt_libtorrent_version=1.2
+            ;;
     esac
 
-    libtorrent_github_tag_default="$(grep -Eom1 "v${qbt_libtorrent_version}.([0-9]{1,2})" <<<"${libtorrent_github_tags_list}")"
+    libtorrent_github_tag_default="$(grep -Eom1 "v${qbt_libtorrent_version}.([0-9]{1,2})" <<< "${libtorrent_github_tags_list}")"
     libtorrent_github_tag="${libtorrent_github_tag:-$libtorrent_github_tag_default}"
 
-    git clone --no-tags --single-branch --branch "${libtorrent_github_tag}" --shallow-submodules --recurse-submodules -j"$(nproc)" --depth 1 "https://github.com/arvidn/libtorrent.git" "/tmp/libtorrent" >>${log} 2>&1 || {
+    git clone --no-tags --single-branch --branch "${libtorrent_github_tag}" --shallow-submodules --recurse-submodules -j"$(nproc)" --depth 1 "https://github.com/arvidn/libtorrent.git" "/tmp/libtorrent">> ${log} 2>&1 || {
         echo_error "Libtorrent could not be cloned from git. Setup will not proceed"
         exit 1
     }
-
+ 
     cd /tmp/libtorrent
     if [[ -f /root/libtorrent-${libtorrent_branch}.patch ]]; then
-        patch -p1 </root/libtorrent-${libtorrent_branch}.patch >>${log} 2>&1 || {
+        patch -p1 < /root/libtorrent-${libtorrent_branch}.patch >> ${log} 2>&1 || {
             echo _error "Something went wrong when patching libtorrent"
             exit 1
         }
@@ -450,37 +349,37 @@ function build_libtorrent_qbittorrent() {
     fi
     VERSION=$(grep -oP "VERSION\ = \K\d\.\d\.\d+" Jamfile)
     case $build_type in
-    cmake)
-        PATH=/opt/local/bin:${PATH} cmake -Wno-dev -Wno-deprecated -G Ninja -B build \
-            -D CMAKE_BUILD_TYPE="Release" \
-            -D CMAKE_CXX_STANDARD="${stdcver//[^0-9]/}" \
-            -D BOOST_INCLUDEDIR="/opt/boost_${BOOST_VERSION}" \
-            -D BUILD_SHARED_LIBS=OFF \
-            -D CMAKE_CXX_FLAGS="${CXXFLAGS}" \
-            -D CMAKE_C_FLAGS="${CFLAGS}" \
-            -D CMAKE_INSTALL_PREFIX="/tmp/dist/libtorrent/usr/local" >>${log} 2>&1
-        PATH=/opt/local/bin:${PATH} cmake --build build >>${log} 2>&1
-        PATH=/opt/local/bin:${PATH} cmake --install build >>${log} 2>&1
-        #Fix pkgconfig paths/quirks
-        sed -i 's|/tmp/dist/libtorrent||g' /tmp/dist/libtorrent/usr/local/lib/pkgconfig/libtorrent-rasterbar.pc
-        sed -i 's|-ltorrent-rasterbar|-l:libtorrent-rasterbar.a|g' /tmp/dist/libtorrent/usr/local/lib/pkgconfig/libtorrent-rasterbar.pc
-        ;;
-    autotools)
-        echo "using gcc : : : <cflags>\"-march=native -std=${stdcver}\" <cxxflags>\"-march=native -std=${stdcver}\" ;" >/root/user-config.jam
-        /opt/boost_${BOOST_VERSION}/b2 -j$(nproc) crypto=${cryptography_type} variant=release link=static install --prefix=/tmp/dist/libtorrent/usr/local install >>${log} 2>&1
-        ;;
-    *)
-        echo_error "Build type must be cmake or autotools"
-        exit 1
-        ;;
+        cmake)
+            PATH=/opt/local/bin:${PATH} cmake -Wno-dev -Wno-deprecated -G Ninja -B build \
+                -D CMAKE_BUILD_TYPE="Release" \
+                -D CMAKE_CXX_STANDARD="${stdcver//[^0-9]/}" \
+                -D BOOST_INCLUDEDIR="/opt/boost_${BOOST_VERSION}" \
+                -D BUILD_SHARED_LIBS=OFF \
+                -D CMAKE_CXX_FLAGS="${CXXFLAGS}" \
+                -D CMAKE_C_FLAGS="${CFLAGS}" \
+                -D CMAKE_INSTALL_PREFIX="/tmp/dist/libtorrent/usr/local" >> ${log} 2>&1
+            PATH=/opt/local/bin:${PATH} cmake --build build >> ${log} 2>&1
+            PATH=/opt/local/bin:${PATH} cmake --install build >> ${log} 2>&1
+            #Fix pkgconfig paths/quirks
+            sed -i 's|/tmp/dist/libtorrent||g' /tmp/dist/libtorrent/usr/local/lib/pkgconfig/libtorrent-rasterbar.pc
+            sed -i 's|-ltorrent-rasterbar|-l:libtorrent-rasterbar.a|g' /tmp/dist/libtorrent/usr/local/lib/pkgconfig/libtorrent-rasterbar.pc
+            ;;
+        autotools)
+            echo "using gcc : : : <cflags>\"-march=native -std=${stdcver}\" <cxxflags>\"-march=native -std=${stdcver}\" ;" > /root/user-config.jam
+            /opt/boost_${BOOST_VERSION}/b2 -j$(nproc) crypto=${cryptography_type} variant=release link=static install --prefix=/tmp/dist/libtorrent/usr/local install >> ${log} 2>&1
+            ;;
+        *)
+            echo_error "Build type must be cmake or autotools"
+            exit 1
+            ;;
     esac
     tag=" static with ${stdcver} march=native"
     mkdir -p /root/dist
-    fpm -f -C /tmp/dist/libtorrent -p /root/dist/libtorrent-rasterbar_VERSION.deb -s dir -t deb -n libtorrent-rasterbar --version ${VERSION} --description "Libtorrent rasterbar compiled by swizzin$tag" >>${log} 2>&1
+    fpm -f -C /tmp/dist/libtorrent -p /root/dist/libtorrent-rasterbar_VERSION.deb -s dir -t deb -n libtorrent-rasterbar --version ${VERSION} --description "Libtorrent rasterbar compiled by swizzin$tag" >> ${log} 2>&1
     cd /tmp
     rm_if_exists /tmp/libtorrent
     rm_if_exists /tmp/dist
-    dpkg -i /root/dist/libtorrent-rasterbar_${VERSION}.deb >>${log} 2>&1 || {
+    dpkg -i /root/dist/libtorrent-rasterbar_${VERSION}.deb >> ${log} 2>&1 || {
         echo_error "Libtorrent could not be installed. Setup will not proceed"
         exit 1
     }
@@ -497,12 +396,12 @@ function build_qbittorrent() {
 
     apt_install --no-recommends $LIST
     rm_if_exists "/tmp/qbittorrent"
-    wget -O /tmp/release-${VERSION}.tar.gz https://github.com/qbittorrent/qBittorrent/archive/release-${VERSION}.tar.gz >>"${log}" 2>&1 || {
+    wget -O /tmp/release-${VERSION}.tar.gz https://github.com/qbittorrent/qBittorrent/archive/release-${VERSION}.tar.gz >> "${log}" 2>&1 || {
         echo_error "qBittorrent could not be downloaded. Setup will not proceed"
         exit 1
     }
     mkdir -p /tmp/qbittorrent
-    tar -xvf /tmp/release-${VERSION}.tar.gz -C /tmp/qbittorrent --strip-components=1 >>$log 2>&1
+    tar -xvf /tmp/release-${VERSION}.tar.gz -C /tmp/qbittorrent --strip-components=1 >> $log 2>&1
     rm -rf /tmp/release-${VERSION}.tar.gz
 
     cd /tmp/qbittorrent
@@ -510,42 +409,42 @@ function build_qbittorrent() {
     #Ensure boost variables are loaded (i.e. libtorrent skipped)
     booststrap
     case $build_type in
-    cmake)
-        PATH=/opt/local/bin:${PATH} cmake -Wno-dev -Wno-deprecated -G Ninja -B build \
-            -D CMAKE_BUILD_TYPE="release" \
-            -D CMAKE_CXX_STANDARD="${stdcver//[^0-9]/}" \
-            -D QT6="${qbt_use_qt6:=OFF}" \
-            -D Boost_NO_BOOST_CMAKE=TRUE \
-            -D CMAKE_CXX_FLAGS="${CXXFLAGS}" \
-            -D CMAKE_C_FLAGS="${CFLAGS}" \
-            -D GUI=OFF \
-            -D CMAKE_INSTALL_PREFIX="/tmp/dist/qbittorrent/usr" >>${log} 2>&1
-        PATH=/opt/local/bin:${PATH} cmake --build build >>${log} 2>&1
-        PATH=/opt/local/bin:${PATH} cmake --install build >>${log} 2>&1
-        ;;
-    autotools)
-        ./configure --prefix=/usr --disable-gui --with-boost=${BOOST_ROOT} --with-boost-libdir="/usr/local/lib" libtorrent_CFLAGS="-I/usr/local/include -I${BOOST_ROOT}" libtorrent_LIBS="-L/usr/local/lib -l:libtorrent-rasterbar.a -lssl -lcrypto" CXXFLAGS="-march=native -std=${stdcver}" ${QT_SWIZZIN} >>${log} 2>&1
-        make -j$(nproc) >>$log 2>&1
-        make INSTALL_ROOT=/tmp/dist/qbittorrent install >>${log} 2>&1
-        ;;
-    *)
-        echo_error "Build type must be cmake or autotools"
-        exit 1
-        ;;
+        cmake)
+            PATH=/opt/local/bin:${PATH} cmake -Wno-dev -Wno-deprecated -G Ninja -B build \
+                -D CMAKE_BUILD_TYPE="release" \
+                -D CMAKE_CXX_STANDARD="${stdcver//[^0-9]/}" \
+                -D QT6="${qbt_use_qt6:=OFF}" \
+                -D Boost_NO_BOOST_CMAKE=TRUE \
+                -D CMAKE_CXX_FLAGS="${CXXFLAGS}" \
+                -D CMAKE_C_FLAGS="${CFLAGS}" \
+                -D GUI=OFF \
+                -D CMAKE_INSTALL_PREFIX="/tmp/dist/qbittorrent/usr" >> ${log} 2>&1
+            PATH=/opt/local/bin:${PATH} cmake --build build >> ${log} 2>&1
+            PATH=/opt/local/bin:${PATH} cmake --install build >> ${log} 2>&1
+            ;;
+        autotools)
+            ./configure --prefix=/usr --disable-gui --with-boost=${BOOST_ROOT} --with-boost-libdir="/usr/local/lib" libtorrent_CFLAGS="-I/usr/local/include -I${BOOST_ROOT}" libtorrent_LIBS="-L/usr/local/lib -l:libtorrent-rasterbar.a -lssl -lcrypto" CXXFLAGS="-march=native -std=${stdcver}" ${QT_SWIZZIN} >> ${log} 2>&1
+            make -j$(nproc) >> $log 2>&1
+            make INSTALL_ROOT=/tmp/dist/qbittorrent install >> ${log} 2>&1
+            ;;
+        *)
+            echo_error "Build type must be cmake or autotools"
+            exit 1
+            ;;
     esac
     #install qbt-cli
     qbt_cli_version=$(github_latest_version ludviglundgren/qbittorrent-cli)
     cd /tmp/dist/qbittorrent/usr/bin
-    wget -O qbtcli.tar.gz https://github.com/ludviglundgren/qbittorrent-cli/releases/download/${qbt_cli_version}/qbittorrent-cli_${qbt_cli_version//v/}_linux_$(_os_arch).tar.gz >>${log} 2>&1
-    tar xvf qbtcli.tar.gz >>${log} 2>&1
-    rm -f qbtcli.tar.gz README.md >>${log} 2>&1
+    wget -O qbtcli.tar.gz https://github.com/ludviglundgren/qbittorrent-cli/releases/download/${qbt_cli_version}/qbittorrent-cli_${qbt_cli_version//v/}_linux_$(_os_arch).tar.gz >> ${log} 2>&1
+    tar xvf qbtcli.tar.gz >> ${log} 2>&1
+    rm -f qbtcli.tar.gz README.md >> ${log} 2>&1
     mkdir -p /root/dist
-    fpm -f -C /tmp/dist/qbittorrent -p /root/dist/qbittorrent-nox_VERSION.deb -s dir -t deb -n qbittorrent-nox --version ${VERSION} --description "qbittorrent-nox compiled by swizzin$tag" >>${log} 2>&1
-    dpkg -i /root/dist/qbittorrent-nox_${VERSION}.deb >>${log} 2>&1 || {
+    fpm -f -C /tmp/dist/qbittorrent -p /root/dist/qbittorrent-nox_VERSION.deb -s dir -t deb -n qbittorrent-nox --version ${VERSION} --description "qbittorrent-nox compiled by swizzin$tag" >> ${log} 2>&1
+    dpkg -i /root/dist/qbittorrent-nox_${VERSION}.deb >> ${log} 2>&1 || {
         echo_error "qBittorrent could not be installed. Setup will not proceed"
         exit 1
     }
-    apt-mark hold qbittorrent-nox >>${log} 2>&1
+    apt-mark hold qbittorrent-nox >> ${log} 2>&1
     cd /tmp
     rm_if_exists /tmp/qbittorrent
     rm_if_exists /tmp/dist
@@ -560,7 +459,7 @@ function qbittorrent_service() {
         if [[ $(systemctl --version | awk 'NR==1 {print $2}') -ge 240 ]]; then
             type=exec
         fi
-        cat >/etc/systemd/system/qbittorrent@.service <<EOQBS
+        cat > /etc/systemd/system/qbittorrent@.service << EOQBS
 [Unit]
 Description=qBittorrent-nox service for %i
 Documentation=man:qbittorrent-nox(1)
@@ -592,7 +491,7 @@ function qbittorrent_user_config() {
         QBTWP="WebUI\Password_PBKDF2=\"@ByteArray($hashed)\""
     fi
 
-    usermod -a -G ${user} www-data 2>>$log
+    usermod -a -G ${user} www-data 2>> $log
     port=$(port 10000 11000)
     mkdir -p /home/${user}/.config/qBittorrent/
     mkdir -p /home/${user}/torrents/qbittorrent
@@ -600,7 +499,7 @@ function qbittorrent_user_config() {
     chown ${user}: /home/${user}/torrents/qbittorrent
     chown $user: /home/${user}/.config
     chown $user: /home/${user}/.config/qBittorrent
-    cat >/home/${user}/.config/qBittorrent/qBittorrent.conf <<QBTCONF
+    cat > /home/${user}/.config/qBittorrent/qBittorrent.conf << QBTCONF
 [BitTorrent]
 Session\DisableAutoTMMByDefault=false 
 
@@ -634,7 +533,7 @@ function qbittorrent_chpasswd() {
     user=$1
     password=$2
     local_packages=/usr/local/bin/swizzin
-    qbtv=$(qbittorrent-nox --version 2>/dev/null | grep -oP '\d+\.\d+\.\d+' || echo '0.0.0.0')
+    qbtv=$(qbittorrent-nox --version 2> /dev/null | grep -oP '\d+\.\d+\.\d+' || echo '0.0.0.0')
     active=$(systemctl is-active qbittorrent@${user})
     if dpkg --compare-versions ${qbtv} lt 4.2.0; then
         hashed=$(echo -n "$password" | md5sum | awk '{print $1}')
@@ -649,4 +548,3 @@ function qbittorrent_chpasswd() {
         systemctl start qbittorrent@${user}
     fi
 }
-

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -310,7 +310,6 @@ function build_libtorrent_qbittorrent() {
     booststrap
     apt_install libssl-dev
 
-    libtorrent_github_url="https://github.com/arvidn/libtorrent.git"
     libtorrent_github_tags_list=$(git ls-remote -q -t --refs https://github.com/arvidn/libtorrent.git | awk '/\/v/{sub("refs/tags/", "");sub("(.*)(-[^0-9].*)(.*)", ""); print $2 }' | awk '!/^$/' | sort -rV)
 
     case $libtorrent_branch in

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -314,6 +314,9 @@ function build_libtorrent_qbittorrent() {
     libtorrent_github_tags_list=$(git ls-remote -q -t --refs https://github.com/arvidn/libtorrent.git | awk '/\/v/{sub("refs/tags/", "");sub("(.*)(-[^0-9].*)(.*)", ""); print $2 }' | awk '!/^$/' | sort -rV)
 
     case $libtorrent_branch in
+        RC_1_1)
+            libtorrent_github_tag=RC_1_1
+            ;;
         RC_1_2)
             qbt_libtorrent_version=1.2
             ;;
@@ -324,15 +327,15 @@ function build_libtorrent_qbittorrent() {
             qbt_libtorrent_version=1.2
             ;;
     esac
-
+    
     libtorrent_github_tag_default="$(grep -Eom1 "v${qbt_libtorrent_version}.([0-9]{1,2})" <<< "${libtorrent_github_tags_list}")"
     libtorrent_github_tag="${libtorrent_github_tag:-$libtorrent_github_tag_default}"
-
+    
     git clone --no-tags --single-branch --branch "${libtorrent_github_tag}" --shallow-submodules --recurse-submodules -j"$(nproc)" --depth 1 "https://github.com/arvidn/libtorrent.git" "/tmp/libtorrent">> ${log} 2>&1 || {
         echo_error "Libtorrent could not be cloned from git. Setup will not proceed"
         exit 1
     }
- 
+
     cd /tmp/libtorrent
     if [[ -f /root/libtorrent-${libtorrent_branch}.patch ]]; then
         patch -p1 < /root/libtorrent-${libtorrent_branch}.patch >> ${log} 2>&1 || {

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -314,6 +314,9 @@ function build_libtorrent_qbittorrent() {
     libtorrent_github_tags_list=$(git ls-remote -q -t --refs https://github.com/arvidn/libtorrent.git | awk '/\/v/{sub("refs/tags/", "");sub("(.*)(-[^0-9].*)(.*)", ""); print $2 }' | awk '!/^$/' | sort -rV)
 
     case $libtorrent_branch in
+        RC_1_1)
+            libtorrent_github_tag=RC_1_1
+            ;;
         RC_1_2)
             qbt_libtorrent_version=1.2
             ;;

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -310,30 +310,8 @@ function build_libtorrent_qbittorrent() {
     booststrap
     apt_install libssl-dev
 
-    libtorrent_github_tags_list=$(git ls-remote -q -t --refs https://github.com/arvidn/libtorrent.git | awk '/\/v/{sub("refs/tags/", "");sub("(.*)(-[^0-9].*)(.*)", ""); print $2 }' | awk '!/^$/' | sort -rV)
-
-    case $libtorrent_branch in
-        RC_1_1)
-            libtorrent_github_tag=RC_1_1
-            ;;
-        RC_1_2)
-            qbt_libtorrent_version=1.2
-            ;;
-        RC_2_0)
-            qbt_libtorrent_version=2.0
-            ;;
-        *)
-            qbt_libtorrent_version=1.2
-            ;;
-    esac
-
-    libtorrent_github_tag_default="$(grep -Eom1 "v${qbt_libtorrent_version}.([0-9]{1,2})" <<< "${libtorrent_github_tags_list}")"
-    libtorrent_github_tag="${libtorrent_github_tag:-$libtorrent_github_tag_default}"
-
-    git clone --no-tags --single-branch --branch "${libtorrent_github_tag}" --shallow-submodules --recurse-submodules -j"$(nproc)" --depth 1 "https://github.com/arvidn/libtorrent.git" "/tmp/libtorrent" >> ${log} 2>&1 || {
-        echo_error "Libtorrent could not be cloned from git. Setup will not proceed"
-        exit 1
-    }
+    export "${libtorrent_branch}"
+    libtorrent_clone
 
     cd /tmp/libtorrent
     if [[ -f /root/libtorrent-${libtorrent_branch}.patch ]]; then

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -99,55 +99,156 @@ function qbittorrent_version_info() {
             libtorrent_branch=RC_1_2
             libtorrent_minimum_version=1.2.11
             stdcver="c++14"
-            qt_minimum_version=5.9
-            cryptography_type=openssl
-            build_type=autotools
-            ;;
-        4.3.3)
-            libtorrent_branch=RC_1_2
-            libtorrent_minimum_version=1.2.11
-            stdcver="c++17"
-            qt_minimum_version=5.9
-            cryptography_type=openssl
-            build_type=autotools
-            ;;
-        4.3.*)
-            libtorrent_branch=RC_1_2
-            libtorrent_minimum_version=1.2.12
-            stdcver="c++17"
-            qt_minimum_version=5.12
-            cryptography_type=openssl
-            build_type=autotools
-            ;;
-        4.4.*)
-            if [[ -n ${LIBTORRENT_VERSION} ]]; then
-                case $LIBTORRENT_VERSION in
-                    RC_2_0)
-                        libtorrent_branch=RC_2_0
-                        ;;
-                    RC_1_2)
-                        libtorrent_branch=RC_1_2
-                        ;;
-                    *)
-                        echo_error "LIBTORRENT_VERSION must be either RC_1_2 or RC_2_0. You entered ${LIBTORRENT_VERSION}."
-                        exit 1
-                        ;;
-                esac
-                echo_info "Overriding libtorrent version with ${LIBTORRENT_VERSION}"
-            else
-                libtorrent_branch=RC_1_2
-            fi
-            libtorrent_minimum_version=1.2.12
-            stdcver="c++17"
-            qt_minimum_version=6.0
-            qbt_use_qt6=ON
-            cryptography_type=openssl
-            build_type=cmake
+#!/bin/bash
+
+function whiptail_qbittorrent() {
+    if [[ -z $QBITTORRENT_VERSION ]]; then
+        . /etc/swizzin/sources/functions/apt
+        codename=$(_os_codename)
+        releases=$(git ls-remote -t --refs https://github.com/qbittorrent/qBittorrent.git | awk '{sub("refs/tags/release-", ""); print $2 }' | grep -v -e "beta" -e "rc" | sort -Vr)
+
+        latestv41=$(echo "$releases" | grep -m1 -oP '^4\.1\.\d?.?\d')
+        latestv42=$(echo "$releases" | grep -m1 -oP '^4\.2\.\d?.?\d')
+        latestv43=$(echo "$releases" | grep -m1 -oP '^4\.3\.\d?.?\d')
+        latestv44=$(echo "$releases" | grep -m1 -oP '^4\.4\.\d?.?\d')
+        #latestv=$(echo "$releases" | grep -m1 -oP '\d.\d?.?\d?.?\d')
+        repov=$(get_candidate_version qbittorrent-nox)
+        case ${codename} in
+        "stretch")
+            #We can't go past 4.3.1 due to openssl and c++ requirements
+            function=$(
+                whiptail --title "Install Software" --menu "Choose a qBittorrent version:" --ok-button "Continue" --nocancel 12 50 5 \
+                    "Repo" "${repov}" \
+                    "4.3.1" "(4.3.1)" \
+                    "4.2" "(${latestv42})" \
+                    "4.1" "(${latestv41})" 3>&1 1>&2 2>&3
+            )
             ;;
         *)
-            echo_error "qBittorrent version should be between 4.1.*(.*) and 4.4.*(.*) -- Setup will not proceed."
+            function=$(whiptail --title "Install Software" --menu "Choose a qBittorrent version:" --ok-button "Continue" --nocancel 12 50 5 \
+                "Repo" "${repov}" \
+                "4.4" "(${latestv44})" \
+                "4.3" "(${latestv43})" \
+                "4.2" "(${latestv42})" \
+                "4.1" "(${latestv41})" 3>&1 1>&2 2>&3)
+            #"Latest" "(${latestv})" 3>&1 1>&2 2>&3)
+            ;;
+        esac
+        case $function in
+        #Latest)
+        #export QBITTORRENT_VERSION=${latestv}
+        #;;
+        4.1)
+            export QBITTORRENT_VERSION=${latestv41}
+            ;;
+        4.2)
+            export QBITTORRENT_VERSION=${latestv42}
+            ;;
+        4.3)
+            export QBITTORRENT_VERSION=${latestv43}
+            ;;
+        4.3.1)
+            export QBITTORRENT_VERSION=4.3.1
+            ;;
+        4.4)
+            export QBITTORRENT_VERSION=${latestv44}
+            ;;
+        Repo)
+            export QBITTORRENT_VERSION=repo
+            ;;
+        *)
+            echo_error "Function not supported"
             exit 1
             ;;
+        esac
+    fi
+}
+
+function qbittorrent_version_info() {
+    if [[ ${QBITTORRENT_VERSION} == "latest" ]]; then
+        case $(_os_codename) in
+        stretch)
+            QBITTORRENT_VERSION=4.3.1
+            ;;
+        *)
+            QBITTORRENT_VERSION=$(git ls-remote -t --refs https://github.com/qbittorrent/qBittorrent.git | awk '{sub("refs/tags/release-", ""); print $2 }' | grep -v -e "beta" -e "rc" | sort -Vr | head -n1)
+            #latestv44=$(echo "$releases" | grep -m1 -oP '4\.4\.\d?.?\d')
+            ;;
+        esac
+    fi
+    CFLAGS="-march=native"
+    CXXFLAGS="-march=native"
+    case $QBITTORRENT_VERSION in
+    4.1.*)
+        libtorrent_branch=RC_1_1
+        libtorrent_minimum_version=1.1.0
+        libtorrent_maximum_version=1.1.14
+        stdcver="c++14"
+        qt_minimum_version=5.5
+        cryptography_type=built-in
+        build_type=autotools
+        ;;
+    4.2.*)
+        libtorrent_branch=RC_1_2
+        libtorrent_minimum_version=1.2.0
+        stdcver="c++14"
+        qt_minimum_version=5.9
+        cryptography_type=openssl
+        build_type=autotools
+        ;;
+    4.3.[012]*)
+        libtorrent_branch=RC_1_2
+        libtorrent_minimum_version=1.2.11
+        stdcver="c++14"
+        qt_minimum_version=5.9
+        cryptography_type=openssl
+        build_type=autotools
+        ;;
+    4.3.3)
+        libtorrent_branch=RC_1_2
+        libtorrent_minimum_version=1.2.11
+        stdcver="c++17"
+        qt_minimum_version=5.9
+        cryptography_type=openssl
+        build_type=autotools
+        ;;
+    4.3.*)
+        libtorrent_branch=RC_1_2
+        libtorrent_minimum_version=1.2.12
+        stdcver="c++17"
+        qt_minimum_version=5.12
+        cryptography_type=openssl
+        build_type=autotools
+        ;;
+    4.4.*)
+        if [[ -n ${LIBTORRENT_VERSION} ]]; then
+            case $LIBTORRENT_VERSION in
+            RC_2_0)
+                libtorrent_branch=RC_2_0
+                ;;
+            RC_1_2)
+                libtorrent_branch=RC_1_2
+                ;;
+            *)
+                echo_error "LIBTORRENT_VERSION must be either RC_1_2 or RC_2_0. You entered ${LIBTORRENT_VERSION}."
+                exit 1
+                ;;
+            esac
+            echo_info "Overriding libtorrent version with ${LIBTORRENT_VERSION}"
+        else
+            libtorrent_branch=RC_1_2
+        fi
+        libtorrent_minimum_version=1.2.12
+        stdcver="c++17"
+        qt_minimum_version=6.0
+        qbt_use_qt6=ON
+        cryptography_type=openssl
+        build_type=cmake
+        ;;
+    *)
+        echo_error "qBittorrent version should be between 4.1.*(.*) and 4.4.*(.*) -- Setup will not proceed."
+        exit 1
+        ;;
     esac
 }
 
@@ -187,22 +288,22 @@ function install_qt() {
         LIST='qtbase5-dev qttools5-dev'
         apt_install --no-recommends $LIST
         #If we're installing from repo then we can remove these (i.e. dist-upgrade or qbit downgrade)
-        dpkg -r qtbase5-swizzin > /dev/null 2>&1
-        dpkg -r qttools5-swizzin > /dev/null 2>&1
+        dpkg -r qtbase5-swizzin >/dev/null 2>&1
+        dpkg -r qttools5-swizzin >/dev/null 2>&1
         QT_METHOD=repo
     fi
 }
 
 function install_qt_swizzin() {
     latest_qt_swizzin=$(github_latest_version swizzin/qt6_crossbuild)
-    installed_qt_swizzin=$(dpkg-query --showformat='${Version}' --show qt6-swizzin 2> /dev/null)
+    installed_qt_swizzin=$(dpkg-query --showformat='${Version}' --show qt6-swizzin 2>/dev/null)
     if [[ -z ${installed_qt_swizzin} ]] || dpkg --compare-versions ${installed_qt_swizzin} lt ${latest_qt_swizzin}; then
         echo_progress_start "Installing latest qt6-swizzin"
-        wget -O /tmp/qt6-swizzin.deb https://github.com/swizzin/qt6_crossbuild/releases/download/${latest_qt_swizzin}/$(_os_distro)-$(_os_codename)-qt6-swizzin-$(_os_arch).deb >> ${log} 2>&1 || {
+        wget -O /tmp/qt6-swizzin.deb https://github.com/swizzin/qt6_crossbuild/releases/download/${latest_qt_swizzin}/$(_os_distro)-$(_os_codename)-qt6-swizzin-$(_os_arch).deb >>${log} 2>&1 || {
             echo_error "qt6-swizzin could not be downloaded from github. Setup will not proceed"
             exit 1
         }
-        dpkg -i /tmp/qt6-swizzin.deb >> ${log} 2>&1 || {
+        dpkg -i /tmp/qt6-swizzin.deb >>${log} 2>&1 || {
             echo_error "Something went wrong when installing qt6-swizzin. Setup will not proceed"
         }
         rm -rf /tmp/qt6-swizzin.deb
@@ -212,14 +313,14 @@ function install_qt_swizzin() {
 
 function install_cmake_swizzin() {
     latest_cmake_swizzin=$(github_latest_version swizzin/cmake_crossbuild)
-    installed_cmake_swizzin=$(dpkg-query --showformat='${Version}' --show cmake-swizzin 2> /dev/null)
+    installed_cmake_swizzin=$(dpkg-query --showformat='${Version}' --show cmake-swizzin 2>/dev/null)
     if [[ -z ${installed_cmake_swizzin} ]] || dpkg --compare-versions ${installed_cmake_swizzin} lt ${latest_cmake_swizzin//_/+}; then
         echo_progress_start "Installing latest cmake-swizzin"
-        wget -O /tmp/cmake-swizzin.deb https://github.com/swizzin/cmake_crossbuild/releases/download/${latest_cmake_swizzin}/$(_os_distro)-$(_os_codename)-cmake-swizzin-$(_os_arch).deb >> ${log} 2>&1 || {
+        wget -O /tmp/cmake-swizzin.deb https://github.com/swizzin/cmake_crossbuild/releases/download/${latest_cmake_swizzin}/$(_os_distro)-$(_os_codename)-cmake-swizzin-$(_os_arch).deb >>${log} 2>&1 || {
             echo_error "cmake-swizzin could not be downloaded from github. Setup will not proceed"
             exit 1
         }
-        dpkg -i /tmp/cmake-swizzin.deb >> ${log} 2>&1 || {
+        dpkg -i /tmp/cmake-swizzin.deb >>${log} 2>&1 || {
             echo_error "Something went wrong when installing cmake-swizzin. Setup will not proceed"
         }
         rm -rf /tmp/cmake-swizzin.deb
@@ -231,51 +332,51 @@ function build_qt_swizzin() {
     cd /tmp
     QT_PREFIX=/usr/local/qt
     case $(_os_codename) in
-        stretch)
-            qt_branch=5.12
-            ;;
-        *)
-            #6.0 requires CMake 3.18
-            qt_branch=5.15
-            ;;
+    stretch)
+        qt_branch=5.12
+        ;;
+    *)
+        #6.0 requires CMake 3.18
+        qt_branch=5.15
+        ;;
     esac
     QT_VERSION=$(git ls-remote -t --refs https://github.com/qt/qtbase | awk '{sub("refs/tags/v", ""); print $2}' | grep ${qt_branch} | sort -Vr | grep -m1 -v -e "alpha" -e "beta" -e "rc")
     if ! skip_qt; then
         echo_progress_start "Compiling qtbase5-swizzin v${QT_VERSION}"
-        git clone --depth 1 -b v${QT_VERSION} --recurse-submodules https://github.com/qt/qtbase /tmp/qtbase >> ${log} 2>&1 || {
+        git clone --depth 1 -b v${QT_VERSION} --recurse-submodules https://github.com/qt/qtbase /tmp/qtbase >>${log} 2>&1 || {
             echo_error "qtbase5 could not be cloned from github. Setup will not proceed"
             exit 1
         }
         cd /tmp/qtbase
         apt_install libssl-dev
-        ./configure --prefix=${QT_PREFIX} -opensource -confirm-license -openssl-linked -c++std ${stdcver} -release -qt-pcre -no-iconv -no-feature-glib -no-feature-opengl -no-feature-dbus -no-feature-gui -no-feature-widgets -no-feature-testlib -no-compile-examples >> ${log} 2>&1
-        make -j$(nproc) >> ${log} 2>&1
-        make INSTALL_ROOT=/tmp/dist/qtbase install >> ${log} 2>&1
+        ./configure --prefix=${QT_PREFIX} -opensource -confirm-license -openssl-linked -c++std ${stdcver} -release -qt-pcre -no-iconv -no-feature-glib -no-feature-opengl -no-feature-dbus -no-feature-gui -no-feature-widgets -no-feature-testlib -no-compile-examples >>${log} 2>&1
+        make -j$(nproc) >>${log} 2>&1
+        make INSTALL_ROOT=/tmp/dist/qtbase install >>${log} 2>&1
         tag=" ${stdcver}"
-        fpm -f -C /tmp/dist/qtbase -p /root/dist/qtbase5-swizzin_VERSION.deb -s dir -t deb -n qtbase5-swizzin --version ${QT_VERSION} --description "qtbase5 compiled by swizzin$tag" >> ${log} 2>&1
+        fpm -f -C /tmp/dist/qtbase -p /root/dist/qtbase5-swizzin_VERSION.deb -s dir -t deb -n qtbase5-swizzin --version ${QT_VERSION} --description "qtbase5 compiled by swizzin$tag" >>${log} 2>&1
         cd /tmp
         rm -rf /tmp/qtbase
         rm -rf /tmp/dist/qtbase
-        dpkg -i /root/dist/qtbase5-swizzin_${QT_VERSION}.deb >> ${log} 2>&1 || {
+        dpkg -i /root/dist/qtbase5-swizzin_${QT_VERSION}.deb >>${log} 2>&1 || {
             echo_error "qtbase5-swizzin could not be installed. Setup will not proceed"
             exit 1
         }
         echo_progress_done "qtbase5-swizzin installed"
         echo_progress_start "Compiling qttools5-swizzin v${QT_VERSION}"
-        git clone --depth 1 -b "v${QT_VERSION}" --recurse-submodules https://github.com/qt/qttools /tmp/qttools >> ${log} 2>&1 || {
+        git clone --depth 1 -b "v${QT_VERSION}" --recurse-submodules https://github.com/qt/qttools /tmp/qttools >>${log} 2>&1 || {
             echo_error "qttools5 could not be cloned from github. Setup will not proceed"
             exit 1
         }
         cd /tmp/qttools
-        ${QT_PREFIX}/bin/qmake -set prefix ${QT_PREFIX} >> ${log} 2>&1
-        ${QT_PREFIX}/bin/qmake >> ${log} 2>&1
-        make -j$(nproc) >> ${log} 2>&1
-        make INSTALL_ROOT=/tmp/dist/qttools install >> ${log} 2>&1
-        fpm -f -C /tmp/dist/qttools -p /root/dist/qttools5-swizzin_VERSION.deb -s dir -t deb -n qttools5-swizzin --version ${QT_VERSION} --description "qttools5 compiled by swizzin$tag" >> ${log} 2>&1
+        ${QT_PREFIX}/bin/qmake -set prefix ${QT_PREFIX} >>${log} 2>&1
+        ${QT_PREFIX}/bin/qmake >>${log} 2>&1
+        make -j$(nproc) >>${log} 2>&1
+        make INSTALL_ROOT=/tmp/dist/qttools install >>${log} 2>&1
+        fpm -f -C /tmp/dist/qttools -p /root/dist/qttools5-swizzin_VERSION.deb -s dir -t deb -n qttools5-swizzin --version ${QT_VERSION} --description "qttools5 compiled by swizzin$tag" >>${log} 2>&1
         cd /tmp
         rm -rf /tmp/qttools
         rm -rf /tmp/dist/qttools
-        dpkg -i /root/dist/qttools5-swizzin_${QT_VERSION}.deb >> ${log} 2>&1 || {
+        dpkg -i /root/dist/qttools5-swizzin_${QT_VERSION}.deb >>${log} 2>&1 || {
             echo_error "qttools5-swizzin could not be installed. Setup will not proceed"
             exit 1
         }
@@ -284,7 +385,7 @@ function build_qt_swizzin() {
 }
 
 function skip_qt() {
-    if dpkg -s qtbase5-swizzin 2> /dev/null | grep -q ${stdcver}; then
+    if dpkg -s qtbase5-swizzin 2>/dev/null | grep -q ${stdcver}; then
         qt_local_version=$(dpkg -s qtbase5-swizzin | grep ^Version | grep ^Version | awk '{print $2}')
         if dpkg --compare-versions ${qt_local_version} ge ${QT_VERSION}; then
             return
@@ -309,36 +410,33 @@ function build_libtorrent_qbittorrent() {
     rm_if_exists /tmp/libtorrent
     booststrap
     apt_install libssl-dev
-    
+
     libtorrent_github_url="https://github.com/arvidn/libtorrent.git"
     libtorrent_github_tags_list=$(git ls-remote -q -t --refs https://github.com/arvidn/libtorrent.git | awk '/\/v/{sub("refs/tags/", "");sub("(.*)(-[^0-9].*)(.*)", ""); print $2 }' | awk '!/^$/' | sort -rV)
 
     case $libtorrent_branch in
-        RC_1_1)
-            libtorrent_github_tag=RC_1_1
-            ;;
-        RC_1_2)
-            qbt_libtorrent_version=1.2
-            ;;
-        RC_2_0)
-            qbt_libtorrent_version=2.0
-            ;;
-        *)
-            qbt_libtorrent_version=1.2
-            ;;
+    RC_1_2)
+        qbt_libtorrent_version=1.2
+        ;;
+    RC_2_0)
+        qbt_libtorrent_version=2.0
+        ;;
+    *)
+        qbt_libtorrent_version=1.2
+        ;;
     esac
-    
-    libtorrent_github_tag_default="$(grep -Eom1 "v${qbt_libtorrent_version}.([0-9]{1,2})" <<< "${libtorrent_github_tags_list}")"
+
+    libtorrent_github_tag_default="$(grep -Eom1 "v${qbt_libtorrent_version}.([0-9]{1,2})" <<<"${libtorrent_github_tags_list}")"
     libtorrent_github_tag="${libtorrent_github_tag:-$libtorrent_github_tag_default}"
-    
-    git clone --no-tags --single-branch --branch "${libtorrent_github_tag}" --shallow-submodules --recurse-submodules -j"$(nproc)" --depth 1 "https://github.com/arvidn/libtorrent.git" "/tmp/libtorrent">> ${log} 2>&1 || {
+
+    git clone --no-tags --single-branch --branch "${libtorrent_github_tag}" --shallow-submodules --recurse-submodules -j"$(nproc)" --depth 1 "https://github.com/arvidn/libtorrent.git" "/tmp/libtorrent" >>${log} 2>&1 || {
         echo_error "Libtorrent could not be cloned from git. Setup will not proceed"
         exit 1
     }
 
     cd /tmp/libtorrent
     if [[ -f /root/libtorrent-${libtorrent_branch}.patch ]]; then
-        patch -p1 < /root/libtorrent-${libtorrent_branch}.patch >> ${log} 2>&1 || {
+        patch -p1 </root/libtorrent-${libtorrent_branch}.patch >>${log} 2>&1 || {
             echo _error "Something went wrong when patching libtorrent"
             exit 1
         }
@@ -352,37 +450,37 @@ function build_libtorrent_qbittorrent() {
     fi
     VERSION=$(grep -oP "VERSION\ = \K\d\.\d\.\d+" Jamfile)
     case $build_type in
-        cmake)
-            PATH=/opt/local/bin:${PATH} cmake -Wno-dev -Wno-deprecated -G Ninja -B build \
-                -D CMAKE_BUILD_TYPE="Release" \
-                -D CMAKE_CXX_STANDARD="${stdcver//[^0-9]/}" \
-                -D BOOST_INCLUDEDIR="/opt/boost_${BOOST_VERSION}" \
-                -D BUILD_SHARED_LIBS=OFF \
-                -D CMAKE_CXX_FLAGS="${CXXFLAGS}" \
-                -D CMAKE_C_FLAGS="${CFLAGS}" \
-                -D CMAKE_INSTALL_PREFIX="/tmp/dist/libtorrent/usr/local" >> ${log} 2>&1
-            PATH=/opt/local/bin:${PATH} cmake --build build >> ${log} 2>&1
-            PATH=/opt/local/bin:${PATH} cmake --install build >> ${log} 2>&1
-            #Fix pkgconfig paths/quirks
-            sed -i 's|/tmp/dist/libtorrent||g' /tmp/dist/libtorrent/usr/local/lib/pkgconfig/libtorrent-rasterbar.pc
-            sed -i 's|-ltorrent-rasterbar|-l:libtorrent-rasterbar.a|g' /tmp/dist/libtorrent/usr/local/lib/pkgconfig/libtorrent-rasterbar.pc
-            ;;
-        autotools)
-            echo "using gcc : : : <cflags>\"-march=native -std=${stdcver}\" <cxxflags>\"-march=native -std=${stdcver}\" ;" > /root/user-config.jam
-            /opt/boost_${BOOST_VERSION}/b2 -j$(nproc) crypto=${cryptography_type} variant=release link=static install --prefix=/tmp/dist/libtorrent/usr/local install >> ${log} 2>&1
-            ;;
-        *)
-            echo_error "Build type must be cmake or autotools"
-            exit 1
-            ;;
+    cmake)
+        PATH=/opt/local/bin:${PATH} cmake -Wno-dev -Wno-deprecated -G Ninja -B build \
+            -D CMAKE_BUILD_TYPE="Release" \
+            -D CMAKE_CXX_STANDARD="${stdcver//[^0-9]/}" \
+            -D BOOST_INCLUDEDIR="/opt/boost_${BOOST_VERSION}" \
+            -D BUILD_SHARED_LIBS=OFF \
+            -D CMAKE_CXX_FLAGS="${CXXFLAGS}" \
+            -D CMAKE_C_FLAGS="${CFLAGS}" \
+            -D CMAKE_INSTALL_PREFIX="/tmp/dist/libtorrent/usr/local" >>${log} 2>&1
+        PATH=/opt/local/bin:${PATH} cmake --build build >>${log} 2>&1
+        PATH=/opt/local/bin:${PATH} cmake --install build >>${log} 2>&1
+        #Fix pkgconfig paths/quirks
+        sed -i 's|/tmp/dist/libtorrent||g' /tmp/dist/libtorrent/usr/local/lib/pkgconfig/libtorrent-rasterbar.pc
+        sed -i 's|-ltorrent-rasterbar|-l:libtorrent-rasterbar.a|g' /tmp/dist/libtorrent/usr/local/lib/pkgconfig/libtorrent-rasterbar.pc
+        ;;
+    autotools)
+        echo "using gcc : : : <cflags>\"-march=native -std=${stdcver}\" <cxxflags>\"-march=native -std=${stdcver}\" ;" >/root/user-config.jam
+        /opt/boost_${BOOST_VERSION}/b2 -j$(nproc) crypto=${cryptography_type} variant=release link=static install --prefix=/tmp/dist/libtorrent/usr/local install >>${log} 2>&1
+        ;;
+    *)
+        echo_error "Build type must be cmake or autotools"
+        exit 1
+        ;;
     esac
     tag=" static with ${stdcver} march=native"
     mkdir -p /root/dist
-    fpm -f -C /tmp/dist/libtorrent -p /root/dist/libtorrent-rasterbar_VERSION.deb -s dir -t deb -n libtorrent-rasterbar --version ${VERSION} --description "Libtorrent rasterbar compiled by swizzin$tag" >> ${log} 2>&1
+    fpm -f -C /tmp/dist/libtorrent -p /root/dist/libtorrent-rasterbar_VERSION.deb -s dir -t deb -n libtorrent-rasterbar --version ${VERSION} --description "Libtorrent rasterbar compiled by swizzin$tag" >>${log} 2>&1
     cd /tmp
     rm_if_exists /tmp/libtorrent
     rm_if_exists /tmp/dist
-    dpkg -i /root/dist/libtorrent-rasterbar_${VERSION}.deb >> ${log} 2>&1 || {
+    dpkg -i /root/dist/libtorrent-rasterbar_${VERSION}.deb >>${log} 2>&1 || {
         echo_error "Libtorrent could not be installed. Setup will not proceed"
         exit 1
     }
@@ -399,12 +497,12 @@ function build_qbittorrent() {
 
     apt_install --no-recommends $LIST
     rm_if_exists "/tmp/qbittorrent"
-    wget -O /tmp/release-${VERSION}.tar.gz https://github.com/qbittorrent/qBittorrent/archive/release-${VERSION}.tar.gz >> "${log}" 2>&1 || {
+    wget -O /tmp/release-${VERSION}.tar.gz https://github.com/qbittorrent/qBittorrent/archive/release-${VERSION}.tar.gz >>"${log}" 2>&1 || {
         echo_error "qBittorrent could not be downloaded. Setup will not proceed"
         exit 1
     }
     mkdir -p /tmp/qbittorrent
-    tar -xvf /tmp/release-${VERSION}.tar.gz -C /tmp/qbittorrent --strip-components=1 >> $log 2>&1
+    tar -xvf /tmp/release-${VERSION}.tar.gz -C /tmp/qbittorrent --strip-components=1 >>$log 2>&1
     rm -rf /tmp/release-${VERSION}.tar.gz
 
     cd /tmp/qbittorrent
@@ -412,42 +510,42 @@ function build_qbittorrent() {
     #Ensure boost variables are loaded (i.e. libtorrent skipped)
     booststrap
     case $build_type in
-        cmake)
-            PATH=/opt/local/bin:${PATH} cmake -Wno-dev -Wno-deprecated -G Ninja -B build \
-                -D CMAKE_BUILD_TYPE="release" \
-                -D CMAKE_CXX_STANDARD="${stdcver//[^0-9]/}" \
-                -D QT6="${qbt_use_qt6:=OFF}" \
-                -D Boost_NO_BOOST_CMAKE=TRUE \
-                -D CMAKE_CXX_FLAGS="${CXXFLAGS}" \
-                -D CMAKE_C_FLAGS="${CFLAGS}" \
-                -D GUI=OFF \
-                -D CMAKE_INSTALL_PREFIX="/tmp/dist/qbittorrent/usr" >> ${log} 2>&1
-            PATH=/opt/local/bin:${PATH} cmake --build build >> ${log} 2>&1
-            PATH=/opt/local/bin:${PATH} cmake --install build >> ${log} 2>&1
-            ;;
-        autotools)
-            ./configure --prefix=/usr --disable-gui --with-boost=${BOOST_ROOT} --with-boost-libdir="/usr/local/lib" libtorrent_CFLAGS="-I/usr/local/include -I${BOOST_ROOT}" libtorrent_LIBS="-L/usr/local/lib -l:libtorrent-rasterbar.a -lssl -lcrypto" CXXFLAGS="-march=native -std=${stdcver}" ${QT_SWIZZIN} >> ${log} 2>&1
-            make -j$(nproc) >> $log 2>&1
-            make INSTALL_ROOT=/tmp/dist/qbittorrent install >> ${log} 2>&1
-            ;;
-        *)
-            echo_error "Build type must be cmake or autotools"
-            exit 1
-            ;;
+    cmake)
+        PATH=/opt/local/bin:${PATH} cmake -Wno-dev -Wno-deprecated -G Ninja -B build \
+            -D CMAKE_BUILD_TYPE="release" \
+            -D CMAKE_CXX_STANDARD="${stdcver//[^0-9]/}" \
+            -D QT6="${qbt_use_qt6:=OFF}" \
+            -D Boost_NO_BOOST_CMAKE=TRUE \
+            -D CMAKE_CXX_FLAGS="${CXXFLAGS}" \
+            -D CMAKE_C_FLAGS="${CFLAGS}" \
+            -D GUI=OFF \
+            -D CMAKE_INSTALL_PREFIX="/tmp/dist/qbittorrent/usr" >>${log} 2>&1
+        PATH=/opt/local/bin:${PATH} cmake --build build >>${log} 2>&1
+        PATH=/opt/local/bin:${PATH} cmake --install build >>${log} 2>&1
+        ;;
+    autotools)
+        ./configure --prefix=/usr --disable-gui --with-boost=${BOOST_ROOT} --with-boost-libdir="/usr/local/lib" libtorrent_CFLAGS="-I/usr/local/include -I${BOOST_ROOT}" libtorrent_LIBS="-L/usr/local/lib -l:libtorrent-rasterbar.a -lssl -lcrypto" CXXFLAGS="-march=native -std=${stdcver}" ${QT_SWIZZIN} >>${log} 2>&1
+        make -j$(nproc) >>$log 2>&1
+        make INSTALL_ROOT=/tmp/dist/qbittorrent install >>${log} 2>&1
+        ;;
+    *)
+        echo_error "Build type must be cmake or autotools"
+        exit 1
+        ;;
     esac
     #install qbt-cli
     qbt_cli_version=$(github_latest_version ludviglundgren/qbittorrent-cli)
     cd /tmp/dist/qbittorrent/usr/bin
-    wget -O qbtcli.tar.gz https://github.com/ludviglundgren/qbittorrent-cli/releases/download/${qbt_cli_version}/qbittorrent-cli_${qbt_cli_version//v/}_linux_$(_os_arch).tar.gz >> ${log} 2>&1
-    tar xvf qbtcli.tar.gz >> ${log} 2>&1
-    rm -f qbtcli.tar.gz README.md >> ${log} 2>&1
+    wget -O qbtcli.tar.gz https://github.com/ludviglundgren/qbittorrent-cli/releases/download/${qbt_cli_version}/qbittorrent-cli_${qbt_cli_version//v/}_linux_$(_os_arch).tar.gz >>${log} 2>&1
+    tar xvf qbtcli.tar.gz >>${log} 2>&1
+    rm -f qbtcli.tar.gz README.md >>${log} 2>&1
     mkdir -p /root/dist
-    fpm -f -C /tmp/dist/qbittorrent -p /root/dist/qbittorrent-nox_VERSION.deb -s dir -t deb -n qbittorrent-nox --version ${VERSION} --description "qbittorrent-nox compiled by swizzin$tag" >> ${log} 2>&1
-    dpkg -i /root/dist/qbittorrent-nox_${VERSION}.deb >> ${log} 2>&1 || {
+    fpm -f -C /tmp/dist/qbittorrent -p /root/dist/qbittorrent-nox_VERSION.deb -s dir -t deb -n qbittorrent-nox --version ${VERSION} --description "qbittorrent-nox compiled by swizzin$tag" >>${log} 2>&1
+    dpkg -i /root/dist/qbittorrent-nox_${VERSION}.deb >>${log} 2>&1 || {
         echo_error "qBittorrent could not be installed. Setup will not proceed"
         exit 1
     }
-    apt-mark hold qbittorrent-nox >> ${log} 2>&1
+    apt-mark hold qbittorrent-nox >>${log} 2>&1
     cd /tmp
     rm_if_exists /tmp/qbittorrent
     rm_if_exists /tmp/dist
@@ -462,7 +560,7 @@ function qbittorrent_service() {
         if [[ $(systemctl --version | awk 'NR==1 {print $2}') -ge 240 ]]; then
             type=exec
         fi
-        cat > /etc/systemd/system/qbittorrent@.service << EOQBS
+        cat >/etc/systemd/system/qbittorrent@.service <<EOQBS
 [Unit]
 Description=qBittorrent-nox service for %i
 Documentation=man:qbittorrent-nox(1)
@@ -494,7 +592,7 @@ function qbittorrent_user_config() {
         QBTWP="WebUI\Password_PBKDF2=\"@ByteArray($hashed)\""
     fi
 
-    usermod -a -G ${user} www-data 2>> $log
+    usermod -a -G ${user} www-data 2>>$log
     port=$(port 10000 11000)
     mkdir -p /home/${user}/.config/qBittorrent/
     mkdir -p /home/${user}/torrents/qbittorrent
@@ -502,7 +600,7 @@ function qbittorrent_user_config() {
     chown ${user}: /home/${user}/torrents/qbittorrent
     chown $user: /home/${user}/.config
     chown $user: /home/${user}/.config/qBittorrent
-    cat > /home/${user}/.config/qBittorrent/qBittorrent.conf << QBTCONF
+    cat >/home/${user}/.config/qBittorrent/qBittorrent.conf <<QBTCONF
 [BitTorrent]
 Session\DisableAutoTMMByDefault=false 
 
@@ -536,7 +634,7 @@ function qbittorrent_chpasswd() {
     user=$1
     password=$2
     local_packages=/usr/local/bin/swizzin
-    qbtv=$(qbittorrent-nox --version 2> /dev/null | grep -oP '\d+\.\d+\.\d+' || echo '0.0.0.0')
+    qbtv=$(qbittorrent-nox --version 2>/dev/null | grep -oP '\d+\.\d+\.\d+' || echo '0.0.0.0')
     active=$(systemctl is-active qbittorrent@${user})
     if dpkg --compare-versions ${qbtv} lt 4.2.0; then
         hashed=$(echo -n "$password" | md5sum | awk '{print $1}')
@@ -551,3 +649,4 @@ function qbittorrent_chpasswd() {
         systemctl start qbittorrent@${user}
     fi
 }
+

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -327,15 +327,15 @@ function build_libtorrent_qbittorrent() {
             qbt_libtorrent_version=1.2
             ;;
     esac
-
+    
     libtorrent_github_tag_default="$(grep -Eom1 "v${qbt_libtorrent_version}.([0-9]{1,2})" <<< "${libtorrent_github_tags_list}")"
     libtorrent_github_tag="${libtorrent_github_tag:-$libtorrent_github_tag_default}"
-
+    
     git clone --no-tags --single-branch --branch "${libtorrent_github_tag}" --shallow-submodules --recurse-submodules -j"$(nproc)" --depth 1 "https://github.com/arvidn/libtorrent.git" "/tmp/libtorrent">> ${log} 2>&1 || {
         echo_error "Libtorrent could not be cloned from git. Setup will not proceed"
         exit 1
     }
- 
+
     cd /tmp/libtorrent
     if [[ -f /root/libtorrent-${libtorrent_branch}.patch ]]; then
         patch -p1 < /root/libtorrent-${libtorrent_branch}.patch >> ${log} 2>&1 || {

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -309,11 +309,30 @@ function build_libtorrent_qbittorrent() {
     rm_if_exists /tmp/libtorrent
     booststrap
     apt_install libssl-dev
-    git clone -b ${libtorrent_branch} --depth 1 --recurse-submodules https://github.com/arvidn/libtorrent /tmp/libtorrent >> ${log} 2>&1 || {
+    
+    libtorrent_github_url="https://github.com/arvidn/libtorrent.git"
+    libtorrent_github_tags_list=$(git ls-remote -q -t --refs https://github.com/arvidn/libtorrent.git | awk '/\/v/{sub("refs/tags/", "");sub("(.*)(-[^0-9].*)(.*)", ""); print $2 }' | awk '!/^$/' | sort -rV)
+
+    case $libtorrent_branch in
+        RC_1_2)
+            qbt_libtorrent_version=1.2
+            ;;
+        RC_2_0)
+            qbt_libtorrent_version=2.0
+            ;;
+        *)
+            qbt_libtorrent_version=1.2
+            ;;
+    esac
+
+    libtorrent_github_tag_default="$(grep -Eom1 "v${qbt_libtorrent_version}.([0-9]{1,2})" <<< "${libtorrent_github_tags_list}")"
+    libtorrent_github_tag="${libtorrent_github_tag:-$libtorrent_github_tag_default}"
+
+    git clone --no-tags --single-branch --branch "${libtorrent_github_tag}" --shallow-submodules --recurse-submodules -j"$(nproc)" --depth 1 "https://github.com/arvidn/libtorrent.git" "/tmp/libtorrent">> ${log} 2>&1 || {
         echo_error "Libtorrent could not be cloned from git. Setup will not proceed"
         exit 1
     }
-
+ 
     cd /tmp/libtorrent
     if [[ -f /root/libtorrent-${libtorrent_branch}.patch ]]; then
         patch -p1 < /root/libtorrent-${libtorrent_branch}.patch >> ${log} 2>&1 || {

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -333,7 +333,7 @@ function build_libtorrent_qbittorrent() {
             if [[ $(get_candidate_version cmake) < 3.16 ]]; then
                 install_cmake_swizzin
             else
-                apt_install cmake
+                apt_install cmake ninja-build
             fi
 
             PATH=/opt/local/bin:${PATH} cmake -Wno-dev -Wno-deprecated -G Ninja -B build \

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -335,7 +335,7 @@ function build_libtorrent_qbittorrent() {
             else
                 apt_install cmake
             fi
-            
+
             PATH=/opt/local/bin:${PATH} cmake -Wno-dev -Wno-deprecated -G Ninja -B build \
                 -D CMAKE_BUILD_TYPE="Release" \
                 -D CMAKE_CXX_STANDARD="${stdcver//[^0-9]/}" \

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -330,6 +330,12 @@ function build_libtorrent_qbittorrent() {
     VERSION=$(grep -oP "VERSION\ = \K\d\.\d\.\d+" Jamfile)
     case $build_type in
         cmake)
+            if [[ $(get_candidate_version cmake) < 3.16 ]]; then
+                install_cmake_swizzin
+            else
+                apt_install cmake
+            fi
+            
             PATH=/opt/local/bin:${PATH} cmake -Wno-dev -Wno-deprecated -G Ninja -B build \
                 -D CMAKE_BUILD_TYPE="Release" \
                 -D CMAKE_CXX_STANDARD="${stdcver//[^0-9]/}" \

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -309,7 +309,7 @@ function build_libtorrent_qbittorrent() {
     rm_if_exists /tmp/libtorrent
     booststrap
     apt_install libssl-dev
-    
+
     libtorrent_github_url="https://github.com/arvidn/libtorrent.git"
     libtorrent_github_tags_list=$(git ls-remote -q -t --refs https://github.com/arvidn/libtorrent.git | awk '/\/v/{sub("refs/tags/", "");sub("(.*)(-[^0-9].*)(.*)", ""); print $2 }' | awk '!/^$/' | sort -rV)
 
@@ -327,11 +327,11 @@ function build_libtorrent_qbittorrent() {
             qbt_libtorrent_version=1.2
             ;;
     esac
-    
+
     libtorrent_github_tag_default="$(grep -Eom1 "v${qbt_libtorrent_version}.([0-9]{1,2})" <<< "${libtorrent_github_tags_list}")"
     libtorrent_github_tag="${libtorrent_github_tag:-$libtorrent_github_tag_default}"
-    
-    git clone --no-tags --single-branch --branch "${libtorrent_github_tag}" --shallow-submodules --recurse-submodules -j"$(nproc)" --depth 1 "https://github.com/arvidn/libtorrent.git" "/tmp/libtorrent">> ${log} 2>&1 || {
+
+    git clone --no-tags --single-branch --branch "${libtorrent_github_tag}" --shallow-submodules --recurse-submodules -j"$(nproc)" --depth 1 "https://github.com/arvidn/libtorrent.git" "/tmp/libtorrent" >> ${log} 2>&1 || {
         echo_error "Libtorrent could not be cloned from git. Setup will not proceed"
         exit 1
     }


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description
<!-- Any general story time goes here :) Feel free to add screenshots/recording of your change in action here-->

Closes discord reports of libtorrent failing to compile due to UTP failure (bad commit from upstream) by turning lt branch into tagged release. 

Closes discord reports of deluge failing to build master (due to master being swapped to 2.1)

## Fixes issues: 
- Discord report from WalkerServers (LT 1.2 build failures)
- Discord report from @stickz (Deluge 2.1 build failures)

## Proposed Changes:
- Add logic from userdocs script to determine a pinned version of libtorrent relative to branch. (fixes https://github.com/arvidn/libtorrent/issues/7158 by tracking versions instead of branch) - achieved in sources/functions/libtorrent functions.
- Add support for Deluge 2.1 - edits to the deluge function file
- Allow users to `export LIBTORRENT_VERSION` for custom versions of libtorrent to be used with deluge - edits to the deluge function file
- Version bump for qbit deps (and fix missing)
- Boost version bump (1.75.0 to 1.80.0)

## Change Categories
<!-- DELETE WHICHEVER BULLET DOES NOT APPLY -->
- Bug fix <!-- non-breaking change which fixes an issue -->
- Change in `functions` <!-- e.g. `utils`, `os`, `apt`, `ask`, etc. -->

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [x] Docs have been made OR are not necessary
    - PR link: 
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Testing was done
   - [x] Tests created or no new tests necessary
   - [x] Tests executed

## Test scenarios
<!-- Please let us know what has been done or anything else that works/doesn't. Feel free to copy-paste the examples at the bottom of this section -->

### Architectures
<!--
Please use these emojis here to fill the table below. It will nicely auto-format with spacing, don't worry. Leave empty wherever you do not know / have not tested
✅ = Works successfully
❎ = Does not work BUT is handled gracefully
🛠 = Still WIP
❌ = Broken / not working
-->
|   			| `amd64` 	| `armhf` 	| `arm64` 	| Unspecified 	|
|--------		|-------- 	|-------- 	|-------- 	|----------		|
| Jammy 		|			|			|			|				|
| Focal 		|			|			|			|				|
| Bionic		|			|			|			|				|
| Bullseye		|		✅	|			|			|				|
| Buster		|			|			|			|				|
| Stretch		|			|			|			|				|
| Raspbian  	|	⚫️		|			|	⚫️		|	⚫️			|

### ✅❎ Passed

qBit 4.3.9 / LT 1.2 on Debian 11 x64
Deluge 1.3 / LT 1.1 on Debian 11 x64
Deluge 2.1 / LT 1.2 on Debian 11 x64
Deluge 2.0 / LT 1.2 on Debian 11 x64
qBit 4.4.5 / LT 1.2 on Debian 11 x64

### 🛠🛠 TODO

LT 1.2 -> Needs Jamfile to patch Boost 1.80 builds (https://github.com/userdocs/qbittorrent-nox-static/blob/master/patches/libtorrent/1.2.17/Jamfile)

### ❌❌ Currently failing

<!-- EXAMPLES :
- Fresh app install without nginx
    - With only one user
    - With multiple users present
- Fresh Install with nginx present nginx
    - With only one user
    - With multiple users present
- Fresh install and nginx install afterwards
    - With only one user
    - With multiple users present
- Update from version in master
- Upgrade from version in master
- Password gets changed from `box` in app
- User removal from `box` acting on app
- New user in `box` gets added to app
- Sysinfo compatibility
    - Info washed
    - Content available
-->

