### PR TITLE
Nginx: Fix package errors during remove

### DIFF
--- a/scripts/remove/nginx.sh
+++ b/scripts/remove/nginx.sh
@@ -2,7 +2,8 @@
 
 systemctl stop -q nginx
 
-APT='nginx-extras nginx libnginx-mod-http-fancyindex ssl-cert php php-cli php-fpm php-dev php-xml php-curl php-xmlrpc php-json php-mcrypt php-opcache php-geoip php-xml php php-cli php-fpm php-dev php-xml php-curl php-xmlrpc php-json php-mcrypt php-opcache'
+[[ $(_os_codename) =~ ^(focal|buster|bullseye)$ ]] && geoip="php-geoip" || geoip=""
+APT="nginx-extras nginx libnginx-mod-http-fancyindex ssl-cert php php-cli php-fpm php-dev php-xml php-curl php-xmlrpc php-json php-opcache ${geoip}"
 apt_remove $APT
 
 LIST='nginx-* php7.0-* php-*'


### PR DESCRIPTION
`php-mcrypt` and `php-geoip` are not supported on some operating systems. We need to check before attempting to remove them. Don't specify packages for removal more than once. If we miss anything, we can purge it. This is bad for maintenance.