### PR TITLE
rTorrent: Patch three memory leaks

### DIFF
--- a/sources/functions/rtorrent
+++ b/sources/functions/rtorrent
@@ -202,11 +202,24 @@ function build_rtorrent() {
     patch -p1 < /etc/swizzin/sources/patches/rtorrent/lockfile-fix.patch >> "$log" 2>&1
     #apply xmlrpc-fix to all rtorrents
     patch -p1 < /etc/swizzin/sources/patches/rtorrent/xmlrpc-fix.patch >> "$log" 2>&1
-    #use pkgconfig for cppunit if 0.9.6
     stdc=
-    if [[ ${rtorrentver} == "0.9.6" ]]; then
+    if [[ ${rtorrentver} == "0.9.8" ]]; then
+        # Patch download list memory leak with rTorrent screen specific with version 0.9.8
+        patch -p1 < /etc/swizzin/sources/patches/rtorrent/memleaks/rtorrent-dl-fix-0.9.8.patch >> "$log" 2>&1
+        # Patch a couple memory leaks related to how rTorrent handles commands for rtorrent.rc
+        patch -p1 < /etc/swizzin/sources/patches/rtorrent/memleaks/rtorrent-cg-fix-0.9.8.patch >> "$log" 2>&1
+        patch -p1 < /etc/swizzin/sources/patches/rtorrent/memleaks/rtorrent-cd-fix-0.9.8.patch >> "$log" 2>&1
+    elif [[ ${rtorrentver} == "0.9.7" ]]; then
+        # Patch a couple memory leaks related to how rTorrent handles commands for rtorrent.rc
+        patch -p1 < /etc/swizzin/sources/patches/rtorrent/memleaks/rtorrent-cg-fix-0.9.7.patch >> "$log" 2>&1
+        patch -p1 < /etc/swizzin/sources/patches/rtorrent/memleaks/rtorrent-cd-fix-0.9.7.patch >> "$log" 2>&1
+    elif [[ ${rtorrentver} == "0.9.6" ]]; then
+        #use pkgconfig for cppunit if 0.9.6
         patch -p1 < /etc/swizzin/sources/patches/rtorrent/rtorrent-0.9.6.patch >> "$log" 2>&1
         stdc="-std=c++11"
+        # Patch a couple memory leaks related to how rTorrent handles commands for rtorrent.rc
+        patch -p1 < /etc/swizzin/sources/patches/rtorrent/memleaks/rtorrent-cg-fix-0.9.6.patch >> "$log" 2>&1
+        patch -p1 < /etc/swizzin/sources/patches/rtorrent/memleaks/rtorrent-cd-fix-0.9.7.patch >> "$log" 2>&1
     fi
     ./autogen.sh >> $log 2>&1
     ./configure --prefix=/usr --with-xmlrpc-c >> $log 2>&1 || {

--- a/sources/patches/rtorrent/memleaks/rtorrent-cd-fix-0.9.6.patch
+++ b/sources/patches/rtorrent/memleaks/rtorrent-cd-fix-0.9.6.patch
@@ -1,0 +1,22 @@
+From 4d6cb3474ff47cd6e2ca46c30644eec458ddc8cb Mon Sep 17 00:00:00 2001
+From: stickz <stickman002@mail.com>
+Date: Sun, 4 Jul 2021 18:51:33 -0400
+Subject: [PATCH] command_dynamic: fix memory leak of dynamic commands
+
+---
+ src/command_dynamic.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/command_dynamic.cc b/src/command_dynamic.cc
+index 0a1f8e7b4..21865f525 100644
+--- a/src/command_dynamic.cc
++++ b/src/command_dynamic.cc
+@@ -144,7 +144,7 @@ system_method_insert_object(const torrent::Object::list_type& args, int flags) {
+     throw torrent::input_error("Invalid type.");
+   }
+ 
+-  int cmd_flags = 0;
++  int cmd_flags = rpc::CommandMap::flag_delete_key;
+ 
+   if (!(flags & rpc::object_storage::flag_static))
+     cmd_flags |= rpc::CommandMap::flag_modifiable;

--- a/sources/patches/rtorrent/memleaks/rtorrent-cd-fix-0.9.7.patch
+++ b/sources/patches/rtorrent/memleaks/rtorrent-cd-fix-0.9.7.patch
@@ -1,0 +1,22 @@
+From 4d6cb3474ff47cd6e2ca46c30644eec458ddc8cb Mon Sep 17 00:00:00 2001
+From: stickz <stickman002@mail.com>
+Date: Sun, 4 Jul 2021 18:51:33 -0400
+Subject: [PATCH] command_dynamic: fix memory leak of dynamic commands
+
+---
+ src/command_dynamic.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/command_dynamic.cc b/src/command_dynamic.cc
+index 0a1f8e7b4..21865f525 100644
+--- a/src/command_dynamic.cc
++++ b/src/command_dynamic.cc
+@@ -145,7 +145,7 @@ system_method_insert_object(const torrent::Object::list_type& args, int flags) {
+     throw torrent::input_error("Invalid type.");
+   }
+ 
+-  int cmd_flags = 0;
++  int cmd_flags = rpc::CommandMap::flag_delete_key;
+ 
+   if (!(flags & rpc::object_storage::flag_static))
+     cmd_flags |= rpc::CommandMap::flag_modifiable;

--- a/sources/patches/rtorrent/memleaks/rtorrent-cd-fix-0.9.8.patch
+++ b/sources/patches/rtorrent/memleaks/rtorrent-cd-fix-0.9.8.patch
@@ -1,0 +1,22 @@
+From 4d6cb3474ff47cd6e2ca46c30644eec458ddc8cb Mon Sep 17 00:00:00 2001
+From: stickz <stickman002@mail.com>
+Date: Sun, 4 Jul 2021 18:51:33 -0400
+Subject: [PATCH] command_dynamic: fix memory leak of dynamic commands
+
+---
+ src/command_dynamic.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/command_dynamic.cc b/src/command_dynamic.cc
+index 0a1f8e7b4..21865f525 100644
+--- a/src/command_dynamic.cc
++++ b/src/command_dynamic.cc
+@@ -147,7 +147,7 @@ system_method_insert_object(const torrent::Object::list_type& args, int flags) {
+     throw torrent::input_error("Invalid type.");
+   }
+ 
+-  int cmd_flags = 0;
++  int cmd_flags = rpc::CommandMap::flag_delete_key;
+ 
+   if (!(flags & rpc::object_storage::flag_static))
+     cmd_flags |= rpc::CommandMap::flag_modifiable;

--- a/sources/patches/rtorrent/memleaks/rtorrent-cg-fix-0.9.6.patch
+++ b/sources/patches/rtorrent/memleaks/rtorrent-cg-fix-0.9.6.patch
@@ -1,0 +1,75 @@
+From 5992c602197834d2e3feb7a84d55f53f08fe0500 Mon Sep 17 00:00:00 2001
+From: stickz <stickman002@mail.com>
+Date: Sun, 4 Jul 2021 18:54:55 -0400
+Subject: [PATCH] command_groups: fix cg_list_hack memory leak
+
+---
+ src/command_groups.cc  | 11 +++++++++++
+ src/command_helpers.cc |  6 ++++++
+ src/command_helpers.h  |  2 ++
+ src/main.cc            |  2 ++
+ 4 files changed, 21 insertions(+)
+
+diff --git a/src/command_groups.cc b/src/command_groups.cc
+index 65e923e0c..acab210bf 100644
+--- a/src/command_groups.cc
++++ b/src/command_groups.cc
+@@ -387,3 +387,14 @@ initialize_command_groups() {
+                                                                  tr1::bind(&torrent::choke_queue::heuristics, CHOKE_GROUP(&torrent::choke_group::down_queue))));
+   CMD2_ANY_LIST    ("choke_group.down.heuristics.set", tr1::bind(&apply_cg_heuristics_set, std::placeholders::_2, false));
+ }
++
++void cleanup_command_groups() {
++#if USE_CHOKE_GROUP
++#else
++  while (!cg_list_hack.empty()) {
++    auto cg = cg_list_hack.back();
++    delete cg;
++    cg_list_hack.pop_back();
++  }
++#endif
++}
+\ No newline at end of file
+diff --git a/src/command_helpers.cc b/src/command_helpers.cc
+index 54c0b35e4..31599e265 100644
+--- a/src/command_helpers.cc
++++ b/src/command_helpers.cc
+@@ -57,6 +57,12 @@ void initialize_command_tracker();
+ void initialize_command_scheduler();
+ void initialize_command_ui();
+ 
++void cleanup_command_groups();
++
++void cleanup_commands() {
++  cleanup_command_groups();
++}
++
+ void
+ initialize_commands() {
+   initialize_command_dynamic();
+diff --git a/src/command_helpers.h b/src/command_helpers.h
+index a104fbbc4..6918f9632 100644
+--- a/src/command_helpers.h
++++ b/src/command_helpers.h
+@@ -45,6 +45,8 @@
+ 
+ void initialize_commands();
+ 
++void cleanup_commands();
++
+ //
+ // New std::function based command_base helper functions:
+ //
+diff --git a/src/main.cc b/src/main.cc
+index b0fd6cf98..4be972259 100644
+--- a/src/main.cc
++++ b/src/main.cc
+@@ -875,6 +875,8 @@ main(int argc, char** argv) {
+     lt_log_print(torrent::LOG_CRITICAL, "Caught exception: '%s'.", e.what());
+     return -1;
+   }
++  
++  cleanup_commands();
+ 
+   torrent::log_cleanup();
+ 

--- a/sources/patches/rtorrent/memleaks/rtorrent-cg-fix-0.9.7.patch
+++ b/sources/patches/rtorrent/memleaks/rtorrent-cg-fix-0.9.7.patch
@@ -1,0 +1,75 @@
+From 5992c602197834d2e3feb7a84d55f53f08fe0500 Mon Sep 17 00:00:00 2001
+From: stickz <stickman002@mail.com>
+Date: Sun, 4 Jul 2021 18:54:55 -0400
+Subject: [PATCH] command_groups: fix cg_list_hack memory leak
+
+---
+ src/command_groups.cc  | 11 +++++++++++
+ src/command_helpers.cc |  6 ++++++
+ src/command_helpers.h  |  2 ++
+ src/main.cc            |  2 ++
+ 4 files changed, 21 insertions(+)
+
+diff --git a/src/command_groups.cc b/src/command_groups.cc
+index 65e923e0c..acab210bf 100644
+--- a/src/command_groups.cc
++++ b/src/command_groups.cc
+@@ -381,3 +381,14 @@ initialize_command_groups() {
+                                                                  std::bind(&torrent::choke_queue::heuristics, CHOKE_GROUP(&torrent::choke_group::down_queue))));
+   CMD2_ANY_LIST    ("choke_group.down.heuristics.set", std::bind(&apply_cg_heuristics_set, std::placeholders::_2, false));
+ }
++
++void cleanup_command_groups() {
++#if USE_CHOKE_GROUP
++#else
++  while (!cg_list_hack.empty()) {
++    auto cg = cg_list_hack.back();
++    delete cg;
++    cg_list_hack.pop_back();
++  }
++#endif
++}
+\ No newline at end of file
+diff --git a/src/command_helpers.cc b/src/command_helpers.cc
+index 54c0b35e4..31599e265 100644
+--- a/src/command_helpers.cc
++++ b/src/command_helpers.cc
+@@ -57,6 +57,12 @@ void initialize_command_tracker();
+ void initialize_command_scheduler();
+ void initialize_command_ui();
+ 
++void cleanup_command_groups();
++
++void cleanup_commands() {
++  cleanup_command_groups();
++}
++
+ void
+ initialize_commands() {
+   initialize_command_dynamic();
+diff --git a/src/command_helpers.h b/src/command_helpers.h
+index a104fbbc4..6918f9632 100644
+--- a/src/command_helpers.h
++++ b/src/command_helpers.h
+@@ -43,6 +43,8 @@
+ 
+ void initialize_commands();
+ 
++void cleanup_commands();
++
+ //
+ // New std::function based command_base helper functions:
+ //
+diff --git a/src/main.cc b/src/main.cc
+index b0fd6cf98..4be972259 100644
+--- a/src/main.cc
++++ b/src/main.cc
+@@ -498,6 +498,8 @@ main(int argc, char** argv) {
+     lt_log_print(torrent::LOG_CRITICAL, "Caught exception: '%s'.", e.what());
+     return -1;
+   }
++  
++  cleanup_commands();
+ 
+   torrent::log_cleanup();
+ 

--- a/sources/patches/rtorrent/memleaks/rtorrent-cg-fix-0.9.8.patch
+++ b/sources/patches/rtorrent/memleaks/rtorrent-cg-fix-0.9.8.patch
@@ -1,0 +1,75 @@
+From 5992c602197834d2e3feb7a84d55f53f08fe0500 Mon Sep 17 00:00:00 2001
+From: stickz <stickman002@mail.com>
+Date: Sun, 4 Jul 2021 18:54:55 -0400
+Subject: [PATCH] command_groups: fix cg_list_hack memory leak
+
+---
+ src/command_groups.cc  | 11 +++++++++++
+ src/command_helpers.cc |  6 ++++++
+ src/command_helpers.h  |  2 ++
+ src/main.cc            |  2 ++
+ 4 files changed, 21 insertions(+)
+
+diff --git a/src/command_groups.cc b/src/command_groups.cc
+index 65e923e0c..acab210bf 100644
+--- a/src/command_groups.cc
++++ b/src/command_groups.cc
+@@ -381,3 +381,14 @@ initialize_command_groups() {
+                                                                  std::bind(&torrent::choke_queue::heuristics, CHOKE_GROUP(&torrent::choke_group::down_queue))));
+   CMD2_ANY_LIST    ("choke_group.down.heuristics.set", std::bind(&apply_cg_heuristics_set, std::placeholders::_2, false));
+ }
++
++void cleanup_command_groups() {
++#if USE_CHOKE_GROUP
++#else
++  while (!cg_list_hack.empty()) {
++    auto cg = cg_list_hack.back();
++    delete cg;
++    cg_list_hack.pop_back();
++  }
++#endif
++}
+\ No newline at end of file
+diff --git a/src/command_helpers.cc b/src/command_helpers.cc
+index 54c0b35e4..31599e265 100644
+--- a/src/command_helpers.cc
++++ b/src/command_helpers.cc
+@@ -57,6 +57,12 @@ void initialize_command_tracker();
+ void initialize_command_scheduler();
+ void initialize_command_ui();
+ 
++void cleanup_command_groups();
++
++void cleanup_commands() {
++  cleanup_command_groups();
++}
++
+ void
+ initialize_commands() {
+   initialize_command_dynamic();
+diff --git a/src/command_helpers.h b/src/command_helpers.h
+index a104fbbc4..6918f9632 100644
+--- a/src/command_helpers.h
++++ b/src/command_helpers.h
+@@ -43,6 +43,8 @@
+ 
+ void initialize_commands();
+ 
++void cleanup_commands();
++
+ //
+ // New std::function based command_base helper functions:
+ //
+diff --git a/src/main.cc b/src/main.cc
+index b0fd6cf98..4be972259 100644
+--- a/src/main.cc
++++ b/src/main.cc
+@@ -508,6 +508,8 @@ main(int argc, char** argv) {
+     lt_log_print(torrent::LOG_CRITICAL, "Caught exception: '%s'.", e.what());
+     return -1;
+   }
++  
++  cleanup_commands();
+ 
+   torrent::log_cleanup();
+ 

--- a/sources/patches/rtorrent/memleaks/rtorrent-dl-fix-0.9.8.patch
+++ b/sources/patches/rtorrent/memleaks/rtorrent-dl-fix-0.9.8.patch
@@ -1,0 +1,29 @@
+From 9b1a7fd7528bbf60f9c71558758dd9d0fe639115 Mon Sep 17 00:00:00 2001
+From: stickz <stickman002@mail.com>
+Date: Sun, 4 Jul 2021 18:56:44 -0400
+Subject: [PATCH] download_list: fix potential memory leak
+
+---
+ src/ui/download_list.cc | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/ui/download_list.cc b/src/ui/download_list.cc
+index f1d6af5c6..7cb0e9a89 100644
+--- a/src/ui/download_list.cc
++++ b/src/ui/download_list.cc
+@@ -272,6 +272,7 @@ DownloadList::receive_view_input(Input type) {
+           std::getline(ss, view_name_var, ',');
+           if (current_view()->name() == rak::trim(view_name_var)) {
+               control->core()->push_log_std("View '" + current_view()->name() + "' can't be filtered.");
++              delete input;
+               return;
+           }
+       }
+@@ -281,6 +282,7 @@ DownloadList::receive_view_input(Input type) {
+     break;
+ 
+   default:
++    delete input;
+     throw torrent::internal_error("DownloadList::receive_view_input(...) Invalid input type.");
+   }
+ 


### PR DESCRIPTION
This commit patches three memory leaks with the rTorrent client to improve memory stability. These three patches were selected because of their known stability. I these changes on ARM64 by downloading a torrent and compiling from source. The compile log succeeded for all source versions (0.9.6, 0.9.7, 0.9.8) and the torrent was successfully downloaded. There are no known issues reported by other users with these changes. I've also tested them personally for an entire year to ensure they are stable.

**rTorrent version 0.9.8**
- Patches a memory leak with the text console on a rTorrent screen.

**rTorrent all versions**
- Patches two memory leaks related to how rTorrent handles commands in `rtorrent.rc`.

The line numbers have changes on different source versions, which is why multiple patch files are required. The patches are created in a new folder to make it easier to find other patches and to avoid confusion. Each different type of patch is separated.

Memory stability is a big problem for rTorrent. Reducing memory leaks allows the torrent client to run longer without a restart.