### PR TITLE
rTorrent: Add latest development fixes

### DIFF
--- a/sources/functions/rtorrent
+++ b/sources/functions/rtorrent
@@ -260,6 +260,8 @@ function build_rtorrent() {
     patch -p1 < /etc/swizzin/sources/patches/rtorrent/xmlrpc-fix.patch >> "$log" 2>&1
     #apply scgi-fix to all rtorrents
     patch -p1 < /etc/swizzin/sources/patches/rtorrent/scgi-fix.patch >> "$log" 2>&1
+    #apply session-file-fix to all rtorrents
+    patch -p1 < /etc/swizzin/sources/patches/rtorrent/session-file-fix.patch >> "$log" 2>&1
     #use pkgconfig for cppunit if 0.9.6
     stdc=
     if [[ ${rtorrentver} == "0.9.6" ]]; then

--- a/sources/functions/rtorrent
+++ b/sources/functions/rtorrent
@@ -258,6 +258,8 @@ function build_rtorrent() {
     patch -p1 < /etc/swizzin/sources/patches/rtorrent/lockfile-fix.patch >> "$log" 2>&1
     #apply xmlrpc-fix to all rtorrents
     patch -p1 < /etc/swizzin/sources/patches/rtorrent/xmlrpc-fix.patch >> "$log" 2>&1
+    #apply xmlrpc-logic-fix to all rtorrents
+    patch -p1 < /etc/swizzin/sources/patches/rtorrent/xmlrpc-logic-fix.patch >> "$log" 2>&1
     #apply scgi-fix to all rtorrents
     patch -p1 < /etc/swizzin/sources/patches/rtorrent/scgi-fix.patch >> "$log" 2>&1
     #apply session-file-fix to all rtorrents

--- a/sources/functions/rtorrent
+++ b/sources/functions/rtorrent
@@ -251,6 +251,12 @@ function build_rtorrent() {
     else
         echo_log_only "No rTorrent patch found at /root/rtorrent-${rtorrentver}.patch"
     fi
+    #apply memory leak fixes to 0.9.8 branches bases only (0.9.8, UDNS, PGO) to reduce maintenance and testing
+    #apply first thing to ensure compatibility with the tracker delay scrape patch by modifying higher line numbers first
+    if [[ ${rtorrentver} == "0.9.8" ]]; then
+        patch -p1 < /etc/swizzin/sources/patches/rtorrent/rtorrent-ml-fixes-0.9.8.patch >> "$log" 2>&1
+    fi
+    #apply tracker delay scrape patch to UDNS branch	
     if [[ ${libudns} == "true" ]]; then
         patch -p1 < /etc/swizzin/sources/patches/rtorrent/rtorrent-scrape-0.9.8.patch >> "$log" 2>&1
     fi

--- a/sources/functions/rtorrent
+++ b/sources/functions/rtorrent
@@ -258,6 +258,8 @@ function build_rtorrent() {
     patch -p1 < /etc/swizzin/sources/patches/rtorrent/lockfile-fix.patch >> "$log" 2>&1
     #apply xmlrpc-fix to all rtorrents
     patch -p1 < /etc/swizzin/sources/patches/rtorrent/xmlrpc-fix.patch >> "$log" 2>&1
+    #apply scgi-fix to all rtorrents
+    patch -p1 < /etc/swizzin/sources/patches/rtorrent/scgi-fix.patch >> "$log" 2>&1
     #use pkgconfig for cppunit if 0.9.6
     stdc=
     if [[ ${rtorrentver} == "0.9.6" ]]; then

--- a/sources/functions/rtorrent
+++ b/sources/functions/rtorrent
@@ -199,6 +199,7 @@ function build_libtorrent_rakshasa() {
     if [[ ${libudns} == "true" ]]; then
         patch -p1 < /etc/swizzin/sources/patches/rtorrent/libtorrent-udns-0.13.8.patch >> "$log" 2>&1
         patch -p1 < /etc/swizzin/sources/patches/rtorrent/libtorrent-scanf-0.13.8.patch >> "$log" 2>&1
+        patch -p1 < /etc/swizzin/sources/patches/rtorrent/lookup-cache-0.13.8.patch >> "$log" 2>&1
     fi
     #apply piece boundary fix to all libtorrents
     patch -p1 < /etc/swizzin/sources/patches/rtorrent/piece-boundary-fix-0.13.8.patch >> "$log" 2>&1	
@@ -261,6 +262,7 @@ function build_rtorrent() {
     #apply tracker delay scrape patch to UDNS branch	
     if [[ ${libudns} == "true" ]]; then
         patch -p1 < /etc/swizzin/sources/patches/rtorrent/rtorrent-scrape-0.9.8.patch >> "$log" 2>&1
+        patch -p1 < /etc/swizzin/sources/patches/rtorrent/fast-session-loading-0.9.8.patch >> "$log" 2>&1
     fi
     #apply lockfile-fix to all rtorrents
     patch -p1 < /etc/swizzin/sources/patches/rtorrent/lockfile-fix.patch >> "$log" 2>&1

--- a/sources/functions/rtorrent
+++ b/sources/functions/rtorrent
@@ -200,6 +200,8 @@ function build_libtorrent_rakshasa() {
         patch -p1 < /etc/swizzin/sources/patches/rtorrent/libtorrent-udns-0.13.8.patch >> "$log" 2>&1
         patch -p1 < /etc/swizzin/sources/patches/rtorrent/libtorrent-scanf-0.13.8.patch >> "$log" 2>&1
     fi
+    #apply piece boundary fix to all libtorrents
+    patch -p1 < /etc/swizzin/sources/patches/rtorrent/piece-boundary-fix-0.13.8.patch >> "$log" 2>&1	
     if [[ ${libtorrentver} =~ ^("0.13.7"|"0.13.8")$ ]]; then
         patch -p1 < /etc/swizzin/sources/patches/rtorrent/throttle-fix-0.13.7-8.patch >> "$log" 2>&1
     fi

--- a/sources/patches/rtorrent/fast-session-loading-0.9.8.patch
+++ b/sources/patches/rtorrent/fast-session-loading-0.9.8.patch
@@ -1,0 +1,73 @@
+From 41b8950ec54b61526361e5028475d680ccdf759c Mon Sep 17 00:00:00 2001
+From: stickz <stickman002@mail.com>
+Date: Sun, 15 Oct 2023 18:54:10 -0400
+Subject: [PATCH] Speed up torrent session loading
+
+Don't check if torrents are being removed.
+Perform hash checks after session is loaded.
+---
+ src/control.cc               |  2 --
+ src/core/download_factory.cc | 10 ++++++----
+ src/main.cc                  |  7 +++++++
+ 3 files changed, 13 insertions(+), 6 deletions(-)
+
+diff --git a/src/control.cc b/src/control.cc
+index 60c9b5301..89a7be071 100644
+--- a/src/control.cc
++++ b/src/control.cc
+@@ -114,8 +114,6 @@ Control::initialize() {
+   m_core->listen_open();
+   m_core->download_store()->enable(rpc::call_command_value("session.use_lock"));
+ 
+-  m_core->set_hashing_view(*m_viewManager->find_throw("hashing"));
+-
+   m_ui->init(this);
+ 
+   if(!display::Canvas::daemon()) {
+diff --git a/src/core/download_factory.cc b/src/core/download_factory.cc
+index 2d2ea5a3b..2a147f5cf 100644
+--- a/src/core/download_factory.cc
++++ b/src/core/download_factory.cc
+@@ -323,11 +323,13 @@ DownloadFactory::receive_success() {
+     std::for_each(m_commands.begin(), m_commands.end(),
+                   rak::bind2nd(std::ptr_fun(&rpc::parse_command_multiple_std), rpc::make_target(download)));
+ 
+-    if (m_manager->download_list()->find(infohash) == m_manager->download_list()->end())
+-      throw torrent::input_error("The newly created download was removed.");
+-
+     if (!m_session)
+-       rpc::call_command("d.state.set", (int64_t)m_start, rpc::make_target(download));
++    {
++      if (m_manager->download_list()->find(infohash) == m_manager->download_list()->end())
++        throw torrent::input_error("The newly created download was removed.");
++
++      rpc::call_command("d.state.set", (int64_t)m_start, rpc::make_target(download));
++    }
+ 
+     rpc::commands.call_catch(m_session ? "event.download.inserted_session" : "event.download.inserted_new",
+                              rpc::make_target(download), torrent::Object(), "Download event action failed: ");
+diff --git a/src/main.cc b/src/main.cc
+index c76558f8f..de8dcfe70 100644
+--- a/src/main.cc
++++ b/src/main.cc
+@@ -62,6 +62,7 @@
+ #include "core/download_factory.h"
+ #include "core/download_store.h"
+ #include "core/manager.h"
++#include "core/view_manager.h"
+ #include "display/canvas.h"
+ #include "display/window.h"
+ #include "display/manager.h"
+@@ -137,6 +138,12 @@ load_session_torrents() {
+     f->load(entries.path() + first->d_name);
+     f->commit();
+   }
++  
++  // Perform hash checks after the session is loaded
++  const auto& hashing_view = *control->view_manager()->find_throw("hashing");
++  control->core()->set_hashing_view(hashing_view);
++  hashing_view->set_focus(hashing_view->focus());
++  priority_queue_perform(&taskScheduler, cachedTime);
+ }
+ 
+ void

--- a/sources/patches/rtorrent/lookup-cache-0.13.8.patch
+++ b/sources/patches/rtorrent/lookup-cache-0.13.8.patch
@@ -1,0 +1,286 @@
+From 2ff6646c2710e244a4357e13c216cd01c4a53b0d Mon Sep 17 00:00:00 2001
+From: stickz <stickman002@mail.com>
+Date: Sun, 15 Oct 2023 14:03:04 -0400
+Subject: [PATCH] Add libtorrent lookup cache
+
+Cache torrent hashes to reduce lookup times.
+---
+ src/dht/dht_hash_map.h                   | 59 ++---------------------
+ src/torrent/download/download_manager.cc | 61 +++++++++++++++---------
+ src/torrent/download/download_manager.h  |  7 +++
+ src/torrent/hash_string.h                | 38 +++++++++++++++
+ 4 files changed, 88 insertions(+), 77 deletions(-)
+
+diff --git a/src/dht/dht_hash_map.h b/src/dht/dht_hash_map.h
+index 140f070bb..3b566a7ab 100644
+--- a/src/dht/dht_hash_map.h
++++ b/src/dht/dht_hash_map.h
+@@ -53,60 +53,9 @@
+ namespace torrent {
+ 
+ #if HAVE_TR1
+-// Hash functions for HashString keys, and dereferencing HashString pointers.
+-
+-// Since the first few bits are very similar if not identical (since the IDs
+-// will be close to our own node ID), we use an offset of 64 bits in the hash
+-// string. These bits will be uniformly distributed until the number of DHT
+-// nodes on the planet approaches 2^64 which is... unlikely.
+-// An offset of 64 bits provides 96 significant bits which is fine as long as
+-// the size of size_t does not exceed 12 bytes, while still having correctly
+-// aligned 64-bit access.
+-static const unsigned int hashstring_hash_ofs = 8;
+-
+-struct hashstring_ptr_hash : public std::unary_function<const HashString*, size_t> {
+-  size_t operator () (const HashString* n) const {
+-#if USE_ALIGNED
+-    size_t result = 0;
+-    const char *first = n->data() + hashstring_hash_ofs;
+-    const char *last = first + sizeof(size_t);
+-
+-    while (first != last)
+-      result = (result << 8) + *first++;
+-    
+-    return result;
+-#else
+-    return *(size_t*)(n->data() + hashstring_hash_ofs);
+-#endif
+-  }
+-};
+-
+-struct hashstring_hash : public std::unary_function<HashString, size_t> {
+-  size_t operator () (const HashString& n) const {
+-#if USE_ALIGNED
+-    size_t result = 0;
+-    const char *first = n.data() + hashstring_hash_ofs;
+-    const char *last = first + sizeof(size_t);
+-
+-    while (first != last)
+-      result = (result << 8) + *first++;
+-    
+-    return result;
+-#else
+-    return *(size_t*)(n.data() + hashstring_hash_ofs);
+-#endif
+-  }
+-};
+-
+-// Compare HashString pointers by dereferencing them.
+-struct hashstring_ptr_equal : public std::binary_function<const HashString*, const HashString*, bool> {
+-  size_t operator () (const HashString* one, const HashString* two) const 
+-  { return *one == *two; }
+-};
+-
+-class DhtNodeList : public std::unordered_map<const HashString*, DhtNode*, hashstring_ptr_hash, hashstring_ptr_equal> {
++class DhtNodeList : public std::unordered_map<const HashString*, DhtNode*> {
+ public:
+-  typedef std::unordered_map<const HashString*, DhtNode*, hashstring_ptr_hash, hashstring_ptr_equal> base_type;
++  using base_type = std::unordered_map<const HashString*, DhtNode*>;
+ 
+   // Define accessor iterator with more convenient access to the key and
+   // element values.  Allows changing the map definition more easily if needed.
+@@ -125,9 +74,9 @@ class DhtNodeList : public std::unordered_map<const HashString*, DhtNode*, hashs
+ 
+ };
+ 
+-class DhtTrackerList : public std::unordered_map<HashString, DhtTracker*, hashstring_hash> {
++class DhtTrackerList : public std::unordered_map<HashString, DhtTracker*> {
+ public:
+-  typedef std::unordered_map<HashString, DhtTracker*, hashstring_hash> base_type;
++  using base_type = std::unordered_map<HashString, DhtTracker*>;
+ 
+   template<typename T>
+   struct accessor_wrapper : public T {
+diff --git a/src/torrent/download/download_manager.cc b/src/torrent/download/download_manager.cc
+index 6df2792c6..e4ba9c089 100644
+--- a/src/torrent/download/download_manager.cc
++++ b/src/torrent/download/download_manager.cc
+@@ -50,37 +50,58 @@ DownloadManager::insert(DownloadWrapper* d) {
+   if (find(d->info()->hash()) != end())
+     throw internal_error("Could not add torrent as it already exists.");
+ 
++  lookup_cache.emplace(d->info()->hash(), size());
++  obfuscated_to_hash.emplace(d->info()->hash_obfuscated(), d->info()->hash());
++
+   return base_type::insert(end(), d);
+ }
+ 
+ DownloadManager::iterator
+ DownloadManager::erase(DownloadWrapper* d) {
+-  iterator itr = std::find(begin(), end(), d);
++  auto itr = find(d->info()->hash());
+ 
+   if (itr == end())
+     throw internal_error("Tried to remove a torrent that doesn't exist");
+     
++  lookup_cache.erase(lookup_cache.find(d->info()->hash()));
++  obfuscated_to_hash.erase(obfuscated_to_hash.find(d->info()->hash_obfuscated()));
++
+   delete *itr;
+   return base_type::erase(itr);
+ }
+ 
+ void
+ DownloadManager::clear() {
+-  while (!empty()) {
+-    delete base_type::back();
+-    base_type::pop_back();
+-  }
++  base_type::clear();
++  lookup_cache.clear();
++  obfuscated_to_hash.clear();
+ }
+ 
+ DownloadManager::iterator
+ DownloadManager::find(const std::string& hash) {
+-  return std::find_if(begin(), end(), rak::equal(*HashString::cast_from(hash),
+-                                                 rak::on(std::mem_fun(&DownloadWrapper::info), std::mem_fun(&DownloadInfo::hash))));
++  return find(*HashString::cast_from(hash));
+ }
+ 
+ DownloadManager::iterator
+ DownloadManager::find(const HashString& hash) {
+-  return std::find_if(begin(), end(), rak::equal(hash, rak::on(std::mem_fun(&DownloadWrapper::info), std::mem_fun(&DownloadInfo::hash))));
++  auto cached = lookup_cache.find(hash);
++
++  if (cached == lookup_cache.end()) {
++    return end();
++  }
++
++  auto cached_i = cached->second;
++
++  auto itr = cached_i < size() ? begin() + cached_i : end();
++  if (itr == end() || (*itr)->info()->hash() != hash) {
++    itr = std::find_if(begin(), end(), [hash](DownloadWrapper* wrapper) {
++      return hash == wrapper->info()->hash();
++    });
++  }
++
++  lookup_cache[hash] = itr - begin();
++
++  return itr; 
+ }
+ 
+ DownloadManager::iterator
+@@ -95,24 +116,20 @@ DownloadManager::find_chunk_list(ChunkList* cl) {
+ 
+ DownloadMain*
+ DownloadManager::find_main(const char* hash) {
+-  iterator itr = std::find_if(begin(), end(), rak::equal(*HashString::cast_from(hash),
+-                                                         rak::on(std::mem_fun(&DownloadWrapper::info), std::mem_fun(&DownloadInfo::hash))));
+-
+-  if (itr == end())
+-    return NULL;
+-  else
+-    return (*itr)->main();
++  auto itr = find(*HashString::cast_from(hash));
++  return itr == end() ? NULL : (*itr)->main();
+ }
+ 
+ DownloadMain*
+-DownloadManager::find_main_obfuscated(const char* hash) {
+-  iterator itr = std::find_if(begin(), end(), rak::equal(*HashString::cast_from(hash),
+-                                                         rak::on(std::mem_fun(&DownloadWrapper::info), std::mem_fun(&DownloadInfo::hash_obfuscated))));
++DownloadManager::find_main_obfuscated(const char* obfuscated) {
++  auto hash_itr = obfuscated_to_hash.find(*HashString::cast_from(obfuscated));
+ 
+-  if (itr == end())
+-    return NULL;
+-  else
+-    return (*itr)->main();
++  if (hash_itr == obfuscated_to_hash.end()) {
++    return nullptr;
++  }
++  
++  auto itr = find(hash_itr->second);
++  return itr == end() ? NULL : (*itr)->main();
+ }
+ 
+ }
+diff --git a/src/torrent/download/download_manager.h b/src/torrent/download/download_manager.h
+index 4dba916cd..b864e8e22 100644
+--- a/src/torrent/download/download_manager.h
++++ b/src/torrent/download/download_manager.h
+@@ -37,8 +37,11 @@
+ #ifndef LIBTORRENT_DOWNLOAD_MANAGER_H
+ #define LIBTORRENT_DOWNLOAD_MANAGER_H
+ 
++#include <unordered_map>
+ #include <vector>
++
+ #include <torrent/common.h>
++#include <torrent/hash_string.h>
+ 
+ namespace torrent {
+ 
+@@ -90,6 +93,10 @@ class LIBTORRENT_EXPORT DownloadManager : private std::vector<DownloadWrapper*>
+   iterator            erase(DownloadWrapper* d) LIBTORRENT_NO_EXPORT;
+ 
+   void                clear() LIBTORRENT_NO_EXPORT;
++  
++ private:
++  std::unordered_map<HashString, size_type>  lookup_cache;
++  std::unordered_map<HashString, HashString> obfuscated_to_hash;
+ };
+ 
+ }
+diff --git a/src/torrent/hash_string.h b/src/torrent/hash_string.h
+index af60780a2..22150fca0 100644
+--- a/src/torrent/hash_string.h
++++ b/src/torrent/hash_string.h
+@@ -61,6 +61,10 @@ class LIBTORRENT_EXPORT HashString {
+ 
+   static const size_type size_data = 20;
+ 
++  static constexpr unsigned int hashstring_hash_ofs = 8;
++  static_assert((hashstring_hash_ofs + sizeof(size_t)) <=
++                HashString::size_data);
++
+   size_type           size() const                      { return size_data; }
+ 
+   iterator            begin()                           { return m_data; }
+@@ -99,6 +103,14 @@ class LIBTORRENT_EXPORT HashString {
+ 
+   static HashString*  cast_from(char* src)                   { return (HashString*)src; }
+ 
++  size_t hash() const {
++    size_t result = 0;
++    std::memcpy(&result,
++                m_data + torrent::HashString::hashstring_hash_ofs,
++                sizeof(size_t));
++    return result;
++  }
++
+ private:
+   char                m_data[size_data];
+ };
+@@ -132,4 +144,30 @@ operator <= (const HashString& one, const HashString& two) {
+ 
+ }
+ 
++namespace std {
++
++template<>
++struct hash<torrent::HashString> {
++  std::size_t operator()(const torrent::HashString& n) const noexcept {
++    return n.hash();
++  }
++};
++
++template<>
++struct hash<torrent::HashString*> {
++  std::size_t operator()(const torrent::HashString* n) const noexcept {
++    return n->hash();
++  }
++};
++
++template<>
++struct equal_to<torrent::HashString*> {
++  bool operator()(const torrent::HashString* a,
++                  const torrent::HashString* b) const noexcept {
++    return *a == *b;
++  }
++};
++
++}
++
+ #endif

--- a/sources/patches/rtorrent/piece-boundary-fix-0.13.8.patch
+++ b/sources/patches/rtorrent/piece-boundary-fix-0.13.8.patch
@@ -1,0 +1,48 @@
+From 4bce4ac4a6c28da2cbd54d9be43e3eeec208a38e Mon Sep 17 00:00:00 2001
+From: stickz <stickman002@mail.com>
+Date: Thu, 28 Sep 2023 15:06:51 -0400
+Subject: [PATCH] piece boundary fix
+
+Resolves various bugs with torrent progress reporting.
+---
+ src/torrent/data/file.h       | 1 +
+ src/torrent/data/file_list.cc | 9 +++++----
+ 2 files changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/src/torrent/data/file.h b/src/torrent/data/file.h
+index 4c58994bd..0238388c2 100644
+--- a/src/torrent/data/file.h
++++ b/src/torrent/data/file.h
+@@ -78,6 +78,7 @@ class LIBTORRENT_EXPORT lt_cacheline_aligned File {
+   bool                has_permissions(int prot) const          { return !(prot & ~m_protection); }
+ 
+   uint64_t            offset() const                           { return m_offset; }
++  uint64_t            offset_end() const                       { return m_offset + m_size; }
+ 
+   uint64_t            size_bytes() const                       { return m_size; }
+   uint32_t            size_chunks() const                      { return m_range.second - m_range.first; }
+diff --git a/src/torrent/data/file_list.cc b/src/torrent/data/file_list.cc
+index 4721bdbd6..859cad08f 100644
+--- a/src/torrent/data/file_list.cc
++++ b/src/torrent/data/file_list.cc
+@@ -676,15 +676,16 @@ FileList::mark_completed(uint32_t index) {
+ 
+ FileList::iterator
+ FileList::inc_completed(iterator firstItr, uint32_t index) {
+-  firstItr         = std::find_if(firstItr, end(), rak::less(index, std::mem_fun(&File::range_second)));
+-  iterator lastItr = std::find_if(firstItr, end(), rak::less(index + 1, std::mem_fun(&File::range_second)));
++  firstItr = std::find_if(firstItr, end(), rak::less(index, std::mem_fun(&File::range_second)));
+ 
+   if (firstItr == end())
+     throw internal_error("FileList::inc_completed() first == m_entryList->end().", data()->hash());
+ 
+-  // TODO: Check if this works right for zero-length files.
++  uint64_t boundary = (index+1)*m_chunkSize;
++  iterator lastItr = std::find_if(firstItr, end(), rak::less_equal(boundary, std::mem_fun(&File::offset_end)));
++
+   std::for_each(firstItr,
+-                lastItr == end() ? end() : (lastItr + 1),
++                lastItr == end() ? end() : lastItr + 1,
+                 std::mem_fun(&File::inc_completed_protected));
+ 
+   return lastItr;

--- a/sources/patches/rtorrent/rtorrent-ml-fixes-0.9.8.patch
+++ b/sources/patches/rtorrent/rtorrent-ml-fixes-0.9.8.patch
@@ -1,0 +1,114 @@
+From ece7a0338d50bffa68993454697b86a055c54a6f Mon Sep 17 00:00:00 2001
+From: stickz <stickman002@mail.com>
+Date: Wed, 4 Oct 2023 07:12:02 -0400
+Subject: [PATCH] Fix various memory leaks
+
+Resolves a potential memory leak with the curses UI when filtering torrents.
+
+Resolves a memory leak with dynamic commands in the .rtorrent.rc file.
+
+Resolves a memory leak during software initialization with choke groups.
+---
+ src/command_dynamic.cc  |  2 +-
+ src/command_groups.cc   | 11 +++++++++++
+ src/command_helpers.cc  |  6 ++++++
+ src/command_helpers.h   |  1 +
+ src/main.cc             |  2 ++
+ src/ui/download_list.cc |  2 ++
+ 6 files changed, 23 insertions(+), 1 deletion(-)
+
+diff --git a/src/command_dynamic.cc b/src/command_dynamic.cc
+index a8d0ff02f..3d7a123b1 100644
+--- a/src/command_dynamic.cc
++++ b/src/command_dynamic.cc
+@@ -147,7 +147,7 @@ system_method_insert_object(const torrent::Object::list_type& args, int flags) {
+     throw torrent::input_error("Invalid type.");
+   }
+ 
+-  int cmd_flags = 0;
++  int cmd_flags = rpc::CommandMap::flag_delete_key;
+ 
+   if (!(flags & rpc::object_storage::flag_static))
+     cmd_flags |= rpc::CommandMap::flag_modifiable;
+diff --git a/src/command_groups.cc b/src/command_groups.cc
+index 359a532e5..cb8bdb584 100644
+--- a/src/command_groups.cc
++++ b/src/command_groups.cc
+@@ -381,3 +381,14 @@ initialize_command_groups() {
+                                                                  std::bind(&torrent::choke_queue::heuristics, CHOKE_GROUP(&torrent::choke_group::down_queue))));
+   CMD2_ANY_LIST    ("choke_group.down.heuristics.set", std::bind(&apply_cg_heuristics_set, std::placeholders::_2, false));
+ }
++
++void cleanup_command_groups() {
++#if USE_CHOKE_GROUP
++#else
++  while (!cg_list_hack.empty()) {
++    auto cg = cg_list_hack.back();
++    delete cg;
++    cg_list_hack.pop_back();
++  }
++#endif
++}
+\ No newline at end of file
+diff --git a/src/command_helpers.cc b/src/command_helpers.cc
+index 54c0b35e4..31599e265 100644
+--- a/src/command_helpers.cc
++++ b/src/command_helpers.cc
+@@ -57,6 +57,12 @@ void initialize_command_tracker();
+ void initialize_command_scheduler();
+ void initialize_command_ui();
+ 
++void cleanup_command_groups();
++
++void cleanup_commands() {
++  cleanup_command_groups();
++}
++
+ void
+ initialize_commands() {
+   initialize_command_dynamic();
+diff --git a/src/command_helpers.h b/src/command_helpers.h
+index a104fbbc4..48e7ea258 100644
+--- a/src/command_helpers.h
++++ b/src/command_helpers.h
+@@ -42,6 +42,7 @@
+ #include "rpc/object_storage.h"
+ 
+ void initialize_commands();
++void cleanup_commands();
+ 
+ //
+ // New std::function based command_base helper functions:
+diff --git a/src/main.cc b/src/main.cc
+index 6be6a4dee..2310013dc 100644
+--- a/src/main.cc
++++ b/src/main.cc
+@@ -509,6 +509,8 @@ main(int argc, char** argv) {
+     return -1;
+   }
+ 
++  cleanup_commands();
++
+   torrent::log_cleanup();
+ 
+   delete control;
+diff --git a/src/ui/download_list.cc b/src/ui/download_list.cc
+index f1d6af5c6..7cb0e9a89 100644
+--- a/src/ui/download_list.cc
++++ b/src/ui/download_list.cc
+@@ -272,6 +272,7 @@ DownloadList::receive_view_input(Input type) {
+           std::getline(ss, view_name_var, ',');
+           if (current_view()->name() == rak::trim(view_name_var)) {
+               control->core()->push_log_std("View '" + current_view()->name() + "' can't be filtered.");
++              delete input;
+               return;
+           }
+       }
+@@ -281,6 +282,7 @@ DownloadList::receive_view_input(Input type) {
+     break;
+ 
+   default:
++    delete input;
+     throw torrent::internal_error("DownloadList::receive_view_input(...) Invalid input type.");
+   }
+ 

--- a/sources/patches/rtorrent/scgi-fix.patch
+++ b/sources/patches/rtorrent/scgi-fix.patch
@@ -1,0 +1,23 @@
+From f600ba802201da20834751412faafa374ce255c4 Mon Sep 17 00:00:00 2001
+From: stickz <stickman002@mail.com>
+Date: Sat, 30 Sep 2023 08:36:15 -0400
+Subject: [PATCH] Increase maximum SCGI request to 16MB
+
+Fixing a problem where xmlrpc-c information fails to update if user is running too many torrents.
+---
+ src/rpc/scgi_task.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/rpc/scgi_task.h b/src/rpc/scgi_task.h
+index e75e9e1ea..a42349bf8 100644
+--- a/src/rpc/scgi_task.h
++++ b/src/rpc/scgi_task.h
+@@ -51,7 +51,7 @@ class SCgiTask : public torrent::Event {
+ public:
+   static const unsigned int default_buffer_size = 2047;
+   static const          int max_header_size     = 2000;
+-  static const          int max_content_size    = (2 << 20);
++  static const          int max_content_size    = (2 << 23);
+ 
+   SCgiTask() { m_fileDesc = -1; }
+ 

--- a/sources/patches/rtorrent/session-file-fix.patch
+++ b/sources/patches/rtorrent/session-file-fix.patch
@@ -1,0 +1,46 @@
+From 7594fc942ecd0ed64f7feea24bd54b6fdddba49b Mon Sep 17 00:00:00 2001
+From: stickz <stickman002@mail.com>
+Date: Sat, 30 Sep 2023 10:34:07 -0400
+Subject: [PATCH] Fix saving session files
+
+Resolves a data corruption issue with torrent session during a power loss.
+---
+ src/core/download_store.cc | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/src/core/download_store.cc b/src/core/download_store.cc
+index 536dba10a..e111b41bc 100644
+--- a/src/core/download_store.cc
++++ b/src/core/download_store.cc
+@@ -40,6 +40,7 @@
+ 
+ #include <fstream>
+ #include <stdio.h>
++#include <fcntl.h>
+ #include <unistd.h>
+ #include <rak/error_number.h>
+ #include <rak/path.h>
+@@ -102,6 +103,7 @@ bool
+ DownloadStore::write_bencode(const std::string& filename, const torrent::Object& obj, uint32_t skip_mask) {
+   torrent::Object tmp;
+   std::fstream output(filename.c_str(), std::ios::out | std::ios::trunc);
++  int fd = -1;
+ 
+   if (!output.is_open())
+     goto download_store_save_error;
+@@ -121,6 +123,15 @@ DownloadStore::write_bencode(const std::string& filename, const torrent::Object&
+     goto download_store_save_error;
+ 
+   output.close();
++  
++  // Ensure that the new file is actually written to the disk
++  fd = ::open(filename.c_str(), O_WRONLY);
++  if (fd < 0)
++    goto download_store_save_error;
++
++  fsync(fd);
++  ::close(fd);
++
+   return true;
+ 
+ download_store_save_error:

--- a/sources/patches/rtorrent/xmlrpc-logic-fix.patch
+++ b/sources/patches/rtorrent/xmlrpc-logic-fix.patch
@@ -1,0 +1,23 @@
+From 898d0b21792c9f021a098961c6d47e07a4b188f1 Mon Sep 17 00:00:00 2001
+From: stickz <stickman002@mail.com>
+Date: Mon, 2 Oct 2023 17:02:06 -0400
+Subject: [PATCH] Resolve xmlrpc logic crash
+
+Resolves a rtorrent crash caused by sending invalid xmlrpc logic.
+---
+ src/rpc/command_impl.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/rpc/command_impl.h b/src/rpc/command_impl.h
+index b7ec9168c..a7838d49c 100644
+--- a/src/rpc/command_impl.h
++++ b/src/rpc/command_impl.h
+@@ -63,7 +63,7 @@ template <> struct target_type_id<core::Download*, core::Download*> { static con
+ template <> inline bool
+ is_target_compatible<target_type>(const target_type& target) { return true; }
+ template <> inline bool
+-is_target_compatible<torrent::File*>(const target_type& target) { return target.first == command_base::target_file || command_base::target_file_itr; }
++is_target_compatible<torrent::File*>(const target_type& target) { return (target.first == command_base::target_file || command_base::target_file_itr) && target.first == target_type_id<torrent::File*>::value; }
+ 
+ template <> inline target_type
+ get_target_cast<target_type>(target_type target, int type) { return target; }


### PR DESCRIPTION
- Resolves an annoying bug with rtorrent where torrent progress is reported as 200%.
- Fixes a problem where xmlrpc-c information fails to update if user is running too many torrents.
- Resolves a data corruption issue with torrent session files during a power loss.
- Resolves a rtorrent crash causing by sending invalid xmlrpc logic to the torrent client.
- Resolves three instances of memory leaks with the rtorrent software.
