### PR TITLE
qbittorrent: update default bind with nginx, warn existing users

### DIFF
--- a/scripts/nginx/qbittorrent.sh
+++ b/scripts/nginx/qbittorrent.sh
@@ -59,4 +59,14 @@ upstream ${user}.qbittorrent {
   server 127.0.0.1:${port};
 }
 QBTUC
+    if grep 'WebUI\\Address=*' /home/${user}/.config/qBittorrent/qBittorrent.conf; then
+        active=$(systemctl is-active qbittorrent@${user})
+        if [[ $active == "active" ]]; then
+            systemctl stop qbittorrent@${user} >> ${log} 2>&1
+        fi
+        sed -i 's|WebUI\\Address=.*|WebUI\\Address=127.0.0.1|g' /home/${user}/.config/qBittorrent/qBittorrent.conf
+        if [[ $active == "active" ]]; then
+            systemctl start qbittorrent@${user} >> ${log} 2>&1
+        fi
+    fi
 done

--- a/scripts/update/qbittorrent.sh
+++ b/scripts/update/qbittorrent.sh
@@ -27,5 +27,11 @@ if [[ -f /install/.qbittorrent.lock ]]; then
             systemctl reload nginx
             echo_progress_done
         fi
+        users=($(_get_user_list))
+        for user in ${users[@]}; do
+            if grep 'WebUI\\Address=*' /home/${user}/.config/qBittorrent/qBittorrent.conf; then
+                echo_warn "qBittorrent WebUI for ${user} is bound to all interfaces and can be accessed without the nginx proxy. The updater will not update this default for you in the event you want to keep it this way. You can fix this yourself in the qBittorrent WebUI: Settings > Web UI > Web User Interface > IP Address: 127.0.0.1. You can suppress this warning by changing your bind address to 0.0.0.0, though this may interfere with ipv6 access. Restart qBittorrent after making the change."
+            fi
+        done
     fi
 fi


### PR DESCRIPTION
Bad security default of leaving qbit bound to `*` by default with nginx installed.

Update default, warn existing users. The warning may be tiresome to endure but I don't believe we should alter the value forcibly as the hook would end up running every time someone updates and would be annoying to fight if they want the port open on purpose.

Could use swizzdb to refine this further and only make the check one time but would require additional effort