### PR TITLE
fix: chpasswd remove user.info when done

### DIFF
--- a/scripts/box
+++ b/scripts/box
@@ -505,6 +505,7 @@ function _chpasswd() {
     echo_success "Password for $user changed"
     pass=""
     unset pass
+    rm /root/"$user".info
 }
 
 function _nukeovh() {


### PR DESCRIPTION
`adduser` already does this, and I believe `chpasswd` should do the same.