### PR TITLE
rTorrent: Disable LTO for xmlrpc-c

### DIFF
--- a/sources/functions/rtorrent
+++ b/sources/functions/rtorrent
@@ -163,7 +163,7 @@ function build_xmlrpc-c() {
     }
     source <(sed 's/ //g' version.mk)
     VERSION=$XMLRPC_MAJOR_RELEASE.$XMLRPC_MINOR_RELEASE.$XMLRPC_POINT_RELEASE
-    make -j$(nproc) CFLAGS="-w ${rtorrentlevel} ${rtorrentflto} ${rtorrentpipe}" >> $log 2>&1
+    make -j$(nproc) CFLAGS="-w ${rtorrentlevel} ${rtorrentpipe}" >> $log 2>&1
     make DESTDIR=/tmp/dist/xmlrpc-c install >> $log 2>&1 || {
         echo_error "Something went wrong while making xmlrpc"
         exit 1


### PR DESCRIPTION
```
gcc -pthread   -shared -Wl,-soname,libxmlrpc_util.so.4  asprintf.osh base64.osh error.osh lock_platform.osh lock_pthread.osh lock_none.osh make_printable.osh memblock.osh mempool.osh select.osh sleep.osh string_number.osh time.osh utf8.osh   -o libxmlrpc_util.so.4.60  
0x1892686 internal_error(char const*, ...)
	???:0
0x69cb13 read_cgraph_and_symbols(unsigned int, char const**)
	???:0
0x688832 lto_main()
	???:0
Please submit a full bug report, with preprocessed source (by using -freport-bug).
Please include the complete backtrace with any bug report.
See <file:///usr/share/doc/gcc-12/README.Bugs> for instructions.
lto-wrapper: fatal error: gcc returned 1 exit status
compilation terminated.
/bin/ld: error: lto-wrapper failed
collect2: error: ld returned 1 exit status
```