### PR TITLE
Don't set `proxy_bind` and instead rely on default behaviour.

### DIFF
--- a/scripts/nginx/calibreweb.sh
+++ b/scripts/nginx/calibreweb.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 cat > /etc/nginx/apps/calibreweb.conf << EOF
 location /calibreweb {
-        proxy_bind              \$server_addr;
         proxy_pass              http://127.0.0.1:8083;
         proxy_set_header        Host            \$http_host;
         proxy_set_header        X-Forwarded-For \$proxy_add_x_forwarded_for;

--- a/scripts/update/calibreweb.sh
+++ b/scripts/update/calibreweb.sh
@@ -16,3 +16,13 @@ if [[ -f /install/.calibreweb.lock ]]; then
         echo_progress_done
     fi
 fi
+
+# Remove the proxy_bind setting from Nginx Conf.
+if [[ -f /etc/nginx/apps/calibreweb.conf ]]; then
+    if grep -q "proxy_bind[ \t]\+\$server_addr;" /etc/nginx/apps/calibreweb.conf ]]; then
+        echo_log_only "Removing proxy_bind from CalibreWeb nginx conf"
+        # Find the proxy_bind line, and remove it
+        sed -i 's/proxy_bind[[:space:]]\+\\\$server_addr;//g' /etc/nginx/apps/calibreweb.conf
+        systemctl reload nginx
+    fi
+fi


### PR DESCRIPTION
Setting `proxy_bind` to `$server_addr` can cause issues if the connecting client is attempting to connect to a different IP protocol address than the backend supports (IPv6 vs IPv4)

This removes explicitly setting the `proxy_bind` setting, and instead relies on the default nginx behaviour (of binding to the same protocol as the upstream service)

## Description

`calibreweb` currently doesn't work with IPv6 as internally, CalibreWeb binds to an IPv4 address `127.0.0.1` - and if you attempt to hit Nginx with a client using IPv6 - `$server_addr` will be an IPv6 address - preventing it to talk to the upstream IPv4 address

## Fixes issues: 
- Issue #1071 1071


## Proposed Changes:
- Changing `/scripts/nginx/calibreweb.sh` to remove setting `proxy_bind`, and instead rely on default behaviour.

## Change Categories
<!-- DELETE WHICHEVER BULLET DOES NOT APPLY -->
- Bug fix               <!-- non-breaking change which fixes an issue -->

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [✅] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [✅] Docs have been made OR are not necessary
- [✅] Changes to panel have been made OR are not necessary
- [✅] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [✅] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [✅] I have commented my code, particularly in hard-to-understand areas
- [✅] Testing was done
   - [✅] Tests created or no new tests necessary
   - [✅] Tests executed

## Test scenarios

I manually modified the Nginx Configuration.

1. Without the change, it errors with `500 Internal Error`
2. With the change, the page loads over both IPv4 and IPv6


### Architectures
<!--
Please use these emojis here to fill the table below. It will nicely auto-format with spacing, don't worry. Leave empty wherever you do not know / have not tested
✅ = Works successfully
❎ = Does not work BUT is handled gracefully
🛠 = Still WIP
❌ = Broken / not working
-->
|   			| `amd64` 	| `armhf` 	| `arm64` 	| Unspecified 	|
|--------		|-------- 	|-------- 	|-------- 	|----------		|
| Jammy 		|			|			|			|				|
| Focal 		|			|			|			|				|
| Bookworm      |           |           |           |               |
| Bullseye		|			|			|			|				|
| Buster		|			|			|			|				|
| Raspbian  	|	⚫️		|			|	⚫️		|	⚫️			|

### ✅❎ Passed

### 🛠🛠 TODO

### ❌❌ Currently failing



<!-- EXAMPLES :
- Fresh app install without nginx
    - With only one user
    - With multiple users present
- Fresh Install with nginx present nginx
    - With only one user
    - With multiple users present
- Fresh install and nginx install afterwards
    - With only one user
    - With multiple users present
- Update from version in master
- Upgrade from version in master
- Password gets changed from `box` in app
- User removal from `box` acting on app
- New user in `box` gets added to app
- Sysinfo compatibility
    - Info washed
    - Content available
-->

