### PR TITLE
fix(autobrr): install/updater select correct package

### DIFF
--- a/sources/functions/autobrr
+++ b/sources/functions/autobrr
@@ -13,7 +13,7 @@ function autobrr_download_latest() {
             ;;
     esac
 
-    latest=$(curl -sL https://api.github.com/repos/autobrr/autobrr/releases/latest | grep "linux_$arch" | grep browser_download_url | cut -d \" -f4) || {
+    latest=$(curl -sL https://api.github.com/repos/autobrr/autobrr/releases/latest | grep "linux_$arch" | grep browser_download_url | grep ".tar.gz" | cut -d \" -f4) || {
         echo_error "Failed to query GitHub for latest version"
         exit 1
     }


### PR DESCRIPTION
## Description

Fix for autobrr installer/upgrader that broke when we started to ship multiple types of packages per arch.

## Fixes issues: 
- Un-tracked issue reported on Discord

## Proposed Changes:
-  Does an additional grep for `.tar.gz` to get the correct archive.

## Change Categories
- Bug fix 

## Checklist
- [x] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [x] Docs have been made OR are not necessary
    - PR link: 
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Testing was done
   - [x] Tests created or no new tests necessary
   - [x] Tests executed

## Test scenarios
- Install autobrr
- Upgrade autobrr

### Architectures
<!--
Please use these emojis here to fill the table below. It will nicely auto-format with spacing, don't worry. Leave empty wherever you do not know / have not tested
✅ = Works successfully
❎ = Does not work BUT is handled gracefully
🛠 = Still WIP
❌ = Broken / not working
-->
|   			| `amd64` 	| `armhf` 	| `arm64` 	| Unspecified 	|
|--------		|-------- 	|-------- 	|-------- 	|----------		|
| Jammy 		|			|			|			|				|
| Focal 		|			|			|			|				|
| Bookworm      |           |           |           |               |
| Bullseye		|			|			|			|				|
| Buster		|			|			|			|				|
| Raspbian  	|	⚫️		|			|	⚫️		|	⚫️			|