### PR TITLE
cURL: Upgrade without cURL binary

### DIFF
--- a/sources/functions/curl
+++ b/sources/functions/curl
@@ -9,7 +9,7 @@ build_cares() {
     cd /tmp
 
     . /etc/swizzin/sources/functions/utils
-    cares_latest=$(github_latest_version c-ares/c-ares)
+    cares_latest=$(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' https://github.com/c-ares/c-ares.git | grep cares | grep -o '[^/^{}]*$' | tail --lines=1)
     cares_tar=${cares_latest/cares/c-ares}
 
     wget -q -O /tmp/cares.tar.gz https://github.com/c-ares/c-ares/releases/download/${cares_latest}/${cares_tar//_/.}.tar.gz >> ${log} 2>&1 || {


### PR DESCRIPTION
This commit fixes a bug where `curl` cannot be upgraded if the `curl` binary is not functioning. It uses `git` instead of `curl` to retrieve the latest version of `c-ares` from GitHub. This allows `box upgrade curl` to always work regardless of distribution upgrades. It produces the same output as `github_latest_version c-ares/c-ares`.