### PR TITLE
Jammy: GCC 12 system default

### DIFF
--- a/scripts/update/10-dependencies.sh
+++ b/scripts/update/10-dependencies.sh
@@ -7,7 +7,7 @@ fi
 
 if [[ $(_os_distro) == "ubuntu" ]]; then
     if [[ $(_os_codename) == "jammy" ]]; then
-        if ! grep 'ubuntu-toolchain-r' /etc/apt/sources.list | grep -q -v '^#'; then
+        if ! grep 'ubuntu-toolchain-r' /etc/apt/sources.list.d/ubuntu-toolchain-r-ubuntu-ppa-jammy.list | grep -q -v '^#'; then
             echo_info "Adding toolchain repo"
             add-apt-repository -y ppa:ubuntu-toolchain-r/ppa >> ${log} 2>&1
             trigger_apt_update=true

--- a/scripts/update/10-dependencies.sh
+++ b/scripts/update/10-dependencies.sh
@@ -6,6 +6,13 @@ if ! which add-apt-repository > /dev/null; then
 fi
 
 if [[ $(_os_distro) == "ubuntu" ]]; then
+    if [[ $(_os_codename) == "jammy" ]]; then
+        if ! grep 'ubuntu-toolchain-r' /etc/apt/sources.list | grep -q -v '^#'; then
+            echo_info "Adding toolchain repo"
+            add-apt-repository -y ppa:ubuntu-toolchain-r/ppa >> ${log} 2>&1
+            trigger_apt_update=true
+        fi
+    fi
     #Ignore a found match if the line is commented out
     if ! grep 'universe' /etc/apt/sources.list | grep -q -v '^#'; then
         echo_info "Enabling universe repo"
@@ -42,3 +49,6 @@ fi
 dependencies="whiptail git sudo curl wget lsof fail2ban apache2-utils vnstat tcl tcl-dev build-essential dirmngr apt-transport-https bc uuid-runtime jq net-tools gnupg2 cracklib-runtime unzip ccze"
 
 apt_install "${dependencies[@]}"
+
+. /etc/swizzin/sources/functions/gcc
+GCC_Jammy_Upgrade

--- a/sources/functions/gcc
+++ b/sources/functions/gcc
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Upgrade to GCC 12 for Jammy users to unlock better performance of compiled software
+
+GCC_Jammy_Upgrade() {
+    # Check if the operating system is Ubuntu 22.04 LTS
+    if [[ $(_os_codename) == "jammy" ]]; then
+        # Check if GCC 12 is installed by looking for the binary path
+        if ! which gcc-12 > /dev/null; then
+            echo_info "Installing GCC 12"
+            apt_install gcc-12 g++-12
+        fi
+        # Check if GCC 12 is system default by comparing the version string
+        if [[ $(gcc --version | grep -c "Ubuntu 12") -le 0 ]]; then
+            echo_info "Configuring GCC 12"
+            echo_log_only "Removing all GCC preferences"
+            update-alternatives --remove-all gcc >> $log 2>&1
+            update-alternatives --remove-all g++ >> $log 2>&1
+            echo_log_only "Setting GCC 12 as system default"
+            update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 12 >> $log 2>&1
+            update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 12 >> $log 2>&1
+            if which gcc-11 > /dev/null; then
+                echo_log_only "Setting GCC 11 as system backup"
+                update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 11 >> $log 2>&1
+                update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 11 >> $log 2>&1
+            fi
+        fi
+    fi
+}


### PR DESCRIPTION
This commit sets GCC 12 as the Ubuntu 22.04 LTS system default. It allows users to unlock the latest improvements for compiled software solutions. It is capable of repairing linkage from previous distribution releases or manual user adjustments.

Implemented as suggested in #992. The plan is to only support Jammy for simplicity. It is pointless upgrading Focal because it's already two versions behind. The user should upgrade their distribution release, if they want the latest software packages.

Tested on Ubuntu 22.04 LTS ARM64. The script was successful.