### PR TITLE
Ubuntu: Upgrade to Python 3.11

### DIFF
--- a/scripts/update/10-dependencies.sh
+++ b/scripts/update/10-dependencies.sh
@@ -10,8 +10,11 @@ if [[ $(_os_distro) == "ubuntu" ]]; then
         echo_info "Upgrading to Python 3.11"
         add-apt-repository -y ppa:deadsnakes/ppa >> ${log} 2>&1
         apt_install python3.11-full
-        echo "alias python=/usr/bin/python3.11" >> ~/.bashrc
-        echo "alias python3=/usr/bin/python3.11" >> ~/.bashrc
+        echo "alias python=/usr/bin/python3.11" >> /root/.bashrc
+        echo "alias python3=/usr/bin/python3.11" >> /root/.bashrc
+        mkdir -p /usr/local/bin/swizzin/python/ >> ${log} 2>&1
+        echo "export PATH=/usr/local/bin/swizzin/python:$PATH" >> /root/.bashrc
+        ln -s /usr/bin/python3.11 /usr/local/bin/swizzin/python/python3 >> ${log} 2>&1
         ln -s /usr/lib/python3.11/dist-packages/$(ls -a | grep apt_pkg.cpython) /usr/lib/python3.11/dist-packages/apt_pkg.so >> ${log} 2>&1
         source ~/.bashrc
     fi

--- a/scripts/update/10-dependencies.sh
+++ b/scripts/update/10-dependencies.sh
@@ -10,9 +10,9 @@ if [[ $(_os_distro) == "ubuntu" ]]; then
         echo_info "Upgrading to Python 3.11"
         add-apt-repository -y ppa:deadsnakes/ppa >> ${log} 2>&1
         apt_install python3.11-full
-        update-alternatives --install /usr/bin/python python /usr/bin/python3.11 11 >> ${log} 2>&1
-        update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 11 >> ${log} 2>&1
-        ln -s /usr/lib/python3/dist-packages/$(ls -a | grep apt_pkg.cpython) /usr/lib/python3/dist-packages/apt_pkg.so >> ${log} 2>&1
+        echo "alias python=‘/usr/bin/python3.11’" >> ~/.bashrc
+        echo "alias python3=‘/usr/bin/python3.11’" >> ~/.bashrc
+        ln -s /usr/lib/python3.11/dist-packages/$(ls -a | grep apt_pkg.cpython) /usr/lib/python3.11/dist-packages/apt_pkg.so >> ${log} 2>&1
     fi
     #Ignore a found match if the line is commented out
     if ! grep 'universe' /etc/apt/sources.list | grep -q -v '^#'; then
@@ -52,4 +52,4 @@ dependencies="whiptail git sudo curl wget lsof fail2ban apache2-utils vnstat tcl
 apt_install "${dependencies[@]}"
 
 #fix pip for python 3.11 after installing curl
-curl -sS https://bootstrap.pypa.io/get-pip.py | python3 >> ${log} 2>&1
+curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11 >> ${log} 2>&1

--- a/scripts/update/10-dependencies.sh
+++ b/scripts/update/10-dependencies.sh
@@ -10,9 +10,10 @@ if [[ $(_os_distro) == "ubuntu" ]]; then
         echo_info "Upgrading to Python 3.11"
         add-apt-repository -y ppa:deadsnakes/ppa >> ${log} 2>&1
         apt_install python3.11-full
-        echo "alias python=‘/usr/bin/python3.11’" >> ~/.bashrc
-        echo "alias python3=‘/usr/bin/python3.11’" >> ~/.bashrc
+        echo "alias python=‘/usr/lib/python3.11’" >> ~/.bashrc
+        echo "alias python3=‘/usr/lib/python3.11’" >> ~/.bashrc
         ln -s /usr/lib/python3.11/dist-packages/$(ls -a | grep apt_pkg.cpython) /usr/lib/python3.11/dist-packages/apt_pkg.so >> ${log} 2>&1
+        source ~/.bashrc
     fi
     #Ignore a found match if the line is commented out
     if ! grep 'universe' /etc/apt/sources.list | grep -q -v '^#'; then

--- a/scripts/update/10-dependencies.sh
+++ b/scripts/update/10-dependencies.sh
@@ -10,8 +10,8 @@ if [[ $(_os_distro) == "ubuntu" ]]; then
         echo_info "Upgrading to Python 3.11"
         add-apt-repository -y ppa:deadsnakes/ppa >> ${log} 2>&1
         apt_install python3.11-full
-        echo "alias python=‘/usr/lib/python3.11’" >> ~/.bashrc
-        echo "alias python3=‘/usr/lib/python3.11’" >> ~/.bashrc
+        echo "alias python=/usr/bin/python3.11" >> ~/.bashrc
+        echo "alias python3=/usr/bin/python3.11" >> ~/.bashrc
         ln -s /usr/lib/python3.11/dist-packages/$(ls -a | grep apt_pkg.cpython) /usr/lib/python3.11/dist-packages/apt_pkg.so >> ${log} 2>&1
         source ~/.bashrc
     fi

--- a/scripts/update/10-dependencies.sh
+++ b/scripts/update/10-dependencies.sh
@@ -6,6 +6,14 @@ if ! which add-apt-repository > /dev/null; then
 fi
 
 if [[ $(_os_distro) == "ubuntu" ]]; then
+    if ! which python3.11 > /dev/null; then
+        echo_info "Upgrading to Python 3.11"
+        add-apt-repository -y ppa:deadsnakes/ppa >> ${log} 2>&1
+        apt_install python3.11-full
+        update-alternatives --install /usr/bin/python python /usr/bin/python3.11 11 >> ${log} 2>&1
+        update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 11 >> ${log} 2>&1
+        ln -s /usr/lib/python3/dist-packages/$(ls -a | grep apt_pkg.cpython) /usr/lib/python3/dist-packages/apt_pkg.so >> ${log} 2>&1
+    fi
     #Ignore a found match if the line is commented out
     if ! grep 'universe' /etc/apt/sources.list | grep -q -v '^#'; then
         echo_info "Enabling universe repo"
@@ -42,3 +50,6 @@ fi
 dependencies="whiptail git sudo curl wget lsof fail2ban apache2-utils vnstat tcl tcl-dev build-essential dirmngr apt-transport-https bc uuid-runtime jq net-tools gnupg2 cracklib-runtime unzip ccze"
 
 apt_install "${dependencies[@]}"
+
+#fix pip for python 3.11 after installing curl
+curl -sS https://bootstrap.pypa.io/get-pip.py | python3 >> ${log} 2>&1


### PR DESCRIPTION
This pull request upgrades Ubuntu to Python 3.11, which is 60% faster than Python 3.10 for package installations. Changes were tested on Ubuntu 22.04 LTS ARM64. The installation speed of packages across the entire script was increased by 60%. This resolves a problem with slower deployment times on ARM, due to lengthy package installation times. x86 will benefit too.