### PR TITLE
rTorrent: Upgrade GCC if supported

### DIFF
--- a/scripts/install/rtorrent.sh
+++ b/scripts/install/rtorrent.sh
@@ -98,6 +98,8 @@ if [[ -n $noexec ]]; then
 fi
 depends_rtorrent
 if [[ ! $rtorrentver == repo ]]; then
+    . /etc/swizzin/sources/functions/gcc
+    Upgrade_GCC_Ubuntu
     configure_rtorrent
     echo_progress_start "Building xmlrpc-c from source"
     build_xmlrpc-c

--- a/scripts/upgrade/gcc.sh
+++ b/scripts/upgrade/gcc.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Script to upgrade GCC on Ubuntu
+# Stickz for Swizzin 2023
+# GPLv3 Applies
+
+. /etc/swizzin/sources/functions/gcc
+Upgrade_GCC_Ubuntu

--- a/scripts/upgrade/rtorrent.sh
+++ b/scripts/upgrade/rtorrent.sh
@@ -34,6 +34,8 @@ echo_progress_start "Checking rTorrent Dependencies ... "
 depends_rtorrent
 echo_progress_done
 if [[ ! $rtorrentver == repo ]]; then
+    . /etc/swizzin/sources/functions/gcc
+    Upgrade_GCC_Ubuntu
     configure_rtorrent
     echo_progress_start "Building xmlrpc-c from source ... "
     build_xmlrpc-c

--- a/sources/functions/gcc
+++ b/sources/functions/gcc
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Functions to upgrade GCC on Ubuntu
+# Stickz for Swizzin 2023
+# GPLv3 Applies
+
+Upgrade_GCC_Ubuntu() {
+    echo_info "Checking OS for GCC upgrade"
+    if [[ "$(_os_codename)" = "focal" ]]; then
+        Upgrade_GCC10_Focal
+    elif [[ "$(_os_codename)" = "jammy" ]]; then
+        Upgrade_GCC12_Jammy
+    else
+        echo_info "Skipping GCC upgrade due to unsupported OS"
+    fi
+}
+
+Upgrade_GCC10_Focal() {
+    local gccten=$(gcc --version | grep -c "Ubuntu 10")
+    if [[ $gccten -le 0 ]]; then
+        echo_info "Ubuntu 20.04 Found. Upgrading from GCC 9 to 10."
+        apt_install gcc-10 g++-10
+
+        echo_progress_start "Configuring GCC 10"
+        update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10 >> $log 2>&1
+        update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10 >> $log 2>&1
+        update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 9 >> $log 2>&1
+        update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 9 >> $log 2>&1
+        echo_progress_done "GCC 10 Configured"
+    else
+        echo_info "GCC version is 10. No upgrade required."
+    fi
+}
+
+Upgrade_GCC12_Jammy() {
+    local gcctwelve=$(gcc --version | grep -c "Ubuntu 12")
+    if [[ $gcctwelve -le 0 ]]; then
+        echo_info "Ubuntu 22.04 Found. Upgrading from GCC 11 to 12."
+        apt_install gcc-12 g++-12
+
+        echo_progress_start "Configuring GCC 12"
+        update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 12 >> $log 2>&1
+        update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 12 >> $log 2>&1
+        update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 11 >> $log 2>&1
+        update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 11 >> $log 2>&1
+        echo_progress_done "GCC 12 Configured"
+    else
+        echo_info "GCC version is 12. No upgrade required."
+    fi
+}


### PR DESCRIPTION
This script upgrades GCC on Ubuntu 20.04 or 22.04 LTS using packages. It improves the performance of software compiled with GCC. This task is performed relatively quickly. 
- Ubuntu 20.04 LTS seamlessly goes from GCC 9 to 10. Ubuntu 22.04 LTS seamlessly goes from GCC 11 to 12. 
- update-alternatives are configured to allow smooth transition from Ubuntu 20.04 to 22.04 LTS. The user just needs to run the script again for the newer version to take priority over the old. If they would like to recompile software.
- Manual upgrade option is added. This task is performed automatically if rTorrent is being compiled from source. 
- Debian has chosen not to provide packages for upgrading GCC. Therefore, it's not possible to seamlessly support this OS. It would take hours to manually compile GCC.

This has been tested on Ubuntu 22.04 LTS ARM64 and confirmed to be working.