### PR TITLE
qbittorrent: Fix interface grep 

### DIFF
--- a/scripts/nginx/qbittorrent.sh
+++ b/scripts/nginx/qbittorrent.sh
@@ -59,7 +59,7 @@ upstream ${user}.qbittorrent {
   server 127.0.0.1:${port};
 }
 QBTUC
-    if grep -q 'WebUI\\Address=*' /home/${user}/.config/qBittorrent/qBittorrent.conf; then
+    if grep -q 'WebUI\\Address=\*' /home/${user}/.config/qBittorrent/qBittorrent.conf; then
         active=$(systemctl is-active qbittorrent@${user})
         if [[ $active == "active" ]]; then
             systemctl stop qbittorrent@${user} >> ${log} 2>&1

--- a/scripts/update/qbittorrent.sh
+++ b/scripts/update/qbittorrent.sh
@@ -29,7 +29,7 @@ if [[ -f /install/.qbittorrent.lock ]]; then
         fi
         users=($(_get_user_list))
         for user in ${users[@]}; do
-            if grep -q 'WebUI\\Address=*' /home/${user}/.config/qBittorrent/qBittorrent.conf; then
+            if grep -q 'WebUI\\Address=\*' /home/${user}/.config/qBittorrent/qBittorrent.conf; then
                 echo_warn "qBittorrent WebUI for ${user} is bound to all interfaces and can be accessed without the nginx proxy. The updater will not update this default for you in the event you want to keep it this way. You can fix this yourself in the qBittorrent WebUI: Settings > Web UI > Web User Interface > IP Address: 127.0.0.1. You can suppress this warning by changing your bind address to 0.0.0.0, though this may interfere with ipv6 access. Restart qBittorrent after making the change."
             fi
         done


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description
The warning about the qbittorrent webinterface appears even for correctly set 127.0.0.1, because * is not escaped in the grep.

## Fixes issues: 
- Un-tracked

## Proposed Changes:
- replace * with \* in the webinterface grep

## Change Categories
<!-- DELETE WHICHEVER BULLET DOES NOT APPLY -->
- Bug fix               <!-- non-breaking change which fixes an issue -->

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [x] Docs have been made OR are not necessary
    - PR link: 
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Testing was done
   - [x] Tests created or no new tests necessary
   - [ ] Tests executed

## Test scenarios
Tested the grep command with and without escape \ in the terminal.

### Architectures
<!--
Please use these emojis here to fill the table below. It will nicely auto-format with spacing, don't worry. Leave empty wherever you do not know / have not tested
✅ = Works successfully
❎ = Does not work BUT is handled gracefully
🛠 = Still WIP
❌ = Broken / not working
-->
|   			| `amd64` 	| `armhf` 	| `arm64` 	| Unspecified 	|
|--------		|-------- 	|-------- 	|-------- 	|----------		|
| Jammy 		|			|			|			|				|
| Focal 		|			|			|			|				|
| Bookworm      |           |           |           |               |
| Bullseye		|			|			|			|				|
| Buster		|			|			|			|				|
| Raspbian  	|	⚫️		|			|	⚫️		|	⚫️			|

### ✅❎ Passed

### 🛠🛠 TODO

### ❌❌ Currently failing



<!-- EXAMPLES :
- Fresh app install without nginx
    - With only one user
    - With multiple users present
- Fresh Install with nginx present nginx
    - With only one user
    - With multiple users present
- Fresh install and nginx install afterwards
    - With only one user
    - With multiple users present
- Update from version in master
- Upgrade from version in master
- Password gets changed from `box` in app
- User removal from `box` acting on app
- New user in `box` gets added to app
- Sysinfo compatibility
    - Info washed
    - Content available
-->

