### PR TITLE
Nginx: dhparm background task

### DIFF
--- a/scripts/install/nginx.sh
+++ b/scripts/install/nginx.sh
@@ -51,11 +51,35 @@ case $codename in
         ;;
 esac
 
+# Prepare the /etc/nginx/ssl/ for openssl dhparm generation
+mkdir -p /etc/nginx/ssl/
+chmod 700 /etc/nginx/ssl
+cd /etc/nginx/ssl
+
+# Create temp.log for openssl dhparm generation to prevent a race condition with logging
+. /etc/swizzin/sources/functions/utils
+templog="/root/logs/temp.log"
+rm_if_exists $templog
+touch $templog
+
+# Start openssl dhparam as a background task using temp.log
+openssl dhparam -out dhparam.pem 2048 >> $templog 2>&1 &
+
+# Install packages for nginx in the foreground
 APT="nginx libnginx-mod-http-fancyindex subversion ssl-cert php-fpm libfcgi0ldbl php-cli php-dev php-xml php-curl php-xmlrpc php-json php-mbstring php-opcache php-zip ${geoip} ${mcrypt}"
-
 apt_install $APT
-mkdir -p /srv
 
+# Wait for the background task of openssl dhparm generation to finish
+wait
+
+# Append the results of temp.log to swizzin.log and remove temp.log
+echo_log_only "Begin of OpenSSL dhparm results"
+cat $templog >> $log 2>&1
+echo_log_only "End of OpenSSL dhparm results"
+rm_if_exists $templog
+
+# Began configuring nginx in the foreground
+mkdir -p /srv
 cd /etc/php
 phpv=$(ls -d */ | cut -d/ -f1)
 echo_progress_start "Making adjustments to PHP"
@@ -125,14 +149,8 @@ server {
 }
 NGC
 
-mkdir -p /etc/nginx/ssl/
 mkdir -p /etc/nginx/snippets/
 mkdir -p /etc/nginx/apps/
-
-chmod 700 /etc/nginx/ssl
-
-cd /etc/nginx/ssl
-openssl dhparam -out dhparam.pem 2048 >> $log 2>&1
 
 cat > /etc/nginx/snippets/ssl-params.conf << SSC
 ssl_protocols TLSv1.2 TLSv1.3;


### PR DESCRIPTION
This commit starts a background task for `openssl dhparam -out dhparam.pem` to allow package installation at the same time. This reduces installation time of `nginx` by 30s on x86 and 60s on ARM64 without any real disadvantages. `temp.log` is created to prevent a race condition with logging. The logging output is appended to `swizzin.log` afterwards and `temp.log` is removed.

Tested on Ubuntu 22.04 LTS ARM64. Works as expected. Package installation finished before `openssl dhparam -out dhparam.pem`. The bash script waited for the background task to finish before proceeding. 60s of installation time was saved.