### PR TITLE
remove feathub link from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,9 +6,6 @@ contact_links:
   - name: "Troubleshooting Guide"
     url: https://swizzin.ltd/docs/guides/troubleshooting
     about: "Please make sure to follow these steps before submitting a bug."
-  - name: "Feature Requests"
-    url: https://feathub.com/liaralabs/swizzin
-    about: In case you'd like something new, search here or create a new suggestion.
   - name: "GitHub Discussions"
     url: https://github.com/liaralabs/swizzin/discussions
     about: Please ask and answer non-bug-related questions here.


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description
Remove feathub from GH Issue tempalte

## Fixes issues: 
- First reported on the [Discord](https://discord.com/channels/577667871727943696/577667871727943700/1070733509301379072)
- Removed from README in https://github.com/swizzin/swizzin/commit/9743e49175209bc59ec636b302519ea78df60e8a

## Change Categories
<!-- DELETE WHICHEVER BULLET DOES NOT APPLY -->
- Bug fix <!-- non-breaking change which fixes an issue -->

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [x] Docs have been made OR are not necessary
- [x] Changes to panel have been made OR are not necessary
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [ ] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [ ] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [ ] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Testing was done
   - [ ] Tests created or no new tests necessary
   - [ ] Tests executed


