### PR TITLE
Changed boost download

### DIFF
--- a/sources/functions/libtorrent
+++ b/sources/functions/libtorrent
@@ -148,13 +148,41 @@ function booststrap() {
     if [[ ! -d ${BOOST_ROOT} ]]; then
         echo_progress_start "Installing boost"
         cd /opt
-        curl -O https://deac-ams.dl.sourceforge.net/project/boost/boost/${BOOST_VERSION//_/.}/boost_${BOOST_VERSION}.tar.gz >> ${log} 2>&1 || {
-            echo_warn "Could not download boost from sourceforge mirror, attempting fallback."
-            wget https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION//_/.}/source/boost_${BOOST_VERSION}.tar.gz >> ${log} 2>&1 || {
-                echo_error "Boost could not be downloaded. Setup will exit."
-                exit 1
-            }
-        }
+        declare -A boost_mirror_urls=(
+    		["jfrog.io"]="https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION//_/.}/source/boost_${BOOST_VERSION}.tar.gz"
+            ["boost.io"]="https://archives.boost.io/release/${BOOST_VERSION//_/.}/source/boost_${BOOST_VERSION}.tar.gz"
+    		["sourceforge"]="https://deac-ams.dl.sourceforge.net/project/boost/boost/${BOOST_VERSION//_/.}/boost_${BOOST_VERSION}.tar.gz"
+		)
+		
+        boost_failed_downloads=0
+        boost_valid_mime_types=("application/octet-stream" "application/x-gzip")
+        
+		for boost_mirror in "${!boost_mirror_urls[@]}"; do
+    		boost_url="${boost_mirror_urls[${boost_mirror}]}"
+
+    		boost_response=$(wget --spider -S --max-redirect=2 --server-response "${boost_url}" 2>&1)
+    		boost_content_type=$(echo "${boost_response}" | awk '/Content-Type/ {print $2}')
+
+    		if [[ " ${boost_valid_mime_types[*]} " == *" ${boost_content_type} "* ]]; then
+       			echo "Downloading from ${boost_mirror}: ${boost_url}..." >> ${log} 2>&1
+        		wget --max-redirect=2 "${boost_url}" >> ${log} 2>&1
+        		if [ $? -eq 0 ]; then
+            		echo_info "Download from ${boost_mirror} successful, extracting files."
+            		break
+        		else
+            		echo_info "Download from ${boost_mirror}. Trying next mirror..." >> ${log}
+                    ((boost_failed_downloads++))
+        		fi
+    		else
+        		echo_info "Skipping mirror ${boost_mirror}. Not a gzip file or offline" >> ${log} 2>&1
+                ((boost_failed_downloads++))
+    		fi
+		done
+        
+        if [ "${boost_failed_downloads}" -eq "${#boost_mirror_urls[@]}" ]; then
+   			echo_error "No download mirror available."
+            exit 1
+		fi
         tar xvf boost_${BOOST_VERSION}.tar.gz >> ${log} 2>&1
         rm -f boost_${BOOST_VERSION}.tar.gz
         cd ${BOOST_ROOT}

--- a/sources/functions/libtorrent
+++ b/sources/functions/libtorrent
@@ -148,9 +148,9 @@ function booststrap() {
     if [[ ! -d ${BOOST_ROOT} ]]; then
         echo_progress_start "Installing boost"
         cd /opt
-        wget https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION//_/.}/source/boost_${BOOST_VERSION}.tar.gz >> ${log} 2>&1 || {
-            echo_warn "Could not download boost from main mirror, attempting fallback."
-            wget https://deac-ams.dl.sourceforge.net/project/boost/boost/${BOOST_VERSION//_/.}/boost_${BOOST_VERSION}.tar.gz >> ${log} 2>&1 || {
+        curl -O https://deac-ams.dl.sourceforge.net/project/boost/boost/${BOOST_VERSION//_/.}/boost_${BOOST_VERSION}.tar.gz >> ${log} 2>&1 || {
+            echo_warn "Could not download boost from sourceforge mirror, attempting fallback."
+            wget https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION//_/.}/source/boost_${BOOST_VERSION}.tar.gz >> ${log} 2>&1 || {
                 echo_error "Boost could not be downloaded. Setup will exit."
                 exit 1
             }


### PR DESCRIPTION
Swapped boost download url because the account on the main site is deactivated, also changed wget to curl to download more than an html file from sourceforge

<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description
<!-- Any general story time goes here :) Feel free to add screenshots/recording of your change in action here-->
The boost download redirects to landing.jfrog.com/reactivate-server/boostorg, wget loads a html page and because it downloads something the fallback isn't working, could be fixed, but is a bit more work, so I canged the dl sites for now as a quick fix. Also changed wget to curl because I got problems with wget and loading from sourceforge.

Also: Is there a reason why boost 1.75 is still in use while there was a boost 1.84 release this december? 1.75 was released in december 2020. Didn't change version in case of breaking stuff.

## Fixes issues: 
- Un-tracked issue...

## Proposed Changes:
- Changed boost download method in libtorrent function

## Change Categories
<!-- DELETE WHICHEVER BULLET DOES NOT APPLY -->
- Bug fix               <!-- non-breaking change which fixes an issue -->
- Change in `functions` <!-- e.g. `utils`, `os`, `apt`, `ask`, etc. -->

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [x] Docs have been made OR are not necessary
    - PR link: 
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Testing was done
   - [x] Tests created or no new tests necessary
   - [x] Tests executed

## Test scenarios
<!-- Please let us know what has been done or anything else that works/doesn't. Feel free to copy-paste the examples at the bottom of this section -->

### Architectures
<!--
Please use these emojis here to fill the table below. It will nicely auto-format with spacing, don't worry. Leave empty wherever you do not know / have not tested
✅ = Works successfully
❎ = Does not work BUT is handled gracefully
🛠 = Still WIP
❌ = Broken / not working
-->
|   			| `amd64` 	| `armhf` 	| `arm64` 	| Unspecified 	|
|--------		|-------- 	|-------- 	|-------- 	|----------		|
| Jammy 		|	✅		|			|			|				|
| Focal 		|			|			|			|				|
| Bookworm      |    ✅       |           |           |               |
| Bullseye		|			|			|			|				|
| Buster		|			|			|			|				|
| Raspbian  	|	⚫️		|			|	⚫️		|	⚫️			|

### ✅❎ Passed

### 🛠🛠 TODO

### ❌❌ Currently failing



<!-- EXAMPLES :
- Fresh app install without nginx
    - With only one user
    - With multiple users present
- Fresh Install with nginx present nginx
    - With only one user
    - With multiple users present
- Fresh install and nginx install afterwards
    - With only one user
    - With multiple users present
- Update from version in master
- Upgrade from version in master
- Password gets changed from `box` in app
- User removal from `box` acting on app
- New user in `box` gets added to app
- Sysinfo compatibility
    - Info washed
    - Content available
-->

