### PR TITLE
rTorrent: Fix a bunch of things

### DIFF
--- a/sources/functions/curl
+++ b/sources/functions/curl
@@ -76,6 +76,6 @@ build_curl() {
     cd /tmp
     rm -rf /tmp/curl-* >> $log 2>&1
 
-    ldconfig /usr/local/bin
     ldconfig /usr/local/lib
+    ldconfig /usr/local/bin
 }

--- a/sources/functions/curl
+++ b/sources/functions/curl
@@ -3,7 +3,7 @@
 
 configure_curl() {
     apt_install cmake libssl-dev libnghttp2-dev libzstd-dev libldap2-dev libssh2-1-dev libpsl-dev
-    rm /usr/local/lib/libcurl.la
+    rm_if_exists /usr/local/lib/libcurl.la
 }
 
 build_cares() {

--- a/sources/functions/rtorrent
+++ b/sources/functions/rtorrent
@@ -5,7 +5,7 @@ export release=$(lsb_release -rs)
 export codename=$(lsb_release -cs)
 
 function whiptail_rtorrent() {
-    if [[ -z $rtorrentver ]] && [[ -z $1 ]]; then
+	if [[ -z $rtorrentver ]] && [[ -z $1 ]] && [[ -z $RTORRENT_VERSION ]]; then
         repov=$(get_candidate_version rtorrent)
 
         whiptail --title "rTorrent Install Advisory" --msgbox "We recommend rTorrent version selection instead of repo (distro) releases. They will compile additional performance and stability improvements in 90s. UDNS includes a stability patch for UDP trackers on rTorrent." 15 50
@@ -20,43 +20,49 @@ function whiptail_rtorrent() {
             exit 1
         }
 
-        case $function in
-            0.9.6)
-                export rtorrentver='0.9.6'
-                export libtorrentver='0.13.6'
-                export libudns='false'
-                ;;
-
-            0.9.7)
-                export rtorrentver='0.9.7'
-                export libtorrentver='0.13.7'
-                export libudns='false'
-                ;;
-
-            0.9.8)
-                export rtorrentver='0.9.8'
-                export libtorrentver='0.13.8'
-                export libudns='false'
-                ;;
-
-            UDNS)
-                export rtorrentver='0.9.8'
-                export libtorrentver='0.13.8'
-                export libudns='true'
-                ;;
-
-            Repo)
-                export rtorrentver='repo'
-                export libtorrentver='repo'
-                export libudns='false'
-                ;;
-
-            *)
-                echo_error "$function is not a valid rTorrent version"
-                exit 1
-                ;;
-        esac
+        set_rtorrent_version $function
+    elif [[ -n $RTORRENT_VERSION ]]; then
+        set_rtorrent_version $RTORRENT_VERSION
     fi
+}
+
+function set_rtorrent_version() {
+	case $1 in
+        0.9.6 | '0.9.6')
+            export rtorrentver='0.9.6'
+            export libtorrentver='0.13.6'
+            export libudns='false'
+            ;;
+
+        0.9.7 | '0.9.7')
+            export rtorrentver='0.9.7'
+            export libtorrentver='0.13.7'
+            export libudns='false'
+            ;;
+
+        0.9.8 | '0.9.8')
+            export rtorrentver='0.9.8'
+            export libtorrentver='0.13.8'
+            export libudns='false'
+            ;;
+
+        UDNS | 'UDNS')
+            export rtorrentver='0.9.8'
+            export libtorrentver='0.13.8'
+            export libudns='true'
+            ;;
+
+        Repo | 'Repo')
+            export rtorrentver='repo'
+            export libtorrentver='repo'
+            export libudns='false'
+            ;;
+
+        *)
+            echo_error "$1 is not a valid rTorrent version"
+            exit 1
+            ;;
+    esac
 }
 
 function configure_rtorrent() {

--- a/sources/functions/rtorrent
+++ b/sources/functions/rtorrent
@@ -74,8 +74,10 @@ function configure_rtorrent() {
         export rtorrentpipe=""
     fi
     # GCC optimization level for program compilation
-    if [ $(nproc) -le 2 ]; then
+    if [ $(nproc) -le 1 ]; then
         export rtorrentlevel="-O1"
+    elif [ $(nproc) -ge 8 ]; then
+        export rtorrentlevel="-O3"
     else
         export rtorrentlevel="-O2"
     fi
@@ -114,7 +116,7 @@ function depends_rtorrent() {
         cd /tmp/udns
         ./autogen.sh >> $log 2>&1
         ./configure --prefix=/usr >> $log 2>&1
-        make -j$(nproc) CFLAGS="-w ${rtorrentflto} ${rtorrentpipe} -O2 -fPIC" >> $log 2>&1
+        make -j$(nproc) CFLAGS="-w ${rtorrentflto} ${rtorrentpipe} ${rtorrentlevel} -fPIC" >> $log 2>&1
         make -s install >> $log 2>&1
         cd /tmp
         rm -rf udns*

--- a/sources/patches/rtorrent/libtorrent-udns-0.13.8.patch
+++ b/sources/patches/rtorrent/libtorrent-udns-0.13.8.patch
@@ -402,7 +402,7 @@ index 93493e478..04d836f49 100644
 -  m_slot_resolver = make_resolver_slot(hostname);
 +  m_resolver_query = manager->connection_manager()->async_resolver().enqueue(
 +      hostname.data(),
-+      AF_INET,
++      AF_UNSPEC,
 +      &m_resolver_callback
 +  );
 +  manager->connection_manager()->async_resolver().flush();
@@ -657,7 +657,7 @@ index 000000000..b53d32e8a
 +    }
 +  }
 +
-+  if (family == AF_INET6 || family == AF_UNSPEC) {
++  if (family == AF_INET6) {
 +    query->a6_query = ::dns_submit_a6(m_ctx, name, 0, a6_callback_wrapper, query);
 +    if (query->a6_query == NULL) {
 +      // it should be impossible for dns_submit_a6 to fail if dns_submit_a4

--- a/unattended.example.env
+++ b/unattended.example.env
@@ -19,6 +19,9 @@ QBITTORRENT_VERSION="latest"
 ## transmission flags (https://docs.swizzin.ltd/applications/transmission#install-options)
 TRANSMISSION_VERSION="Repo"
 
+## rtorrent flags (https://swizzin.ltd/applications/rtorrent/#initial-setup)
+RTORRENT_VERSION="0.9.8"
+
 ## LetsEncrypt options ((https://docs.swizzin.ltd/applications/letsencrypt#install-options))
 LE_HOSTNAME="domain.tld"
 LE_DEFAULTCONF=yes


### PR DESCRIPTION
* Improve compile level optimizations for rtorrent. Utilize level 3 optimizations with 8+ threads. Apply optimizations to libudns. Decrease thread count from 2 to 1 for level 1 optimizations. Level 2 is still relatively quick on 2 threads.

* Fix support for unattended setup by refactoring version checking code. Add example for 0.9.8 source unattended.

* Fix a UDNS patch error regression from a previous commit. Remove IPV6 UDNS queries a different way instead.

* Fix a couple issues with curl. Silence build noise if la file doesn't exist. Fix curl not working properly by running ldconfig on the library before the binary.

Tested on Ubuntu 22.04 LTS ARM64 without unattended setup. Recommended to test with unattended before merging. 

closes #966.