### PR TITLE
rTorrent: Installation speed improvements

### DIFF
--- a/scripts/install/rtorrent.sh
+++ b/scripts/install/rtorrent.sh
@@ -98,6 +98,7 @@ if [[ -n $noexec ]]; then
 fi
 depends_rtorrent
 if [[ ! $rtorrentver == repo ]]; then
+    configure_rtorrent
     echo_progress_start "Building xmlrpc-c from source"
     build_xmlrpc-c
     echo_progress_done

--- a/scripts/upgrade/rtorrent.sh
+++ b/scripts/upgrade/rtorrent.sh
@@ -34,6 +34,7 @@ echo_progress_start "Checking rTorrent Dependencies ... "
 depends_rtorrent
 echo_progress_done
 if [[ ! $rtorrentver == repo ]]; then
+    configure_rtorrent
     echo_progress_start "Building xmlrpc-c from source ... "
     build_xmlrpc-c
     echo_progress_done

--- a/sources/functions/rtorrent
+++ b/sources/functions/rtorrent
@@ -63,7 +63,7 @@ function depends_rtorrent() {
 
     # mktorrent from source
     cd /tmp
-    wget -q -O mktorrent.zip https://github.com/Rudde/mktorrent/archive/v1.1.zip >> $log 2>&1
+    curl -sL https://github.com/Rudde/mktorrent/archive/v1.1.zip -o mktorrent.zip >> $log 2>&1rm
     . /etc/swizzin/sources/functions/utils
     rm_if_exists "/tmp/mktorrent"
     unzip -d mktorrent -j mktorrent.zip >> $log 2>&1

--- a/sources/functions/rtorrent
+++ b/sources/functions/rtorrent
@@ -63,7 +63,7 @@ function depends_rtorrent() {
 
     # mktorrent from source
     cd /tmp
-    curl -sL https://github.com/Rudde/mktorrent/archive/v1.1.zip -o mktorrent.zip >> $log 2>&1rm
+    curl -sL https://github.com/Rudde/mktorrent/archive/v1.1.zip -o mktorrent.zip >> $log 2>&1
     . /etc/swizzin/sources/functions/utils
     rm_if_exists "/tmp/mktorrent"
     unzip -d mktorrent -j mktorrent.zip >> $log 2>&1

--- a/sources/functions/rtorrent
+++ b/sources/functions/rtorrent
@@ -143,7 +143,11 @@ function build_libtorrent_rakshasa() {
     if [ $(nproc) -ge 4 ]; then
         flto="-flto=$(nproc)"
     fi
-    make -j$(nproc) CXXFLAGS="-O2 ${flto}" >> $log 2>&1 || {
+    level="-O2"
+    if [ $(nproc) -le 2 ]; then
+        level="-O1"
+    fi
+    make -j$(nproc) CXXFLAGS="${level} ${flto}" >> $log 2>&1 || {
         echo_error "Something went wrong while making libtorrent"
         exit 1
     }
@@ -193,7 +197,11 @@ function build_rtorrent() {
     if [ $(nproc) -ge 4 ]; then
         flto="-flto=$(nproc)"
     fi
-    make -j$(nproc) CXXFLAGS="-O2 ${flto} ${stdc}" >> $log 2>&1 || {
+    level="-O2"
+    if [ $(nproc) -le 2 ]; then
+        level="-O1"
+    fi
+    make -j$(nproc) CXXFLAGS="${level} ${flto} ${stdc}" >> $log 2>&1 || {
         echo_error "Something went wrong while making rtorrent"
         exit 1
     }

--- a/sources/functions/rtorrent
+++ b/sources/functions/rtorrent
@@ -92,7 +92,12 @@ function build_xmlrpc-c() {
     if [ $(nproc) -ge 4 ]; then
         flto="-flto=$(nproc)"
     fi
-    make -j$(nproc) CFLAGS="${flto}" >> $log 2>&1
+    memory = $(awk '/MemAvailable/ {printf( "%.f\n", $2 / 1024 )}' /proc/meminfo)
+    pipe=
+    if [[ $memory > 1024 ]]; then
+        pipe="-pipe"
+    fi
+    make -j$(nproc) CFLAGS="${flto} ${pipe}" >> $log 2>&1
     make DESTDIR=/tmp/dist/xmlrpc-c install >> $log 2>&1 || {
         echo_error "Something went wrong while making xmlrpc"
         exit 1
@@ -147,7 +152,12 @@ function build_libtorrent_rakshasa() {
     if [ $(nproc) -le 2 ]; then
         level="-O1"
     fi
-    make -j$(nproc) CXXFLAGS="${level} ${flto}" >> $log 2>&1 || {
+    memory = $(awk '/MemAvailable/ {printf( "%.f\n", $2 / 1024 )}' /proc/meminfo)
+    pipe=
+    if [[ $memory > 1024 ]]; then
+        pipe="-pipe"
+    fi
+    make -j$(nproc) CXXFLAGS="${level} ${flto} ${pipe}" >> $log 2>&1 || {
         echo_error "Something went wrong while making libtorrent"
         exit 1
     }
@@ -201,7 +211,12 @@ function build_rtorrent() {
     if [ $(nproc) -le 2 ]; then
         level="-O1"
     fi
-    make -j$(nproc) CXXFLAGS="${level} ${flto} ${stdc}" >> $log 2>&1 || {
+    memory = $(awk '/MemAvailable/ {printf( "%.f\n", $2 / 1024 )}' /proc/meminfo)
+    pipe=
+    if [[ $memory > 1024 ]]; then
+        pipe="-pipe"
+    fi
+    make -j$(nproc) CXXFLAGS="${level} ${flto} ${pipe} ${stdc}" >> $log 2>&1 || {
         echo_error "Something went wrong while making rtorrent"
         exit 1
     }

--- a/sources/functions/rtorrent
+++ b/sources/functions/rtorrent
@@ -116,9 +116,9 @@ function build_libtorrent_rakshasa() {
     . /etc/swizzin/sources/functions/utils
     rm_if_exists "/tmp/libtorrent"
     mkdir /tmp/libtorrent
-    wget -q ${libtorrentloc} -O /tmp/libtorrent-${libtorrentver}.tar.gz
+    curl -sL ${libtorrentloc} -o /tmp/libtorrent-${libtorrentver}.tar.gz
     VERSION=$libtorrentver
-    tar -xvf /tmp/libtorrent-${libtorrentver}.tar.gz -C /tmp/libtorrent --strip-components=1 >> $log 2>&1
+    tar -xf /tmp/libtorrent-${libtorrentver}.tar.gz -C /tmp/libtorrent --strip-components=1 >> $log 2>&1
     cd /tmp/libtorrent >> $log 2>&1
 
     if [[ -f /root/libtorrent-rakshasa-${libtorrentver}.patch ]]; then
@@ -177,8 +177,8 @@ function build_rtorrent() {
     . /etc/swizzin/sources/functions/utils
     rm_if_exists "/tmp/rtorrent*"
     mkdir /tmp/rtorrent
-    wget -q ${rtorrentloc} -O /tmp/rtorrent-${rtorrentver}.tar.gz
-    tar -xzvf /tmp/rtorrent-${rtorrentver}.tar.gz -C /tmp/rtorrent --strip-components=1 >> $log 2>&1
+    curl -sL ${rtorrentloc} -o /tmp/rtorrent-${rtorrentver}.tar.gz
+    tar -xzf /tmp/rtorrent-${rtorrentver}.tar.gz -C /tmp/rtorrent --strip-components=1 >> $log 2>&1
     VERSION=$rtorrentver
     cd /tmp/rtorrent
     if [[ -f /root/rtorrent-${rtorrentver}.patch ]]; then

--- a/sources/functions/rtorrent
+++ b/sources/functions/rtorrent
@@ -97,7 +97,7 @@ function build_xmlrpc-c() {
     if [[ $memory > 1024 ]]; then
         pipe="-pipe"
     fi
-    make -j$(nproc) CFLAGS="${flto} ${pipe}" >> $log 2>&1
+    make -j$(nproc) CFLAGS="-w ${flto} ${pipe}" >> $log 2>&1
     make DESTDIR=/tmp/dist/xmlrpc-c install >> $log 2>&1 || {
         echo_error "Something went wrong while making xmlrpc"
         exit 1
@@ -157,7 +157,7 @@ function build_libtorrent_rakshasa() {
     if [[ $memory > 1024 ]]; then
         pipe="-pipe"
     fi
-    make -j$(nproc) CXXFLAGS="${level} ${flto} ${pipe}" >> $log 2>&1 || {
+    make -j$(nproc) CXXFLAGS="-w ${level} ${flto} ${pipe}" >> $log 2>&1 || {
         echo_error "Something went wrong while making libtorrent"
         exit 1
     }
@@ -216,7 +216,7 @@ function build_rtorrent() {
     if [[ $memory > 1024 ]]; then
         pipe="-pipe"
     fi
-    make -j$(nproc) CXXFLAGS="${level} ${flto} ${pipe} ${stdc}" >> $log 2>&1 || {
+    make -j$(nproc) CXXFLAGS="-w ${level} ${flto} ${pipe} ${stdc}" >> $log 2>&1 || {
         echo_error "Something went wrong while making rtorrent"
         exit 1
     }

--- a/sources/functions/rtorrent
+++ b/sources/functions/rtorrent
@@ -46,6 +46,30 @@ function whiptail_rtorrent() {
     fi
 }
 
+function configure_rtorrent() {    
+    # Link time optimizations for 4 plus threads
+    flto=
+    if [ $(nproc) -ge 4 ]; then
+        flto="-flto=$(nproc)"
+    fi    
+    export rtorrentflto=${flto}
+    
+    # pipe optimizations for 512MB plus memory
+    memory=$(awk '/MemAvailable/ {printf( "%.f\n", $2 / 1024 )}' /proc/meminfo)
+    pipe=
+    if [[ $memory > 512 ]]; then
+        pipe="-pipe"
+    fi
+    export rtorrentpipe=${pipe}
+    
+    # GCC optimization level for program compilation
+    level="-O2"
+    if [ $(nproc) -le 2 ]; then
+        level="-O1"
+    fi
+    export rtorrentlevel=${level}
+}
+
 function depends_rtorrent() {
     if [[ ! $rtorrentver == repo ]]; then
         APT='subversion dos2unix bc screen zip unzip sysstat build-essential comerr-dev
@@ -88,16 +112,7 @@ function build_xmlrpc-c() {
     }
     source <(sed 's/ //g' version.mk)
     VERSION=$XMLRPC_MAJOR_RELEASE.$XMLRPC_MINOR_RELEASE.$XMLRPC_POINT_RELEASE
-    flto=
-    if [ $(nproc) -ge 4 ]; then
-        flto="-flto=$(nproc)"
-    fi
-    memory=$(awk '/MemAvailable/ {printf( "%.f\n", $2 / 1024 )}' /proc/meminfo)
-    pipe=
-    if [[ $memory > 512 ]]; then
-        pipe="-pipe"
-    fi
-    make -j$(nproc) CFLAGS="-w ${flto} ${pipe}" >> $log 2>&1
+    make -j$(nproc) CFLAGS="-w ${rtorrentflto} ${rtorrentpipe}" >> $log 2>&1
     make DESTDIR=/tmp/dist/xmlrpc-c install >> $log 2>&1 || {
         echo_error "Something went wrong while making xmlrpc"
         exit 1
@@ -144,20 +159,7 @@ function build_libtorrent_rakshasa() {
         echo_error "Something went wrong while configuring libtorrent"
         exit 1
     }
-    flto=
-    if [ $(nproc) -ge 4 ]; then
-        flto="-flto=$(nproc)"
-    fi
-    level="-O2"
-    if [ $(nproc) -le 2 ]; then
-        level="-O1"
-    fi
-    memory=$(awk '/MemAvailable/ {printf( "%.f\n", $2 / 1024 )}' /proc/meminfo)
-    pipe=
-    if [[ $memory > 512 ]]; then
-        pipe="-pipe"
-    fi
-    make -j$(nproc) CXXFLAGS="-w ${level} ${flto} ${pipe}" >> $log 2>&1 || {
+    make -j$(nproc) CXXFLAGS="-w ${rtorrentlevel} ${rtorrentflto} ${rtorrentpipe}" >> $log 2>&1 || {
         echo_error "Something went wrong while making libtorrent"
         exit 1
     }
@@ -203,20 +205,7 @@ function build_rtorrent() {
         echo_error "Something went wrong while configuring rtorrent"
         exit 1
     }
-    flto=
-    if [ $(nproc) -ge 4 ]; then
-        flto="-flto=$(nproc)"
-    fi
-    level="-O2"
-    if [ $(nproc) -le 2 ]; then
-        level="-O1"
-    fi
-    memory=$(awk '/MemAvailable/ {printf( "%.f\n", $2 / 1024 )}' /proc/meminfo)
-    pipe=
-    if [[ $memory > 512 ]]; then
-        pipe="-pipe"
-    fi
-    make -j$(nproc) CXXFLAGS="-w ${level} ${flto} ${pipe} ${stdc}" >> $log 2>&1 || {
+    make -j$(nproc) CXXFLAGS="-w ${rtorrentlevel} ${rtorrentflto} ${rtorrentpipe} ${stdc}" >> $log 2>&1 || {
         echo_error "Something went wrong while making rtorrent"
         exit 1
     }

--- a/sources/functions/rtorrent
+++ b/sources/functions/rtorrent
@@ -92,9 +92,9 @@ function build_xmlrpc-c() {
     if [ $(nproc) -ge 4 ]; then
         flto="-flto=$(nproc)"
     fi
-    memory = $(awk '/MemAvailable/ {printf( "%.f\n", $2 / 1024 )}' /proc/meminfo)
+    memory=$(awk '/MemAvailable/ {printf( "%.f\n", $2 / 1024 )}' /proc/meminfo)
     pipe=
-    if [[ $memory > 1024 ]]; then
+    if [[ $memory > 512 ]]; then
         pipe="-pipe"
     fi
     make -j$(nproc) CFLAGS="-w ${flto} ${pipe}" >> $log 2>&1
@@ -152,9 +152,9 @@ function build_libtorrent_rakshasa() {
     if [ $(nproc) -le 2 ]; then
         level="-O1"
     fi
-    memory = $(awk '/MemAvailable/ {printf( "%.f\n", $2 / 1024 )}' /proc/meminfo)
+    memory=$(awk '/MemAvailable/ {printf( "%.f\n", $2 / 1024 )}' /proc/meminfo)
     pipe=
-    if [[ $memory > 1024 ]]; then
+    if [[ $memory > 512 ]]; then
         pipe="-pipe"
     fi
     make -j$(nproc) CXXFLAGS="-w ${level} ${flto} ${pipe}" >> $log 2>&1 || {
@@ -211,9 +211,9 @@ function build_rtorrent() {
     if [ $(nproc) -le 2 ]; then
         level="-O1"
     fi
-    memory = $(awk '/MemAvailable/ {printf( "%.f\n", $2 / 1024 )}' /proc/meminfo)
+    memory=$(awk '/MemAvailable/ {printf( "%.f\n", $2 / 1024 )}' /proc/meminfo)
     pipe=
-    if [[ $memory > 1024 ]]; then
+    if [[ $memory > 512 ]]; then
         pipe="-pipe"
     fi
     make -j$(nproc) CXXFLAGS="-w ${level} ${flto} ${pipe} ${stdc}" >> $log 2>&1 || {

--- a/sources/functions/rtorrent
+++ b/sources/functions/rtorrent
@@ -46,28 +46,26 @@ function whiptail_rtorrent() {
     fi
 }
 
-function configure_rtorrent() {    
+function configure_rtorrent() {
     # Link time optimizations for 4 plus threads
-    flto=
     if [ $(nproc) -ge 4 ]; then
-        flto="-flto=$(nproc)"
-    fi    
-    export rtorrentflto=${flto}
-    
+        export rtorrentflto="-flto=$(nproc)"
+    else
+        export rtorrentflto=""
+    fi
     # pipe optimizations for 512MB plus memory
     memory=$(awk '/MemAvailable/ {printf( "%.f\n", $2 / 1024 )}' /proc/meminfo)
-    pipe=
     if [[ $memory > 512 ]]; then
-        pipe="-pipe"
+        export rtorrentpipe="-pipe"
+    else
+        export rtorrentpipe=""
     fi
-    export rtorrentpipe=${pipe}
-    
     # GCC optimization level for program compilation
-    level="-O2"
     if [ $(nproc) -le 2 ]; then
-        level="-O1"
+        export rtorrentlevel="-O1"
+    else
+        export rtorrentlevel="-O2"
     fi
-    export rtorrentlevel=${level}
 }
 
 function depends_rtorrent() {


### PR DESCRIPTION
Compile libtorrent and rtorrent with level 1 optimizations if there are 2 or less processor threads available.
- This drastically reduces build times on systems such as virtual machines. It is still better than level 0 repo.

Compile xmlrpc, libtorrent and rtorrent with piping if at least 512 MB of memory is available.
- This greatly reduces build times by using memory instead of temporary files for compilation.

Compile xmlrpc, libtorrent and rtorrent without warning messages.
- Warning messages do not impact functionality of the software. 
- Disabling these reduces compile times by eliminating overhead.

Retrieve libtorrent and rtorrent faster using curl instead of wget.
- This is already installed because it's required for rtorrent.

Don't verbose messages about libtorrent and rtorrent extraction.
- The extraction process if faster if we don't list the files.
- The log file is also cleaner and will still show errors.