### PR TITLE
fix: navidrome fails to download on amd64 arch

### DIFF
--- a/sources/functions/navidrome
+++ b/sources/functions/navidrome
@@ -16,7 +16,7 @@ function _navidrome_download_latest() {
     github_tag="$(git ls-remote -q -t --refs https://github.com/navidrome/navidrome.git | awk '{sub("refs/tags/", ""); print $2 }' | awk '!/^$/' | sort -rV | head -n 1)"
     latest="https://github.com/navidrome/navidrome/releases/download/${github_tag}/navidrome_${github_tag#v}_Linux_${arch}.tar.gz"
 
-    if ! curl "${latest}" -L -o "/tmp/navidrome.tar.gz" &>> "${log}"; then
+    if ! curl "${latest}" -f -L -o "/tmp/navidrome.tar.gz" &>> "${log}"; then
         echo_error "Download failed, exiting"
         exit 1
     fi

--- a/sources/functions/navidrome
+++ b/sources/functions/navidrome
@@ -4,7 +4,7 @@ function _navidrome_download_latest() {
     echo_progress_start "Downloading release archive"
 
     case "$(_os_arch)" in
-        "amd64") arch='x86_64' ;;
+        "amd64") arch='amd64' ;;
         "arm64") arch="arm64" ;;
         "armhf") arch="armv7" ;;
         *)


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description
The latest releases of Navidrome for amd64 arch no longer includes `x86_64` in the URL, this has been replaced with `amd64` - therefore downloads/installs currently fail.

## Fixes issues: 
- #1100 

## Proposed Changes:
- Replace `x86_64` with `amd64` within `sources/functions/navidrome`
- Add the `-f` flag to the `curl` download line - right now the 'download failed' check isn't being triggered on HTTP 404, instead we're getting a `navidrome.tar.gz` file with the contents of `Not Found`

## Change Categories
<!-- DELETE WHICHEVER BULLET DOES NOT APPLY -->
- Bug fix               <!-- non-breaking change which fixes an issue -->

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [x] Docs have been made OR are not necessary
    - PR link: 
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Testing was done
   - [x] Tests created or no new tests necessary
   - [x] Tests executed

## Test scenarios
<!-- Please let us know what has been done or anything else that works/doesn't. Feel free to copy-paste the examples at the bottom of this section -->
- Fresh Swizzin install
    - Attempt to install Navidrome. Fail. :( Check code. :)
    - URL changed.
    - Update URL
        - Attempt to install again!
        - It works!

### Architectures
<!--
Please use these emojis here to fill the table below. It will nicely auto-format with spacing, don't worry. Leave empty wherever you do not know / have not tested
✅ = Works successfully
❎ = Does not work BUT is handled gracefully
🛠 = Still WIP
❌ = Broken / not working
-->
|   			| `amd64` 	| `armhf` 	| `arm64` 	| Unspecified 	|
|--------		|-------- 	|-------- 	|-------- 	|----------		|
| Jammy 		|			|			|			|				|
| Focal 		|			|			|			|				|
| Bookworm      |     ✅      |           |           |               |
| Bullseye		|			|			|			|				|
| Buster		|			|			|			|				|
| Raspbian  	|	⚫️		|			|	⚫️		|	⚫️			|

### ✅❎ Passed

### 🛠🛠 TODO

### ❌❌ Currently failing



<!-- EXAMPLES :
- Fresh app install without nginx
    - With only one user
    - With multiple users present
- Fresh Install with nginx present nginx
    - With only one user
    - With multiple users present
- Fresh install and nginx install afterwards
    - With only one user
    - With multiple users present
- Update from version in master
- Upgrade from version in master
- Password gets changed from `box` in app
- User removal from `box` acting on app
- New user in `box` gets added to app
- Sysinfo compatibility
    - Info washed
    - Content available
-->

