### PR TITLE
rTorrent: Compile curl with c-ares

### DIFF
--- a/scripts/install/rtorrent.sh
+++ b/scripts/install/rtorrent.sh
@@ -77,6 +77,7 @@ EOF
 export DEBIAN_FRONTEND=noninteractive
 
 . /etc/swizzin/sources/functions/rtorrent
+. /etc/swizzin/sources/functions/curl
 noexec=$(grep "/tmp" /etc/fstab | grep noexec)
 user=$(cut -d: -f1 < /root/.master.info)
 rutorrent="/srv/rutorrent/"
@@ -98,6 +99,12 @@ if [[ -n $noexec ]]; then
 fi
 depends_rtorrent
 if [[ ! $rtorrentver == repo ]]; then
+    echo_progress_start "Building c-ares from source"
+    build_cares
+    echo_progress_done
+    echo_progress_start "Building curl from source"
+    build_curl
+    echo_progress_done
     configure_rtorrent
     echo_progress_start "Building xmlrpc-c from source"
     build_xmlrpc-c

--- a/scripts/install/rtorrent.sh
+++ b/scripts/install/rtorrent.sh
@@ -99,6 +99,7 @@ if [[ -n $noexec ]]; then
 fi
 depends_rtorrent
 if [[ ! $rtorrentver == repo ]]; then
+    configure_curl
     echo_progress_start "Building c-ares from source"
     build_cares
     echo_progress_done

--- a/scripts/upgrade/curl.sh
+++ b/scripts/upgrade/curl.sh
@@ -1,39 +1,8 @@
 #!/bin/bash
 # Upgrade curl to bypass the bug in Debian 10. Can be used on any system however, but the benefit is to Buster users most
 
-cd /tmp
-version=$(basename $(curl -fsSLI -o /dev/null -w %{url_effective} https://github.com/curl/curl/releases/latest))
-
-wget -O /tmp/curl.zip https://github.com/curl/curl/releases/download/${version}/${version//_/.}.zip >> ${log} 2>&1 || {
-    echo_error "There was an error downloading curl! Please check the log for more info"
-    rm /tmp/curl.zip >> $log 2>&1
-    exit 1
-}
-
-unzip /tmp/curl.zip -d /tmp >> $log 2>&1
-rm /tmp/curl.zip
-
-apt_install libssl-dev
-
-cd /tmp/${version//_/.}
-./configure --enable-versioned-symbols --with-openssl >> ${log} 2>&1 || {
-    echo_error "There was an error configuring curl! Please check the log for more info"
-    cd /tmp
-    rm -rf /tmp/curl-* >> $log 2>&1
-    exit 1
-}
-make -j$(nproc) >> ${log} 2>&1 || {
-    echo_error "There was an error compiling curl! Please check the log for more info"
-    cd /tmp
-    rm -rf /tmp/curl-*
-    exit 1
-}
-make install >> ${log} 2>&1 >> $log 2>&1
-
-cd /tmp
-rm -rf /tmp/curl-* >> $log 2>&1
-
-echo "/usr/local/bin" >> /etc/ld.so.conf
-ldconfig
+. /etc/swizzin/sources/functions/curl
+build_cares
+build_curl
 
 echo_info "An up-to-date version of curl has been installed to /usr/local/bin. Please be aware that curl may show an older version of curl until you log out and back in"

--- a/scripts/upgrade/curl.sh
+++ b/scripts/upgrade/curl.sh
@@ -2,7 +2,6 @@
 # Upgrade curl to bypass the bug in Debian 10. Can be used on any system however, but the benefit is to Buster users most
 
 . /etc/swizzin/sources/functions/curl
+configure_curl
 build_cares
 build_curl
-
-echo_info "An up-to-date version of curl has been installed to /usr/local/bin. Please be aware that curl may show an older version of curl until you log out and back in"

--- a/scripts/upgrade/rtorrent.sh
+++ b/scripts/upgrade/rtorrent.sh
@@ -35,6 +35,7 @@ echo_progress_start "Checking rTorrent Dependencies ... "
 depends_rtorrent
 echo_progress_done
 if [[ ! $rtorrentver == repo ]]; then
+    configure_curl
     echo_progress_start "Building c-ares from source"
     build_cares
     echo_progress_done

--- a/scripts/upgrade/rtorrent.sh
+++ b/scripts/upgrade/rtorrent.sh
@@ -11,6 +11,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 #shellcheck source=sources/functions/rtorrent
 . /etc/swizzin/sources/functions/rtorrent
+. /etc/swizzin/sources/functions/curl
 whiptail_rtorrent
 
 user=$(cut -d: -f1 < /root/.master.info)
@@ -34,6 +35,12 @@ echo_progress_start "Checking rTorrent Dependencies ... "
 depends_rtorrent
 echo_progress_done
 if [[ ! $rtorrentver == repo ]]; then
+    echo_progress_start "Building c-ares from source"
+    build_cares
+    echo_progress_done
+    echo_progress_start "Building curl from source"
+    build_curl
+    echo_progress_done
     configure_rtorrent
     echo_progress_start "Building xmlrpc-c from source ... "
     build_xmlrpc-c

--- a/sources/functions/curl
+++ b/sources/functions/curl
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Upgrade curl to bypass the bug in Debian 10. Can be used on any system however, but the benefit is to Buster users most
+
+build_cares() {
+    cd /tmp
+
+    . /etc/swizzin/sources/functions/utils
+    cares_latest=$(github_latest_version c-ares/c-ares)
+    cares_tar=${cares_latest/cares/c-ares}
+    
+    wget -O /tmp/cares.tar.gz https://github.com/c-ares/c-ares/releases/download/${cares_latest}/${cares_tar//_/.}.tar.gz > ${log} 2>&1 || {
+        echo_error "There was an error downloading c-ares! Please check the log for more info"
+        rm /tmp/cares.tar.gz >> $log 2>&1
+        exit 1
+    }
+    
+    mkdir -p /tmp/cares
+    tar -xzf /tmp/cares.tar.gz -C /tmp/cares --strip-components=1 >> $log 2>&1
+    rm /tmp/cares.tar.gz
+
+    cd /tmp/cares
+    ./configure --prefix=/usr >> ${log} 2>&1 || {
+    echo_error "There was an error configuring c-ares! Please check the log for more info"
+        cd /tmp
+        rm -rf /tmp/cares >> $log 2>&1
+        exit 1
+    }
+    make -j$(nproc) CFLAGS="-O2 -flto=$(nproc)" >> ${log} 2>&1 || {
+        echo_error "There was an error compiling c-ares! Please check the log for more info"
+        cd /tmp
+        rm -rf /tmp/cares >> $log 2>&1
+        exit 1
+    }
+    make install >> ${log} 2>&1 >> $log 2>&1
+
+    cd /tmp
+    rm -rf /tmp/cares >> $log 2>&1
+}
+
+build_curl() {
+    cd /tmp
+    
+    wget -O /tmp/curl.zip https://salsa.debian.org/debian/curl/-/archive/debian/bullseye-backports/curl-debian-bullseye-backports.zip >> ${log} 2>&1 || {
+        echo_error "There was an error downloading curl! Please check the log for more info"
+        rm /tmp/curl.zip >> $log 2>&1
+        exit 1
+    }
+
+    unzip /tmp/curl.zip -d /tmp >> $log 2>&1
+    rm /tmp/curl.zip
+
+    apt_install libssl-dev
+
+    cd /tmp/curl-debian-bullseye-backports
+    ./configure --enable-versioned-symbols --with-openssl --enable-ares >> ${log} 2>&1 || {
+        echo_error "There was an error configuring curl! Please check the log for more info"
+        cd /tmp
+        rm -rf /tmp/curl-* >> $log 2>&1
+        exit 1
+    }
+    make -j$(nproc) CFLAGS="-O2 -flto=$(nproc)" >> ${log} 2>&1 || {
+        echo_error "There was an error compiling curl! Please check the log for more info"
+        cd /tmp
+        rm -rf /tmp/curl-* >> $log 2>&1
+        exit 1
+    }
+    make install >> ${log} 2>&1 >> $log 2>&1
+
+    cd /tmp
+    rm -rf /tmp/curl-* >> $log 2>&1
+
+    ldconfig /usr/local/bin
+    ldconfig /usr/local/lib
+}
+

--- a/sources/functions/curl
+++ b/sources/functions/curl
@@ -7,20 +7,20 @@ build_cares() {
     . /etc/swizzin/sources/functions/utils
     cares_latest=$(github_latest_version c-ares/c-ares)
     cares_tar=${cares_latest/cares/c-ares}
-    
+
     wget -O /tmp/cares.tar.gz https://github.com/c-ares/c-ares/releases/download/${cares_latest}/${cares_tar//_/.}.tar.gz > ${log} 2>&1 || {
         echo_error "There was an error downloading c-ares! Please check the log for more info"
         rm /tmp/cares.tar.gz >> $log 2>&1
         exit 1
     }
-    
+
     mkdir -p /tmp/cares
     tar -xzf /tmp/cares.tar.gz -C /tmp/cares --strip-components=1 >> $log 2>&1
     rm /tmp/cares.tar.gz
 
     cd /tmp/cares
     ./configure --prefix=/usr >> ${log} 2>&1 || {
-    echo_error "There was an error configuring c-ares! Please check the log for more info"
+        echo_error "There was an error configuring c-ares! Please check the log for more info"
         cd /tmp
         rm -rf /tmp/cares >> $log 2>&1
         exit 1
@@ -39,7 +39,7 @@ build_cares() {
 
 build_curl() {
     cd /tmp
-    
+
     wget -O /tmp/curl.zip https://salsa.debian.org/debian/curl/-/archive/debian/bullseye-backports/curl-debian-bullseye-backports.zip >> ${log} 2>&1 || {
         echo_error "There was an error downloading curl! Please check the log for more info"
         rm /tmp/curl.zip >> $log 2>&1
@@ -72,4 +72,3 @@ build_curl() {
     ldconfig /usr/local/bin
     ldconfig /usr/local/lib
 }
-

--- a/sources/functions/curl
+++ b/sources/functions/curl
@@ -1,6 +1,24 @@
 #!/bin/bash
 # Upgrade curl to bypass the bug in Debian 10. Can be used on any system however, but the benefit is to Buster users most
 
+configure_curl() {
+    # pipe optimizations for 2048MB plus memory
+    # only required for c-ares due to high memory consumption
+    memory=$(awk '/MemAvailable/ {printf( "%.f\n", $2 / 1024 )}' /proc/meminfo)
+    if [[ $memory > 2048 ]]; then
+        export curlpipe="-pipe"
+    else
+        export curlpipe=""
+    fi
+    # link time optimizations for 2 plus threads
+    # Only required for curl due to high cpu usage
+    if [ $(nproc) -ge 2 ]; then
+        export curlflto="-flto=$(nproc)"
+    else
+        export curlflto=""
+    fi
+}
+
 build_cares() {
     cd /tmp
 
@@ -8,7 +26,7 @@ build_cares() {
     cares_latest=$(github_latest_version c-ares/c-ares)
     cares_tar=${cares_latest/cares/c-ares}
 
-    wget -O /tmp/cares.tar.gz https://github.com/c-ares/c-ares/releases/download/${cares_latest}/${cares_tar//_/.}.tar.gz > ${log} 2>&1 || {
+    wget -q -O /tmp/cares.tar.gz https://github.com/c-ares/c-ares/releases/download/${cares_latest}/${cares_tar//_/.}.tar.gz > ${log} 2>&1 || {
         echo_error "There was an error downloading c-ares! Please check the log for more info"
         rm /tmp/cares.tar.gz >> $log 2>&1
         exit 1
@@ -19,13 +37,13 @@ build_cares() {
     rm /tmp/cares.tar.gz
 
     cd /tmp/cares
-    ./configure --prefix=/usr >> ${log} 2>&1 || {
+    ./configure --prefix=/usr --disable-shared --disable-debug >> ${log} 2>&1 || {
         echo_error "There was an error configuring c-ares! Please check the log for more info"
         cd /tmp
         rm -rf /tmp/cares >> $log 2>&1
         exit 1
     }
-    make -j$(nproc) CFLAGS="-O2 -flto=$(nproc)" >> ${log} 2>&1 || {
+    make -j$(nproc) CFLAGS="-w -O2 -flto ${curlpipe}" >> ${log} 2>&1 || {
         echo_error "There was an error compiling c-ares! Please check the log for more info"
         cd /tmp
         rm -rf /tmp/cares >> $log 2>&1
@@ -40,25 +58,26 @@ build_cares() {
 build_curl() {
     cd /tmp
 
-    wget -O /tmp/curl.zip https://salsa.debian.org/debian/curl/-/archive/debian/bullseye-backports/curl-debian-bullseye-backports.zip >> ${log} 2>&1 || {
+    wget -q -O /tmp/curl.zip https://salsa.debian.org/debian/curl/-/archive/debian/bullseye-backports/curl-debian-bullseye-backports.zip >> ${log} 2>&1 || {
         echo_error "There was an error downloading curl! Please check the log for more info"
         rm /tmp/curl.zip >> $log 2>&1
         exit 1
     }
 
-    unzip /tmp/curl.zip -d /tmp >> $log 2>&1
+    unzip -q /tmp/curl.zip -d /tmp >> $log 2>&1
     rm /tmp/curl.zip
 
-    apt_install libssl-dev
+    apt_install libssl-dev libnghttp2-dev libzstd-dev libldap2-dev libssh2-1-dev librtmp-dev libpsl-dev
 
     cd /tmp/curl-debian-bullseye-backports
-    ./configure --enable-versioned-symbols --with-openssl --enable-ares >> ${log} 2>&1 || {
+    ./configure --with-openssl --with-zlib --with-zstd --with-libssh2 --with-nghttp2 --with-librtmp --with-libpsl \
+        --enable-ares --enable-ldap --enable-ldaps --enable-websockets --disable-shared --disable-debug >> ${log} 2>&1 || {
         echo_error "There was an error configuring curl! Please check the log for more info"
         cd /tmp
         rm -rf /tmp/curl-* >> $log 2>&1
         exit 1
     }
-    make -j$(nproc) CFLAGS="-O2 -flto=$(nproc)" >> ${log} 2>&1 || {
+    make -j$(nproc) CFLAGS="-w -O2 ${curlflto} -pipe" >> ${log} 2>&1 || {
         echo_error "There was an error compiling curl! Please check the log for more info"
         cd /tmp
         rm -rf /tmp/curl-* >> $log 2>&1


### PR DESCRIPTION
This pull request enhances curl for rTorrent by recompiling it with c-ares support for threaded DNS lookups. The latest stable release of curl from Debian Bullseye back-ports is used. The latest upstream release of c-ares is used.

Tested on Ubuntu 22.04LTS ARM64 and confirmed to be working.