### PR TITLE
Fix pyload.sh

### DIFF
--- a/scripts/install/pyload.sh
+++ b/scripts/install/pyload.sh
@@ -41,8 +41,10 @@ fi
 python2_venv ${user} pyload
 
 echo_progress_start "Installing python dependencies"
-PIP='wheel setuptools<45 pycurl pycrypto tesseract pillow pyOpenSSL js2py feedparser beautifulsoup'
+PIP='wheel setuptools<45 pycrypto tesseract pillow pyOpenSSL js2py feedparser beautifulsoup'
 /opt/.venv/pyload/bin/pip install $PIP >> "${log}" 2>&1
+# Fix 'ImportError: pycurl: libcurl link-time ssl backend (openssl) is different from compile-time ssl backend (none/other)' error
+/opt/.venv/pyload/bin/pip install pycurl --no-cache-dir >> "${log}" 2>&1
 chown -R ${user}: /opt/.venv/pyload
 echo_progress_done
 


### PR DESCRIPTION
Fixes installing PyLoad

<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description
Running Ubuntu 22.04 LTS, and for whatever reason Pyload kept erroring during the DB setup.

Checked the script, and tried running the erroring command myself and kept getting the following error 
`ImportError: pycurl: libcurl link-time ssl backend (openssl) is different from compile-time ssl backend (none/other)`

Added a work around to fix the issue and tested it successfully. 

## Change Categories
- Bug fix               <!-- non-breaking change which fixes an issue -->
