### PR TITLE
rTorrent: Bump xmlrpc-c to super stable

### DIFF
--- a/sources/functions/rtorrent
+++ b/sources/functions/rtorrent
@@ -134,8 +134,7 @@ function build_xmlrpc-c() {
     . /etc/swizzin/sources/functions/utils
     rm_if_exists "/tmp/xmlrpc-c"
     rm_if_exists "/tmp/dist/xmlrpc-c "
-    XMLRPC_REV=2954
-    svn co http://svn.code.sf.net/p/xmlrpc-c/code/advanced@$XMLRPC_REV /tmp/xmlrpc-c >> $log 2>&1 || { svn co https://github.com/mirror/xmlrpc-c/trunk/advanced@$XMLRPC_REV /tmp/xmlrpc-c >> $log 2>&1; }
+    svn checkout svn://svn.code.sf.net/p/xmlrpc-c/code/super_stable /tmp/xmlrpc-c >> $log 2>&1;
     cd /tmp/xmlrpc-c
     cp -rf /etc/swizzin/sources/patches/rtorrent/xmlrpc-config.guess config.guess >> $log 2>&1
     cp -rf /etc/swizzin/sources/patches/rtorrent/xmlrpc-config.sub config.sub >> $log 2>&1


### PR DESCRIPTION
Resolves: `svn: E155000: '/tmp/xmlrpc-c' is already a working copy for a different URL`

I came across this error when testing the develop branch. The first instance of `svn co` failed, which caused the second one to fail. The simplest solution is bump xmlrpc-c to super-stable and update the link to the svn handle.