### PR TITLE
curl: Override to silence unzip replace prompt

### DIFF
--- a/sources/functions/curl
+++ b/sources/functions/curl
@@ -53,7 +53,7 @@ build_curl() {
         exit 1
     }
 
-    unzip -q /tmp/curl.zip -d /tmp >> $log 2>&1
+    unzip -q -o /tmp/curl.zip -d /tmp >> $log 2>&1
     rm /tmp/curl.zip
 
     cd /tmp/curl-debian-bullseye-backports


### PR DESCRIPTION
Resolves a bug with curl when installation is terminated midway and restarted. Script will freeze by prompting for override.