### PR TITLE
ruTorrent: update config for v4.1.4

### DIFF
--- a/sources/functions/rutorrent
+++ b/sources/functions/rutorrent
@@ -116,13 +116,7 @@ function rutorrent_install() {
 	$localHostedMode = false; 		// Set to true if rTorrent is hosted on the SAME machine as ruTorrent
 	
 	$cachedPluginLoading = false;	// Set to true to enable rapid cached loading of ruTorrent plugins	
-	$pluginJSCacheExpire = 3*60;	// Sets duration ruTorrent plugin javascript cache is valid for in minutes
-						            // Default is 3 hours which equals 3 hours * 60 minutes due to caching issues
-						            // Optionally raise this value and clear web browser cache when upgrading versions
-						
-	$miscCacheExpire = 3*60*24;		// Sets duration ruTorrent miscellaneous web browser cache is valid for in minutes
-						            // The goal here to avoid keeping stale content in the web browser
-						            // Default is 3 days which equals 3 days * 60 minutes * 24 hours
+                                    // Required to clear web browser cache when upgrading versions
 
 	$localhosts = array( 			// list of local interfaces
 		"127.0.0.1",


### PR DESCRIPTION
Updates configuration variables for version 4.1.4. Cached age expiry is removed due to bugs with dynamic hooks. These variables serve no purpose anymore, other than to confuse the user. https://github.com/Novik/ruTorrent/releases/tag/v4.1.4