### PR TITLE
allow access to /feed/calendar via NGINX

### DIFF
--- a/scripts/nginx/lidarr.sh
+++ b/scripts/nginx/lidarr.sh
@@ -39,6 +39,14 @@ location ^~ /$app_baseurl/api {
     auth_basic off;
     proxy_pass http://127.0.0.1:$app_port;
 }
+
+# Allow Calendar Feed External Access via NGINX
+
+location ^~ /$app_baseurl/feed/calendar {
+    auth_basic off;
+    proxy_pass http://127.0.0.1:$app_port;
+}
+
 ARRNGINX
 
 wasActive=$(systemctl is-active $app_servicefile)

--- a/scripts/nginx/radarr.sh
+++ b/scripts/nginx/radarr.sh
@@ -40,6 +40,13 @@ location ^~ /$app_baseurl/api {
     proxy_pass http://127.0.0.1:$app_port;
 }
 
+# Allow Calendar Feed External Access via NGINX
+
+location ^~ /$app_baseurl/feed/calendar {
+    auth_basic off;
+    proxy_pass http://127.0.0.1:$app_port;
+}
+
 ARRNGINX
 
 wasActive=$(systemctl is-active $app_servicefile)

--- a/scripts/nginx/readarr.sh
+++ b/scripts/nginx/readarr.sh
@@ -39,6 +39,13 @@ location ^~ /$app_baseurl/api {
     proxy_pass http://127.0.0.1:$app_port;
 }
 
+# Allow Calendar Feed External Access via NGINX
+
+location ^~ /$app_baseurl/feed/calendar {
+    auth_basic off;
+    proxy_pass http://127.0.0.1:$app_port;
+}
+
 ARRNGINX
 
 wasActive=$(systemctl is-active $app_servicefile)

--- a/scripts/nginx/sonarr.sh
+++ b/scripts/nginx/sonarr.sh
@@ -39,6 +39,14 @@ location ^~ /$app_baseurl/api {
     auth_basic off;
     proxy_pass http://127.0.0.1:$app_port;
 }
+
+# Allow Calendar Feed External Access via NGINX
+
+location ^~ /$app_baseurl/feed/calendar {
+    auth_basic off;
+    proxy_pass http://127.0.0.1:$app_port;
+}
+
 ARRNGINX
 
 wasActive=$(systemctl is-active $app_servicefile)

--- a/scripts/update/lidarr.sh
+++ b/scripts/update/lidarr.sh
@@ -78,11 +78,11 @@ if [[ -f /install/.lidarr.lock ]]; then
     fi
 
     if [[ -f /install/.nginx.lock ]]; then
-        if grep -q "8686/lidarr" /etc/nginx/apps/lidarr.conf; then
-            echo_progress_start "Updating nginx for config lidarr"
+        if grep -q "8686/lidarr" /etc/nginx/apps/lidarr.conf || ! grep -q "calendar" /etc/nginx/apps/lidarr.conf; then
+            echo_progress_start "Updating nginx for config for lidarr"
             bash /etc/swizzin/scripts/nginx/lidarr.sh
-            systemctl reload nginx
-            echo_progress_done "nginx updated."
+            systemctl reload nginx -q
+            echo_progress_done "nginx conf for lidarr upgraded"
         fi
     fi
 fi

--- a/scripts/update/radarr.sh
+++ b/scripts/update/radarr.sh
@@ -107,7 +107,7 @@ ${app_name^} updater is exiting, please try again later."
     fi
     if [[ -f /install/.nginx.lock ]]; then
         # check for /feed/calendar auth bypass
-        if grep -q "7878/radarr" /etc/nginx/apps/radarr.conf || ! grep -q "calendar" /etc/nginx/apps/sonarr.conf; then
+        if grep -q "7878/radarr" /etc/nginx/apps/radarr.conf || ! grep -q "calendar" /etc/nginx/apps/radarr.conf; then
             echo_progress_start "Upgrading nginx config for Radarr"
             bash /etc/swizzin/scripts/nginx/radarr.sh
             systemctl reload nginx -q

--- a/scripts/update/radarr.sh
+++ b/scripts/update/radarr.sh
@@ -106,11 +106,12 @@ ${app_name^} updater is exiting, please try again later."
         echo_log_only "Radarr's ports are not on 8787"
     fi
     if [[ -f /install/.nginx.lock ]]; then
-        if grep -q "7878/radarr" /etc/nginx/apps/radarr.conf; then
+        # check for /feed/calendar auth bypass
+        if grep -q "7878/radarr" /etc/nginx/apps/radarr.conf || ! grep -q "calendar" /etc/nginx/apps/sonarr.conf; then
             echo_progress_start "Upgrading nginx config for Radarr"
             bash /etc/swizzin/scripts/nginx/radarr.sh
             systemctl reload nginx -q
-            echo_progress_done "Nginx config for Radarr upgraded"
+            echo_progress_done "nginx config for Radarr upgraded"
         fi
     fi
 fi

--- a/scripts/update/readarr.sh
+++ b/scripts/update/readarr.sh
@@ -2,11 +2,12 @@
 
 if [[ -f /install/.readarr.lock ]]; then
     if [[ -f /install/.nginx.lock ]]; then
-        if grep -q "8787/readarr" /etc/nginx/apps/readarr.conf; then
+        # check for /feed/calendar auth bypass
+        if grep -q "8787/readarr" "/etc/nginx/apps/readarr.conf" || ! grep -q "calendar" /etc/nginx/apps/readarr.conf; then
             echo_progress_start "Upgrading nginx config for Readarr"
             bash /etc/swizzin/scripts/nginx/readarr.sh
             systemctl reload nginx -q
-            echo_progress_done "Nginx conf for Readarr upgraded"
+            echo_progress_done "nginx conf for Readarr upgraded"
         fi
     fi
 fi

--- a/scripts/update/sonarr.sh
+++ b/scripts/update/sonarr.sh
@@ -111,3 +111,14 @@ if [[ -f /install/.sonarr.lock ]] && dpkg -l | grep sonarr | grep ^ii > /dev/nul
     fi
     echo_progress_done
 fi
+# Check for /feed/calendar auth bypass
+if [[ -f /install/.readarr.lock ]]; then
+    if [[ -f /install/.nginx.lock ]]; then
+        if ! grep -q "calendar" /etc/nginx/apps/sonarr.conf; then
+            echo_progress_start "Upgrading nginx config for Sonarr"
+            bash /etc/swizzin/scripts/nginx/sonarr.sh
+            systemctl reload nginx -q
+            echo_progress_done "nginx conf for Sonarr upgraded"
+        fi
+    fi
+fi


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description
Allow access to `/feed/calendar` since GCal import doesn't like inline HTTP auth

## Fixes issues: 

## Proposed Changes:
- Bypass authentication for path `/feed/calendar` for *arrs
  - sonarr
  - lidarr
  - radarr
  - readarr

## Change Categories
<!-- DELETE WHICHEVER BULLET DOES NOT APPLY -->
- New feature <!-- non-breaking change which adds functionality -->

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [x] Docs have been made OR are not necessary
- [x] Changes to panel have been made OR are not necessary
- [x] Code is formatted [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Shellcheck isn't screaming [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#editor-plugins-and-tooling)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Testing was done
   - [x] Tests created or no new tests necessary
   - [x] Tests executed

## Test scenarios
Since it targets nginx config, `nginx -t` was used instead and formatting was copied from previous instances of API exclusion