### PR TITLE
rTorrent: Support 10gbit throttle

### DIFF
--- a/sources/functions/rtorrent
+++ b/sources/functions/rtorrent
@@ -143,6 +143,9 @@ function build_libtorrent_rakshasa() {
     else
         echo_log_only "No libtorrent-rakshasa patch found at /root/libtorrent-rakshasa-${libtorrentver}.patch"
     fi
+    if [[ ${libtorrentver} =~ ^("0.13.7"|"0.13.8")$ ]]; then
+        patch -p1 < /etc/swizzin/sources/patches/rtorrent/throttle-fix-0.13.7-8.patch >> "$log" 2>&1
+    fi
     if [[ ${libtorrentver} =~ ^("0.13.6"|"0.13.7")$ ]]; then
         patch -p1 < /etc/swizzin/sources/patches/rtorrent/openssl.patch >> "$log" 2>&1
         if pkg-config --atleast-version=1.14 cppunit && [[ ${libtorrentver} == 0.13.6 ]]; then
@@ -150,6 +153,7 @@ function build_libtorrent_rakshasa() {
         fi
         if [[ ${libtorrentver} == "0.13.6" ]]; then
             patch -p1 < /etc/swizzin/sources/patches/rtorrent/bencode-libtorrent.patch >> "$log" 2>&1
+            patch -p1 < /etc/swizzin/sources/patches/rtorrent/throttle-fix-0.13.6.patch >> "$log" 2>&1
         fi
     fi
     ./autogen.sh >> $log 2>&1

--- a/sources/patches/rtorrent/throttle-fix-0.13.6.patch
+++ b/sources/patches/rtorrent/throttle-fix-0.13.6.patch
@@ -1,0 +1,35 @@
+From 326598abe30a82f8f74794788e11228300a36164 Mon Sep 17 00:00:00 2001
+From: stickz <stickman002@mail.com>
+Date: Fri, 24 Feb 2023 12:57:59 -0500
+Subject: [PATCH] Allow 10 gigabit speed throttles
+
+This commit increases max upload and download speed by 16 times. It allows utilization of 10 gigabit connections.
+---
+ src/torrent/download/resource_manager.cc | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/torrent/download/resource_manager.cc b/src/torrent/download/resource_manager.cc
+index 8ca7b02e..f882a202 100644
+--- a/src/torrent/download/resource_manager.cc
++++ b/src/torrent/download/resource_manager.cc
+@@ -187,16 +187,16 @@ ResourceManager::set_group(iterator itr, uint16_t grp) {
+ 
+ void
+ ResourceManager::set_max_upload_unchoked(unsigned int m) {
+-  if (m > (1 << 16))
+-    throw input_error("Max unchoked must be between 0 and 2^16.");
++  if (m > (1 << 20))
++    throw input_error("Max unchoked must be between 0 and 2^20.");
+ 
+   m_maxUploadUnchoked = m;
+ }
+ 
+ void
+ ResourceManager::set_max_download_unchoked(unsigned int m) {
+-  if (m > (1 << 16))
+-    throw input_error("Max unchoked must be between 0 and 2^16.");
++  if (m > (1 << 20))
++    throw input_error("Max unchoked must be between 0 and 2^20.");
+ 
+   m_maxDownloadUnchoked = m;
+ }

--- a/sources/patches/rtorrent/throttle-fix-0.13.7-8.patch
+++ b/sources/patches/rtorrent/throttle-fix-0.13.7-8.patch
@@ -1,0 +1,35 @@
+From 326598abe30a82f8f74794788e11228300a36164 Mon Sep 17 00:00:00 2001
+From: stickz <stickman002@mail.com>
+Date: Fri, 24 Feb 2023 12:57:59 -0500
+Subject: [PATCH] Allow 10 gigabit speed throttles
+
+This commit increases max upload and download speed by 16 times. It allows utilization of 10 gigabit connections.
+---
+ src/torrent/download/resource_manager.cc | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/torrent/download/resource_manager.cc b/src/torrent/download/resource_manager.cc
+index 8ca7b02e..f882a202 100644
+--- a/src/torrent/download/resource_manager.cc
++++ b/src/torrent/download/resource_manager.cc
+@@ -266,16 +266,16 @@ ResourceManager::set_group(iterator itr, uint16_t grp) {
+ 
+ void
+ ResourceManager::set_max_upload_unchoked(unsigned int m) {
+-  if (m > (1 << 16))
+-    throw input_error("Max unchoked must be between 0 and 2^16.");
++  if (m > (1 << 20))
++    throw input_error("Max unchoked must be between 0 and 2^20.");
+ 
+   m_maxUploadUnchoked = m;
+ }
+ 
+ void
+ ResourceManager::set_max_download_unchoked(unsigned int m) {
+-  if (m > (1 << 16))
+-    throw input_error("Max unchoked must be between 0 and 2^16.");
++  if (m > (1 << 20))
++    throw input_error("Max unchoked must be between 0 and 2^20.");
+ 
+   m_maxDownloadUnchoked = m;
+ }


### PR DESCRIPTION
Adds support for 10 gigabit throttling when libtorrent is compiled from source. Backports pull request merged into master.  https://github.com/rakshasa/libtorrent/pull/239