### PR TITLE
qBittorrent: Allow forced reannounces

### DIFF
--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -361,6 +361,7 @@ function build_libtorrent_qbittorrent() {
         #Dirty hack to ensure finished library uses `libtorrent-rasterbar` for its name in the deprecated 1.1 branch
         sed -i 's/virtual-target.add-prefix-and-suffix $(name)/virtual-target.add-prefix-and-suffix $(name)-rasterbar/g' Jamfile
     elif [[ ${libtorrent_branch} == "RC_1_2" ]]; then
+        sed -i 's|, (arg("seconds") = 0, arg("tracker_idx") = -1, arg("flags") = reannounce_flags_t{}))|, (arg("seconds") = 0, arg("tracker_idx") = -1, arg("flags") = 1))|g' bindings/python/src/torrent_handle.cpp
         sed -i 's|static constexpr reannounce_flags_t ignore_min_interval = 0_bit|static constexpr reannounce_flags_t ignore_min_interval = 1_bit|g' include/libtorrent/torrent_handle.hpp
     fi
     VERSION=$(grep -oP "VERSION\ = \K\d\.\d\.\d+" Jamfile)

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -360,9 +360,9 @@ function build_libtorrent_qbittorrent() {
     if [[ ${libtorrent_branch} == "RC_1_1" ]]; then
         #Dirty hack to ensure finished library uses `libtorrent-rasterbar` for its name in the deprecated 1.1 branch
         sed -i 's/virtual-target.add-prefix-and-suffix $(name)/virtual-target.add-prefix-and-suffix $(name)-rasterbar/g' Jamfile
-    elif [[ ${libtorrent_branch} == "RC_1_2" ]]; then
-        sed -i 's|, (arg("seconds") = 0, arg("tracker_idx") = -1, arg("flags") = reannounce_flags_t{}))|, (arg("seconds") = 0, arg("tracker_idx") = -1, arg("flags") = 1))|g' bindings/python/src/torrent_handle.cpp
-        sed -i 's|static constexpr reannounce_flags_t ignore_min_interval = 0_bit|static constexpr reannounce_flags_t ignore_min_interval = 1_bit|g' include/libtorrent/torrent_handle.hpp
+    #elif [[ ${libtorrent_branch} == "RC_1_2" ]]; then
+        #sed -i 's|, (arg("seconds") = 0, arg("tracker_idx") = -1, arg("flags") = reannounce_flags_t{}))|, (arg("seconds") = 0, arg("tracker_idx") = -1, arg("flags") = 1))|g' bindings/python/src/torrent_handle.cpp
+        #sed -i 's|static constexpr reannounce_flags_t ignore_min_interval = 0_bit|static constexpr reannounce_flags_t ignore_min_interval = 1_bit|g' include/libtorrent/torrent_handle.hpp
     fi
     VERSION=$(grep -oP "VERSION\ = \K\d\.\d\.\d+" Jamfile)
     case $build_type in
@@ -450,6 +450,13 @@ function build_qbittorrent() {
     rm -rf /tmp/release-${VERSION}.tar.gz
 
     cd /tmp/qbittorrent
+
+    if [[ $build_type == "cmake" ]]; then
+        # Patch force_reannounce function to actually force the reannounce
+        echo_info "Patching qBit reannounce function"
+        sed -i 's|m_nativeHandle.force_reannounce(0, index);|m_nativeHandle.force_reannounce(0, index, lt::torrent_handle::ignore_min_interval);|g' src/base/bittorrent/torrentimpl.cpp
+    fi
+
     tag=" static with ${stdcver} O3 march=native"
     #Ensure boost variables are loaded (i.e. libtorrent skipped)
     booststrap

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -361,8 +361,7 @@ function build_libtorrent_qbittorrent() {
         #Dirty hack to ensure finished library uses `libtorrent-rasterbar` for its name in the deprecated 1.1 branch
         sed -i 's/virtual-target.add-prefix-and-suffix $(name)/virtual-target.add-prefix-and-suffix $(name)-rasterbar/g' Jamfile
     elif [[ ${libtorrent_branch} == "RC_1_2" ]]; then
-        sed -i 's|, (arg("seconds") = 0, arg("tracker_idx") = -1, arg("flags") = reannounce_flags_t{}))|, (arg("seconds") = 0, arg("tracker_idx") = -1, arg("flags") = 1))|g' bindings/python/src/torrent_handle.cpp
-        #sed -i 's|static constexpr reannounce_flags_t ignore_min_interval = 0_bit|static constexpr reannounce_flags_t ignore_min_interval = 1_bit|g' include/libtorrent/torrent_handle.hpp
+        patch -p1 < /etc/swizzin/sources/patches/qbittorrent/libtorrent-RC_1_2-reannounce.patch
     fi
     VERSION=$(grep -oP "VERSION\ = \K\d\.\d\.\d+" Jamfile)
     case $build_type in

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -360,9 +360,9 @@ function build_libtorrent_qbittorrent() {
     if [[ ${libtorrent_branch} == "RC_1_1" ]]; then
         #Dirty hack to ensure finished library uses `libtorrent-rasterbar` for its name in the deprecated 1.1 branch
         sed -i 's/virtual-target.add-prefix-and-suffix $(name)/virtual-target.add-prefix-and-suffix $(name)-rasterbar/g' Jamfile
-    #elif [[ ${libtorrent_branch} == "RC_1_2" ]]; then
-        #sed -i 's|, (arg("seconds") = 0, arg("tracker_idx") = -1, arg("flags") = reannounce_flags_t{}))|, (arg("seconds") = 0, arg("tracker_idx") = -1, arg("flags") = 1))|g' bindings/python/src/torrent_handle.cpp
-        #sed -i 's|static constexpr reannounce_flags_t ignore_min_interval = 0_bit|static constexpr reannounce_flags_t ignore_min_interval = 1_bit|g' include/libtorrent/torrent_handle.hpp
+    elif [[ ${libtorrent_branch} == "RC_1_2" ]]; then
+        sed -i 's|, (arg("seconds") = 0, arg("tracker_idx") = -1, arg("flags") = reannounce_flags_t{}))|, (arg("seconds") = 0, arg("tracker_idx") = -1, arg("flags") = 1))|g' bindings/python/src/torrent_handle.cpp
+        sed -i 's|static constexpr reannounce_flags_t ignore_min_interval = 0_bit|static constexpr reannounce_flags_t ignore_min_interval = 1_bit|g' include/libtorrent/torrent_handle.hpp
     fi
     VERSION=$(grep -oP "VERSION\ = \K\d\.\d\.\d+" Jamfile)
     case $build_type in

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -450,12 +450,6 @@ function build_qbittorrent() {
 
     cd /tmp/qbittorrent
 
-    if [[ $build_type == "cmake" ]]; then
-        # Patch force_reannounce function to actually force the reannounce
-        echo_info "Patching qBit reannounce function"
-        sed -i 's|m_nativeHandle.force_reannounce(0, index);|m_nativeHandle.force_reannounce(0, index, lt::torrent_handle::ignore_min_interval);|g' src/base/bittorrent/torrentimpl.cpp
-    fi
-
     tag=" static with ${stdcver} O3 march=native"
     #Ensure boost variables are loaded (i.e. libtorrent skipped)
     booststrap

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -362,7 +362,7 @@ function build_libtorrent_qbittorrent() {
         sed -i 's/virtual-target.add-prefix-and-suffix $(name)/virtual-target.add-prefix-and-suffix $(name)-rasterbar/g' Jamfile
     elif [[ ${libtorrent_branch} == "RC_1_2" ]]; then
         sed -i 's|, (arg("seconds") = 0, arg("tracker_idx") = -1, arg("flags") = reannounce_flags_t{}))|, (arg("seconds") = 0, arg("tracker_idx") = -1, arg("flags") = 1))|g' bindings/python/src/torrent_handle.cpp
-        sed -i 's|static constexpr reannounce_flags_t ignore_min_interval = 0_bit|static constexpr reannounce_flags_t ignore_min_interval = 1_bit|g' include/libtorrent/torrent_handle.hpp
+        #sed -i 's|static constexpr reannounce_flags_t ignore_min_interval = 0_bit|static constexpr reannounce_flags_t ignore_min_interval = 1_bit|g' include/libtorrent/torrent_handle.hpp
     fi
     VERSION=$(grep -oP "VERSION\ = \K\d\.\d\.\d+" Jamfile)
     case $build_type in

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -360,6 +360,8 @@ function build_libtorrent_qbittorrent() {
     if [[ ${libtorrent_branch} == "RC_1_1" ]]; then
         #Dirty hack to ensure finished library uses `libtorrent-rasterbar` for its name in the deprecated 1.1 branch
         sed -i 's/virtual-target.add-prefix-and-suffix $(name)/virtual-target.add-prefix-and-suffix $(name)-rasterbar/g' Jamfile
+    elif [[ ${libtorrent_branch} == "RC_1_2" ]]; then
+        sed -i 's|static constexpr reannounce_flags_t ignore_min_interval = 0_bit|static constexpr reannounce_flags_t ignore_min_interval = 1_bit|g' include/libtorrent/torrent_handle.hpp
     fi
     VERSION=$(grep -oP "VERSION\ = \K\d\.\d\.\d+" Jamfile)
     case $build_type in

--- a/sources/patches/qbittorrent/libtorrent-RC_1_2-reannounce.patch
+++ b/sources/patches/qbittorrent/libtorrent-RC_1_2-reannounce.patch
@@ -1,0 +1,21 @@
+diff --git a/src/torrent.cpp b/src/torrent.cpp
+index a01018bd5..0a60661d2 100644
+--- a/src/torrent.cpp
++++ b/src/torrent.cpp
+@@ -3689,6 +3689,7 @@ bool is_downloading_state(int const st)
+                                        aep.next_announce = (flags & torrent_handle::ignore_min_interval)
+                                                ? time_point_cast<seconds32>(t) + seconds32(1)
+                                                : std::max(time_point_cast<seconds32>(t), aep.min_announce) + seconds32(1);
++                                       aep.min_announce = aep.next_announce;
+                                        aep.triggered_manually = true;
+ #ifndef TORRENT_DISABLE_LOGGING
+                                        found_one = true;
+@@ -3706,6 +3707,7 @@ bool is_downloading_state(int const st)
+                                aep.next_announce = (flags & torrent_handle::ignore_min_interval)
+                                        ? time_point_cast<seconds32>(t) + seconds32(1)
+                                        : std::max(time_point_cast<seconds32>(t), aep.min_announce) + seconds32(1);
++                               aep.min_announce = aep.next_announce;
+                                aep.triggered_manually = true;
+ #ifndef TORRENT_DISABLE_LOGGING
+                                found_one = true;
+


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description
Currently, reannounces fail due to the tracker timeout, see https://github.com/arvidn/libtorrent/issues/3226

## Fixes issues: 
- Un-tracked issue reported by HostingByDesign

## Proposed Changes:
- Add patch used in deluge compile

## Change Categories
<!-- DELETE WHICHEVER BULLET DOES NOT APPLY -->
- Bug fix               <!-- non-breaking change which fixes an issue -->


## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [x] Docs have been made OR are not necessary
    - PR link: 
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Testing was done
   - [x] Tests created or no new tests necessary
   - [x] Tests executed

## Test scenarios
<!-- Please let us know what has been done or anything else that works/doesn't. Feel free to copy-paste the examples at the bottom of this section -->

### Architectures
<!--
Please use these emojis here to fill the table below. It will nicely auto-format with spacing, don't worry. Leave empty wherever you do not know / have not tested
✅ = Works successfully
❎ = Does not work BUT is handled gracefully
🛠 = Still WIP
❌ = Broken / not working
-->
|   			| `amd64` 	| `armhf` 	| `arm64` 	| Unspecified 	|
|--------		|-------- 	|-------- 	|-------- 	|----------		|
| Jammy 		|			|			|			|				|
| Focal 		|			|			|			|				|
| Bookworm      |      ✅     |           |           |               |
| Bullseye		|			|			|			|				|
| Buster		|			|			|			|				|
| Raspbian  	|	⚫️		|			|	⚫️		|	⚫️			|

### ✅❎ Passed

### 🛠🛠 TODO

### ❌❌ Currently failing



<!-- EXAMPLES :
- Fresh app install without nginx
    - With only one user
    - With multiple users present
- Fresh Install with nginx present nginx
    - With only one user
    - With multiple users present
- Fresh install and nginx install afterwards
    - With only one user
    - With multiple users present
- Update from version in master
- Upgrade from version in master
- Password gets changed from `box` in app
- User removal from `box` acting on app
- New user in `box` gets added to app
- Sysinfo compatibility
    - Info washed
    - Content available
-->

