### PR TITLE
curl: Add missing libbrotli-dev dependency

### DIFF
--- a/sources/functions/curl
+++ b/sources/functions/curl
@@ -2,7 +2,7 @@
 # Upgrade curl to bypass the bug in Debian 10. Can be used on any system however, but the benefit is to Buster users most
 
 configure_curl() {
-    apt_install cmake libssl-dev libnghttp2-dev libzstd-dev libldap2-dev libssh2-1-dev libpsl-dev
+    apt_install cmake libssl-dev libnghttp2-dev libzstd-dev libldap2-dev libssh2-1-dev libpsl-dev libbrotli-dev
     rm_if_exists /usr/local/lib/libcurl.la
 }
 


### PR DESCRIPTION
Debian decided to bump the curl version. We need to add a dependency to ensure it compiles.