### PR TITLE
ruTorrent: Set $localHostedMode to true

### DIFF
--- a/sources/functions/rutorrent
+++ b/sources/functions/rutorrent
@@ -113,7 +113,7 @@ function rutorrent_install() {
 		"stat"	=> '',			// Something like /usr/bin/stat. If empty, will be found in PATH.
 	);
 	
-	$localHostedMode = false; 		// Set to true if rTorrent is hosted on the SAME machine as ruTorrent
+	$localHostedMode = true; 		// Set to true if rTorrent is hosted on the SAME machine as ruTorrent
 	
 	$cachedPluginLoading = false;	// Set to true to enable rapid cached loading of ruTorrent plugins	
 	$pluginJSCacheExpire = 3*60;	// Sets duration ruTorrent plugin javascript cache is valid for in minutes


### PR DESCRIPTION
It was introduced and set to false when testing ruTorrent version 4.0.1. The regressions were since resolved in ruTorrent version 4.0.2. See change-log here: https://github.com/Novik/ruTorrent/releases/tag/v4.0.2

The feature purpose is to improve loading times when ruTorrent is hosted on the SAME machine as rTorrent. It performs plugin dependency checks through shell and caches the results. This is a more viable option than executing XMLRPC commands, which is designed be performed for remote hosts. XMLRPC is bound by various bottlenecks such as disk i/o resources.