### PR TITLE
rTorrent: Save session files hourly

### DIFF
--- a/scripts/install/rtorrent.sh
+++ b/scripts/install/rtorrent.sh
@@ -38,6 +38,7 @@ throttle.min_peers.normal.set = 1
 throttle.min_peers.seed.set = -1
 trackers.use_udp.set = yes
 schedule2 = session_save, 1200, 3600, ((session.save))
+method.set_key = event.download.inserted, 2_save_session, ((d.save_full_session))
 
 execute = {sh,-c,/usr/bin/php /srv/rutorrent/php/initplugins.php ${user} &}
 

--- a/scripts/install/rtorrent.sh
+++ b/scripts/install/rtorrent.sh
@@ -37,6 +37,7 @@ throttle.max_uploads.global.set = 100
 throttle.min_peers.normal.set = 1
 throttle.min_peers.seed.set = -1
 trackers.use_udp.set = yes
+schedule2 = session_save, 1200, 3600, ((session.save))
 
 execute = {sh,-c,/usr/bin/php /srv/rutorrent/php/initplugins.php ${user} &}
 


### PR DESCRIPTION
This commit fixes an I/O thrashing issue with mechanical hard drives. We need to save session files for torrents hourly instead of once every 20 minutes by default. Otherwise, it will trash the disk, if the user has thousands of torrents. This operation can take minutes, especially with shared resources. rTorrent saves torrent information into session files on disk. This is very intensive.

See here for the default value of 20 minutes which is 1200 seconds. Adding the `session_save` function to `rtorrent.rc` overrides this value. https://github.com/rakshasa/rtorrent/blob/master/src/main.cc#LL358C63-L358C63