### PR TITLE
Add Ubuntu 23.04 Lunar to supported releases in dev branch

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -198,7 +198,7 @@ _os() {
         echo_error "Your distribution ($distribution) is not supported. Swizzin requires Ubuntu or Debian."
         exit 1
     fi
-    if [[ ! $codename =~ ^(buster|focal|bullseye|jammy)$ ]]; then
+    if [[ ! $codename =~ ^(buster|focal|bullseye|jammy|lunar)$ ]]; then
         echo_error "Your release ($codename) of $distribution is not supported."
         exit 1
     fi


### PR DESCRIPTION

<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description
<!-- Any general story time goes here :) Feel free to add screenshots/recording of your change in action here-->
Ubuntu recently released 23.04 Lunar Lobster - I manually ran the swizzin setup script with the new release name, and all seems to be working as expected. Tested web interfaces for ShellInABox, Deluge, Filebrowser, LibreSpeed, NetData, nzbGet, and Prowlarr

## Fixes issues: 
- Issue #nr...
- Un-tracked issue...

## Proposed Changes:
- Changed xyz...
Include Ubuntu 23.04 Lunar in list of supported OSes

## Change Categories
<!-- DELETE WHICHEVER BULLET DOES NOT APPLY -->
- Change in `functions` <!-- e.g. `utils`, `os`, `apt`, `ask`, etc. -->

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [N/A] Docs have been made OR are not necessary
    - PR link: 
- [N/A] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [x] Testing was done
   - [ ] Tests created or no new tests necessary
   - [x] Tests executed

## Test scenarios
<!-- Please let us know what has been done or anything else that works/doesn't. Feel free to copy-paste the examples at the bottom of this section -->

Tested web interfaces for ShellInABox, Deluge, Filebrowser, LibreSpeed, NetData, nzbGet, and Prowlarr


### Architectures
<!--
Please use these emojis here to fill the table below. It will nicely auto-format with spacing, don't worry. Leave empty wherever you do not know / have not tested
✅ = Works successfully
❎ = Does not work BUT is handled gracefully
🛠 = Still WIP
❌ = Broken / not working
-->
|   			| `amd64` 	| `armhf` 	| `arm64` 	| Unspecified 	|
|--------		|-------- 	|-------- 	|-------- 	|----------		|
| Jammy 		|			|			|			|				|
| Focal 		|			|			|			|				|
| Bionic		|			|			|			|				|
| Bullseye		|			|			|			|				|
| Buster		|			|			|			|				|
| Stretch		|			|			|			|				|
| Raspbian  	|	⚫️		|			|	⚫️		|	⚫️			|

### ✅❎ Passed

### 🛠🛠 TODO

### ❌❌ Currently failing

<!-- EXAMPLES :
- Fresh app install without nginx
    - With only one user
    - With multiple users present
- Fresh Install with nginx present nginx
    - With only one user
    - With multiple users present
- Fresh install and nginx install afterwards
    - With only one user
    - With multiple users present
- Update from version in master
- Upgrade from version in master
- Password gets changed from `box` in app
- User removal from `box` acting on app
- New user in `box` gets added to app
- Sysinfo compatibility
    - Info washed
    - Content available
-->

