### PR TITLE
FPM: Fix Ubuntu 20.04 installation

### DIFF
--- a/sources/functions/fpm
+++ b/sources/functions/fpm
@@ -9,6 +9,10 @@ function install_fpm() {
         case $(_os_codename) in
             buster)
                 gem install public_suffix -v 4.0.7 >> $log 2>&1
+                gem install dotenv -v 2.8.1 >> $log 2>&1
+                ;;
+            focal)
+                gem install dotenv -v 2.8.1 >> $log 2>&1
                 ;;
             *) ;;
         esac


### PR DESCRIPTION
This commit resolves a critical installation issue on Ubuntu 20.04 with rTorrent, Deluge and qBittorrent when building from source. There is a package conflict with `dotenv` that prevents `fpm` from installing.

```
ERROR:  Error installing fpm:
	The last version of dotenv (>= 0) to support your Ruby & RubyGems was 2.8.1. Try installing it with `gem install dotenv -v 2.8.1` and then running the current command again
	dotenv requires Ruby version >= 3.0. The current ruby version is 2.7.0.0.
```