### PR TITLE
Update btsync.sh for potential security risk

### DIFF
--- a/scripts/update/btsync.sh
+++ b/scripts/update/btsync.sh
@@ -17,7 +17,7 @@ if [[ -f /install/.btsync.lock ]]; then
 
     "webui" :
     {
-        "listen" : "BTSGUIP:8888"
+        "listen" : "127.0.0.1:8888"
     }
 }
 RSCONF


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description
A simple and effective port setting of `127.0.0.1:8888` instead of using `BTSGUIP:8888`, which imposes serious risk to host's server, because it bypasses IP check and for some reason will open 8888 port to everyone on the internet.

## Fixes issues: 
- Un-tracked issue, but is a serious potential security issue.

## Proposed Changes:
- Changed port listening in the resilio-sync config file

## Change Categories
<!-- DELETE WHICHEVER BULLET DOES NOT APPLY -->
- Bug fix               <!-- non-breaking change which fixes an issue -->

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [x] Docs have been made OR are not necessary
    - PR link: 
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Testing was done
   - [x] Tests created or no new tests necessary
   - [x] Tests executed

## Test scenarios
n/a

### Architectures
n/a