### PR TITLE
rTorrent: Fix bug with UDNS branch

### DIFF
--- a/sources/patches/rtorrent/libtorrent-udns-0.13.8.patch
+++ b/sources/patches/rtorrent/libtorrent-udns-0.13.8.patch
@@ -402,7 +402,7 @@ index 93493e478..04d836f49 100644
 -  m_slot_resolver = make_resolver_slot(hostname);
 +  m_resolver_query = manager->connection_manager()->async_resolver().enqueue(
 +      hostname.data(),
-+      AF_UNSPEC,
++      AF_INET,
 +      &m_resolver_callback
 +  );
 +  manager->connection_manager()->async_resolver().flush();


### PR DESCRIPTION
Author pinged here about fix for UDNS failing for IPV6. rTorrent doesn't offer meaning IPV6 support, so we should only attempt to resolve UDP trackers using IPV4 to prevent failures. https://github.com/rakshasa/libtorrent/pull/134#issuecomment-1593671383

See commit https://github.com/rakshasa/libtorrent/commit/25100693ee7ace605fbdbf58339b55af0d59b9f2 for more details.

