### PR TITLE
Fix header location for nextcloud installation

### DIFF
--- a/scripts/install/nextcloud.sh
+++ b/scripts/install/nextcloud.sh
@@ -132,6 +132,25 @@ location = /.well-known/caldav {
 location /.well-known/acme-challenge { }
 
 location ^~ /nextcloud {
+    add_header Cache-Control "public, max-age=15778463";
+    # Add headers to serve security related headers  (It is intended
+    # to have those duplicated to the ones above)
+    # Before enabling Strict-Transport-Security headers please read
+    # into this topic first.
+    #add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;" always;
+    #
+    # WARNING: Only add the preload option once you read about
+    # the consequences in https://hstspreload.org/. This option
+    # will add the domain to a hardcoded list that is shipped
+    # in all major browsers and getting removed from this list
+    # could take several months.
+    add_header Referrer-Policy "no-referrer" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Download-Options "noopen" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Permitted-Cross-Domain-Policies "none" always;
+    add_header X-Robots-Tag "none" always;
+    add_header X-XSS-Protection "1; mode=block" always;
 
     # set max upload size
     client_max_body_size 512M;
@@ -186,26 +205,6 @@ location ^~ /nextcloud {
     # Make sure it is BELOW the PHP block
     location ~ ^\/nextcloud\/.+[^\/]\.(?:css|js|woff2?|svg|gif|map)\$ {
         try_files \$uri /nextcloud/index.php\$request_uri;
-        add_header Cache-Control "public, max-age=15778463";
-        # Add headers to serve security related headers  (It is intended
-        # to have those duplicated to the ones above)
-        # Before enabling Strict-Transport-Security headers please read
-        # into this topic first.
-        #add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;" always;
-        #
-        # WARNING: Only add the preload option once you read about
-        # the consequences in https://hstspreload.org/. This option
-        # will add the domain to a hardcoded list that is shipped
-        # in all major browsers and getting removed from this list
-        # could take several months.
-        add_header Referrer-Policy "no-referrer" always;
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header X-Download-Options "noopen" always;
-        add_header X-Frame-Options "SAMEORIGIN" always;
-        add_header X-Permitted-Cross-Domain-Policies "none" always;
-        add_header X-Robots-Tag "none" always;
-        add_header X-XSS-Protection "1; mode=block" always;
-
         # Optional: Don't log access to assets
         access_log off;
     }


### PR DESCRIPTION
Currently the headers are in the wrong place in the nginx config.

<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description
In the current status the recommended headers for a nextcloud installation are not set (can be checked with `curl -I tld/nextcloud`). This commit fixes the headers.

## Fixes issues: 
- Un-tracked issue

## Proposed Changes:
- Put the headers in the right position in the nginx config.

## Change Categories
<!-- DELETE WHICHEVER BULLET DOES NOT APPLY -->
- Bug fix <!-- non-breaking change which fixes an issue -->


## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [ ] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [x] Docs have been made OR are not necessary
    - PR link: 
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [ ] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Testing was done
   - [ ] Tests created or no new tests necessary
   - [ ] Tests executed


