### PR TITLE
AutoDL: Use consistent install/upgrade methods

### DIFF
--- a/scripts/install/autodl.sh
+++ b/scripts/install/autodl.sh
@@ -27,7 +27,10 @@ function _installautodl() {
 
 function _autoconf() {
     echo_progress_start "Downloading autodl source code"
-    curl -sL http://git.io/vlcND | grep -Po '(?<="browser_download_url":).*?[^\\].zip"' | sed 's/"//g' | xargs wget -O /tmp/autodl-irssi.zip --quiet
+    wget -q "$(curl -sL http://git.io/vlcND | jq .assets[0].browser_download_url -r)" -O /tmp/autodl-irssi.zip >> $log 2>&1 || {
+        echo_error "Autodl download failed, please check the log"
+        exit 1
+    }
     echo_progress_done "Download finished"
     for u in "${users[@]}"; do
         echo_progress_start "Configuring autodl for $u"


### PR DESCRIPTION
We should use consistent install and upgrade methods for autodl. This implementation is cleaner than the previous one and prevents possible errors from occurring. https://github.com/swizzin/swizzin/blob/master/scripts/upgrade/autodl.sh#L8-L11