### PR TITLE
rTorrent: Limit piece preloading to 50KB/s plus

### DIFF
--- a/scripts/install/rtorrent.sh
+++ b/scripts/install/rtorrent.sh
@@ -25,6 +25,7 @@ network.scgi.open_local = /var/run/${user}/.rtorrent.sock
 schedule2 = chmod_scgi_socket, 0, 0, "execute2=chmod,\"g+w,o=\",/var/run/${user}/.rtorrent.sock"
 network.tos.set = throughput
 pieces.hash.on_completion.set = no
+pieces.preload.min_rate.set = 50000
 protocol.pex.set = no
 schedule = watch_directory,5,5,load.start=/home/${user}/rwatch/*.torrent
 session.path.set = /home/${user}/.sessions/


### PR DESCRIPTION
This PR addresses the notorious issue with piece preloading, where i/o trashing occurs. Many pieces distributing at very low rates speed are attempted to be loaded into memory. We should limit this feature (which is disabled by default) to torrents distributing at a rate of speed faster than 50KB/s to mitigate the problem. If the user enables the feature it will work significantly better.
https://github.com/rakshasa/rtorrent/issues/443