### PR TITLE
tautulli: use venv and pyenv on py3<3.7

### DIFF
--- a/scripts/remove/tautulli.sh
+++ b/scripts/remove/tautulli.sh
@@ -2,6 +2,7 @@
 systemctl stop -q tautulli
 systemctl disable -q tautulli
 rm -rf /opt/tautulli
+rm -rf /opt/.venv/tautulli
 rm /install/.tautulli.lock
 rm -f /etc/nginx/apps/tautulli.conf
 systemctl reload nginx

--- a/scripts/update/tautulli.sh
+++ b/scripts/update/tautulli.sh
@@ -13,13 +13,35 @@ if [[ -f /install/.tautulli.lock ]]; then
         echo_progress_done
     fi
 
-    if ! grep -q python3 /etc/systemd/system/tautulli.service; then
-        echo_progress_start "Updating Tautulli systemd service file"
-        sed -i 's|ExecStart=.*|ExecStart=/usr/bin/python3 /opt/tautulli/Tautulli.py --quiet --daemon --nolaunch --config /opt/tautulli/config.ini --datadir /opt/tautulli|g' /etc/systemd/system/tautulli.service
-        chown -R tautulli:nogroup /opt/tautulli
-        sudo -u tautulli git -C /opt/tautulli pull
+    if [[ ! -d /opt/.venv/tautulli ]]; then
+        echo_progress_start "Migrating Tautulli to venv"
+        . /etc/swizzin/sources/functions/pyenv
+        systempy3_ver=$(get_candidate_version python3)
+
+        if dpkg --compare-versions ${systempy3_ver} lt 3.8.0; then
+            PYENV=True
+            echo_info "pyenv will be used for the Tautulli venv. You may need to restart tautulli manually!"
+        else
+            LIST='python3-dev python3-setuptools python3-pip python3-venv'
+            apt_install $LIST
+        fi
+
+        case ${PYENV} in
+            True)
+                pyenv_install
+                pyenv_install_version 3.11.3
+                pyenv_create_venv 3.11.3 /opt/.venv/tautulli
+                chown -R tautulli: /opt/.venv/tautulli
+                ;;
+            *)
+                python3_venv tautulli tautulli
+                ;;
+        esac
+        sed -i 's|ExecStart=/usr|ExecStart=/opt/.venv/tautulli|g' /etc/systemd/system/tautulli.service
         systemctl daemon-reload
-        systemctl try-restart tautulli
+        if systemctl is-active tautulli > /dev/null 2>&1; then
+            systemctl restart tautulli
+        fi
         echo_progress_done
     fi
 fi


### PR DESCRIPTION
Tautulli requires 3.8 now, so swap installer to use this by minimum and forcefully update all users to a venv. Additionally update users who don't have 3.8 minimum and push them onto pyenv.