### PR TITLE
rTorrent: Consolidate package installs

### DIFF
--- a/sources/functions/rtorrent
+++ b/sources/functions/rtorrent
@@ -87,7 +87,9 @@ function depends_rtorrent() {
     dstat automake libtool libcppunit-dev libssl-dev pkg-config libcurl4-openssl-dev
     libsigc++-2.0-dev unzip curl libncurses5-dev yasm fontconfig libfontconfig1
     libfontconfig1-dev mediainfo'
-        apt_install $APT
+        FPM='ruby ruby-dev libffi-dev'
+        CURL='cmake libssl-dev libnghttp2-dev libzstd-dev libldap2-dev libssh2-1-dev libpsl-dev'
+        apt_install $APT $FPM $CURL
 
         . /etc/swizzin/sources/functions/fpm
         install_fpm


### PR DESCRIPTION
This commit consolidates package installs to be performed at the same time. It reduces install script overhead and makes it easier for the user to understand what is happening. Feature specific requirements are defined with a new variable, so developers know which ones to adjust if maintenance is required. Compatible with #1003.