### PR TITLE
rTorrent: Pin xmlrpc-c to stable revision 3212

### DIFF
--- a/sources/functions/rtorrent
+++ b/sources/functions/rtorrent
@@ -153,7 +153,7 @@ function build_xmlrpc-c() {
     . /etc/swizzin/sources/functions/utils
     rm_if_exists "/tmp/xmlrpc-c"
     rm_if_exists "/tmp/dist/xmlrpc-c "
-    svn checkout svn://svn.code.sf.net/p/xmlrpc-c/code/super_stable /tmp/xmlrpc-c >> $log 2>&1;
+    svn checkout svn://svn.code.sf.net/p/xmlrpc-c/code/stable@3212 /tmp/xmlrpc-c >> $log 2>&1;
     cd /tmp/xmlrpc-c
     cp -rf /etc/swizzin/sources/patches/rtorrent/xmlrpc-config.guess config.guess >> $log 2>&1
     cp -rf /etc/swizzin/sources/patches/rtorrent/xmlrpc-config.sub config.sub >> $log 2>&1


### PR DESCRIPTION
This commit fixes a critical stability issue with xmlrpc-c on rtorrent. It pins xmlrpc-c to stable revision 3212 (which has been tested) to prevent a future reoccurrence. We were running a rolling release and the author introduced a regression. It was required to hard code 3212 because the variable notation did not work. Tested on Ubuntu 22.04 LTS by two users. Confirmed to be stable. 