### PR TITLE
cURL: Optimized cmake building

### DIFF
--- a/sources/functions/curl
+++ b/sources/functions/curl
@@ -2,7 +2,7 @@
 # Upgrade curl to bypass the bug in Debian 10. Can be used on any system however, but the benefit is to Buster users most
 
 configure_curl() {
-    apt_install cmake
+    apt_install cmake libssl-dev libnghttp2-dev libzstd-dev libldap2-dev libssh2-1-dev libpsl-dev
 }
 
 build_cares() {
@@ -54,8 +54,6 @@ build_curl() {
 
     unzip -q /tmp/curl.zip -d /tmp >> $log 2>&1
     rm /tmp/curl.zip
-
-    apt_install libssl-dev libnghttp2-dev libzstd-dev libldap2-dev libssh2-1-dev libpsl-dev
 
     cd /tmp/curl-debian-bullseye-backports
     rm CMakeCache.txt >> $log 2>&1

--- a/sources/functions/curl
+++ b/sources/functions/curl
@@ -2,21 +2,7 @@
 # Upgrade curl to bypass the bug in Debian 10. Can be used on any system however, but the benefit is to Buster users most
 
 configure_curl() {
-    # pipe optimizations for 2048MB plus memory
-    # only required for c-ares due to high memory consumption
-    memory=$(awk '/MemAvailable/ {printf( "%.f\n", $2 / 1024 )}' /proc/meminfo)
-    if [[ $memory > 2048 ]]; then
-        export curlpipe="-pipe"
-    else
-        export curlpipe=""
-    fi
-    # link time optimizations for 2 plus threads
-    # Only required for curl due to high cpu usage
-    if [ $(nproc) -ge 2 ]; then
-        export curlflto="-flto=$(nproc)"
-    else
-        export curlflto=""
-    fi
+    apt_install cmake
 }
 
 build_cares() {
@@ -37,13 +23,15 @@ build_cares() {
     rm /tmp/cares.tar.gz
 
     cd /tmp/cares
-    ./configure --prefix=/usr --disable-shared --disable-debug >> ${log} 2>&1 || {
+    rm CMakeCache.txt >> $log 2>&1
+
+    cmake . -D CARES_STATIC=ON -D CARES_SHARED=OFF -D CARES_STATIC_PIC=ON -D CMAKE_BUILD_TYPE:STRING="Release" -D CMAKE_C_FLAGS_RELEASE:STRING="-w -O3 -flto=\"$(nproc)\" -march=native" >> ${log} 2>&1 || {
         echo_error "There was an error configuring c-ares! Please check the log for more info"
         cd /tmp
         rm -rf /tmp/cares >> $log 2>&1
         exit 1
     }
-    make -j$(nproc) CFLAGS="-w -O2 -flto ${curlpipe}" >> ${log} 2>&1 || {
+    cmake --build . --clean-first --parallel $(nproc) >> ${log} 2>&1 || {
         echo_error "There was an error compiling c-ares! Please check the log for more info"
         cd /tmp
         rm -rf /tmp/cares >> $log 2>&1
@@ -67,17 +55,18 @@ build_curl() {
     unzip -q /tmp/curl.zip -d /tmp >> $log 2>&1
     rm /tmp/curl.zip
 
-    apt_install libssl-dev libnghttp2-dev libzstd-dev libldap2-dev libssh2-1-dev librtmp-dev libpsl-dev
+    apt_install libssl-dev libnghttp2-dev libzstd-dev libldap2-dev libssh2-1-dev libpsl-dev
 
     cd /tmp/curl-debian-bullseye-backports
-    ./configure --with-openssl --with-zlib --with-zstd --with-libssh2 --with-nghttp2 --with-librtmp --with-libpsl \
-        --enable-ares --enable-ldap --enable-ldaps --enable-websockets --disable-shared --disable-debug >> ${log} 2>&1 || {
+    rm CMakeCache.txt >> $log 2>&1
+
+    cmake . -D ENABLE_ARES=ON -D ENABLE_WEBSOCKETS=ON -D CURL_LTO=ON -D CURL_USE_OPENSSL=ON -D CURL_USE_OPENLDAP=ON -D CURL_BROTLI=ON -D CURL_ZSTD=ON -D CURL_USE_LIBPSL=ON -D USE_NGHTTP2=ON -D BUILD_SHARED_LIBS=OFF -D CMAKE_BUILD_TYPE:STRING="Release" -D CMAKE_C_FLAGS_RELEASE:STRING="-w -O3 -flto=\"$(nproc)\" -march=native" >> ${log} 2>&1 || {
         echo_error "There was an error configuring curl! Please check the log for more info"
         cd /tmp
         rm -rf /tmp/curl-* >> $log 2>&1
         exit 1
     }
-    make -j$(nproc) CFLAGS="-w -O2 ${curlflto} -pipe" >> ${log} 2>&1 || {
+    cmake --build . --clean-first --parallel $(nproc) >> ${log} 2>&1 || {
         echo_error "There was an error compiling curl! Please check the log for more info"
         cd /tmp
         rm -rf /tmp/curl-* >> $log 2>&1

--- a/sources/functions/curl
+++ b/sources/functions/curl
@@ -12,7 +12,7 @@ build_cares() {
     cares_latest=$(github_latest_version c-ares/c-ares)
     cares_tar=${cares_latest/cares/c-ares}
 
-    wget -q -O /tmp/cares.tar.gz https://github.com/c-ares/c-ares/releases/download/${cares_latest}/${cares_tar//_/.}.tar.gz > ${log} 2>&1 || {
+    wget -q -O /tmp/cares.tar.gz https://github.com/c-ares/c-ares/releases/download/${cares_latest}/${cares_tar//_/.}.tar.gz >> ${log} 2>&1 || {
         echo_error "There was an error downloading c-ares! Please check the log for more info"
         rm /tmp/cares.tar.gz >> $log 2>&1
         exit 1


### PR DESCRIPTION
**Tested on Ubuntu 22.04 LTS ARM64**.
- Decreased build time from 3 minutes to 60 seconds on ARM64.
- Always enable Link Time Optimizations.
- Use Level 3 compiler optimizations with native march.