### PR TITLE
rTorrent: Parallel dependency installation

### DIFF
--- a/sources/build/libudns.sh
+++ b/sources/build/libudns.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/bash
+# libudns Builder
+
+udnslog=$1
+
+source /etc/swizzin/sources/functions/utils
+rm_if_exists $udnslog
+touch $udnslog
+
+rm_if_exists "/tmp/udns"
+git clone -q https://github.com/shadowsocks/libudns /tmp/udns >> $udnslog 2>&1
+cd /tmp/udns
+./autogen.sh >> $udnslog 2>&1
+./configure --prefix=/usr >> $udnslog 2>&1
+make CFLAGS="-w -flto -O2 -fPIC" >> $udnslog 2>&1
+make -s install >> $udnslog 2>&1
+cd /tmp
+rm -rf udns*

--- a/sources/build/mktorrent.sh
+++ b/sources/build/mktorrent.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/bash
+# mktorrent Builder
+
+mklog=$1
+
+source /etc/swizzin/sources/functions/utils
+rm_if_exists $mklog
+touch $mklog
+
+cd /tmp
+curl -sL https://github.com/Rudde/mktorrent/archive/v1.1.zip -o mktorrent.zip >> $mklog 2>&1
+rm_if_exists "/tmp/mktorrent"
+unzip -d mktorrent -j mktorrent.zip >> $mklog 2>&1
+cd mktorrent
+make >> $mklog 2>&1
+make install PREFIX=/usr >> $mklog 2>&1
+cd /tmp
+rm -rf mktorrent*

--- a/sources/functions/rtorrent
+++ b/sources/functions/rtorrent
@@ -82,6 +82,21 @@ function configure_rtorrent() {
 }
 
 function depends_rtorrent() {
+    # mktorrent and libudns from source
+    echo_info "Building source dependencies"
+    local mklog="/root/logs/mktorrent.log"
+    local udnslog="/root/logs/libudns.log"
+    bash "/etc/swizzin/sources/build/mktorrent.sh" $mklog &
+    if [[ ${libudns} == "true" ]]; then
+        bash "/etc/swizzin/sources/build/libudns.sh" $udnslog &
+    fi
+
+    # wait for building to complete if less than 4 threads, otherwise it will take longer
+    if [ $(nproc) -lt 4 ]; then
+        wait
+    fi
+
+    # package installation of dependencies
     if [[ ! $rtorrentver == repo ]]; then
         APT='subversion dos2unix bc screen zip unzip sysstat build-essential comerr-dev
     dstat automake libtool libcppunit-dev libssl-dev pkg-config libcurl4-openssl-dev
@@ -96,29 +111,25 @@ function depends_rtorrent() {
         apt_install $APT
     fi
 
-    # mktorrent from source
-    cd /tmp
-    curl -sL https://github.com/Rudde/mktorrent/archive/v1.1.zip -o mktorrent.zip >> $log 2>&1
-    . /etc/swizzin/sources/functions/utils
-    rm_if_exists "/tmp/mktorrent"
-    unzip -d mktorrent -j mktorrent.zip >> $log 2>&1
-    cd mktorrent
-    make >> $log 2>&1
-    make install PREFIX=/usr >> $log 2>&1
-    cd /tmp
-    rm -rf mktorrent*
+    # Wait for build tasks to complete
+    wait
 
-    # libudns from source
+    # mktorrent and udns log append
+    rt_build_log_append "mktorrent" $mklog
     if [[ ${libudns} == "true" ]]; then
-        git clone -q https://github.com/shadowsocks/libudns /tmp/udns >> $log 2>&1
-        cd /tmp/udns
-        ./autogen.sh >> $log 2>&1
-        ./configure --prefix=/usr >> $log 2>&1
-        make -j$(nproc) CFLAGS="-w ${rtorrentflto} ${rtorrentpipe} -O2 -fPIC" >> $log 2>&1
-        make -s install >> $log 2>&1
-        cd /tmp
-        rm -rf udns*
+        rt_build_log_append "libudns" $udnslog
     fi
+}
+
+function rt_build_log_append() {
+    local binary=$1
+    local file=$2
+
+    echo -e "\nBegin of $binary build log" >> $log 2>&1
+    cat $file >> $log 2>&1
+    echo -e "End of $binary build log\n" >> $log 2>&1
+    . /etc/swizzin/sources/functions/utils
+    rm_if_exists $file
 }
 
 function build_xmlrpc-c() {


### PR DESCRIPTION
This commit allows modular and parallel building of rTorrent dependencies. Tested on Ubuntu 22.04 x86. Requires log file fix from #1003 for proper testing. Output is appended to `swizzin.log` afterwards more cleanly than before. Temporary log files are used to prevent race conditions from happening. Threads counts and task concurrency are limited to ensure stable installation times.