### PR TITLE
rTorrent: Add install advisory & sink repo release

### DIFF
--- a/sources/functions/rtorrent
+++ b/sources/functions/rtorrent
@@ -9,8 +9,8 @@ function whiptail_rtorrent() {
         repov=$(get_candidate_version rtorrent)
 
         function=$(whiptail --title "Choose an rTorrent version" --menu "All versions other than repo will be locally compiled from source" --ok-button "Continue" 14 50 5 \
+            0.9.8 "(Recommended)" \
             Repo "(${repov})" \
-            0.9.8 "" \
             0.9.7 "" \
             0.9.6 "" 3>&1 1>&2 2>&3) || {
             echo_error "rTorrent version choice aborted"

--- a/sources/functions/rtorrent
+++ b/sources/functions/rtorrent
@@ -7,7 +7,7 @@ export codename=$(lsb_release -cs)
 function whiptail_rtorrent() {
     if [[ -z $rtorrentver ]] && [[ -z $1 ]]; then
         repov=$(get_candidate_version rtorrent)
-        
+
         whiptail --title "rTorrent Install Advisory" --msgbox "We recommend rTorrent version selection instead of repo (distro) releases. They will compile additional performance and stability improvements in 90s." 15 50
 
         function=$(whiptail --title "Choose an rTorrent version" --menu "All versions other than repo will be locally compiled from source" --ok-button "Continue" 14 50 5 \

--- a/sources/functions/rtorrent
+++ b/sources/functions/rtorrent
@@ -7,12 +7,14 @@ export codename=$(lsb_release -cs)
 function whiptail_rtorrent() {
     if [[ -z $rtorrentver ]] && [[ -z $1 ]]; then
         repov=$(get_candidate_version rtorrent)
+        
+        whiptail --title "rTorrent Install Advisory" --msgbox "We recommend rTorrent version selection instead of repo (distro) releases. They will compile additional performance and stability improvements in 90s." 15 50
 
         function=$(whiptail --title "Choose an rTorrent version" --menu "All versions other than repo will be locally compiled from source" --ok-button "Continue" 14 50 5 \
-            0.9.8 "(Recommended)" \
-            Repo "(${repov})" \
+            0.9.8 "" \
             0.9.7 "" \
-            0.9.6 "" 3>&1 1>&2 2>&3) || {
+            0.9.6 "" \
+            Repo "(${repov})" 3>&1 1>&2 2>&3) || {
             echo_error "rTorrent version choice aborted"
             exit 1
         }


### PR DESCRIPTION
This pull request adds an install advisory for rTorrent and moves the repo release to the bottom of the list.