### PR TITLE
ruTorrent: Install ffmpeg by default

### DIFF
--- a/scripts/install/rutorrent.sh
+++ b/scripts/install/rutorrent.sh
@@ -16,6 +16,12 @@ bash /usr/local/bin/swizzin/nginx/rutorrent.sh || {
     exit 1
 }
 
+if [[ ! -f /install.ffmpeg.lock ]]; then
+    echo_progress_start "Installing ffmpeg for ruTorrent"
+    . /etc/swizzin/sources/functions/ffmpeg
+    ffmpeg_install
+fi
+
 if [[ -f /install/.autodl.lock ]]; then
     echo_progress_start "Configuring Autodl Plugin"
     bash /usr/local/bin/swizzin/nginx/autodl.sh || {

--- a/sources/functions/ffmpeg
+++ b/sources/functions/ffmpeg
@@ -12,5 +12,12 @@
 #   including (via compiler) GPL-licensed code must also be made available
 #   under the GPL along with build & install instructions.
 
-. /etc/swizzin/sources/functions/ffmpeg
-ffmpeg_install
+ffmpeg_install() {
+    export distribution=$(lsb_release -is)
+    export release=$(lsb_release -rs)
+    export codename=$(lsb_release -cs)
+
+    apt_install ffmpeg
+
+    touch /install/.ffmpeg.lock
+}


### PR DESCRIPTION
ffmpeg is required for the screenshots plugin. Many users want to use this plugin, so it's not a good idea to gut the functionality. It's supported on all platforms and is a tiny binary file.

This commit makes the ffmpeg install script modular, so it's easier to maintain and changes apply to ruTorrent. It only installs ffmpeg if it's not already installed.

These changes are tested on Ubuntu 22.04 LTS ARM64. They are confirmed to be working and the screenshots plugin is now functional out of the box. When users deploy ruTorrent, everything will work as intended!