### PR TITLE
rTorrent: Resolve lockfile crash

### DIFF
--- a/sources/functions/rtorrent
+++ b/sources/functions/rtorrent
@@ -190,6 +190,8 @@ function build_rtorrent() {
     else
         echo_log_only "No rTorrent patch found at /root/rtorrent-${rtorrentver}.patch"
     fi
+    #apply lockfile-fix to all rtorrents
+    patch -p1 < /etc/swizzin/sources/patches/rtorrent/lockfile-fix.patch >> "$log" 2>&1
     #apply xmlrpc-fix to all rtorrents
     patch -p1 < /etc/swizzin/sources/patches/rtorrent/xmlrpc-fix.patch >> "$log" 2>&1
     #use pkgconfig for cppunit if 0.9.6

--- a/sources/patches/rtorrent/lockfile-fix.patch
+++ b/sources/patches/rtorrent/lockfile-fix.patch
@@ -1,0 +1,28 @@
+From 812bba81bc049a5f786282b3654cab294b0ef236 Mon Sep 17 00:00:00 2001
+From: Aleksa Sarai <cyphar@cyphar.com>
+Date: Mon, 20 Jun 2022 19:09:57 +1000
+Subject: [PATCH] utils: lockfile: avoid stack overflow for lockfile buffer
+
+There appears to have been some change on openSUSE (likely some new
+hardening flags for builds, or some glibc hardening) such that incorrect
+buffer handling results in a segfault even if the buffer is never
+overflowed.
+
+Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>
+---
+ src/utils/lockfile.cc | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/utils/lockfile.cc b/src/utils/lockfile.cc
+index 7d11d8c99..fac5cb23e 100644
+--- a/src/utils/lockfile.cc
++++ b/src/utils/lockfile.cc
+@@ -98,7 +98,8 @@ Lockfile::try_lock() {
+   int pos = ::gethostname(buf, 255);
+ 
+   if (pos == 0) {
+-    ::snprintf(buf + std::strlen(buf), 255, ":+%i\n", ::getpid());
++    ssize_t len = std::strlen(buf);
++    ::snprintf(buf + len, 255 - len, ":+%i\n", ::getpid());
+     int __UNUSED result = ::write(fd, buf, std::strlen(buf));
+   }


### PR DESCRIPTION
Backports fix for lock file crash merged into rTorrent master. https://github.com/rakshasa/rtorrent/pull/1169