### PR TITLE
libtorrent: upgrade boost to 1.85 for bookworm and newer

### DIFF
--- a/sources/functions/libtorrent
+++ b/sources/functions/libtorrent
@@ -146,7 +146,7 @@ function booststrap() {
     export BOOST_INCLUDEDIR=${BOOST_ROOT}
     export BOOST_BUILD_PATH=${BOOST_ROOT}
     oldBoosts=($(ls /opt/boost | grep boost | grep -v ${BOOST_VERSION}))
-    if -n ${oldBoosts[@]}; then
+    if [[ -n ${oldBoosts[@]} ]]; then
         for oldBoost in ${oldBoosts[@]}; do
             echo_info "Removing old boost: ${oldBoost}"
             if [[ -d /opt/${oldBoost} ]]; then

--- a/sources/functions/libtorrent
+++ b/sources/functions/libtorrent
@@ -145,7 +145,7 @@ function booststrap() {
     export BOOST_ROOT=/opt/boost_${BOOST_VERSION}
     export BOOST_INCLUDEDIR=${BOOST_ROOT}
     export BOOST_BUILD_PATH=${BOOST_ROOT}
-    oldBoosts=($(ls /opt/boost | grep boost | grep -v ${BOOST_VERSION}))
+    oldBoosts=($(ls /opt 2> /dev/null | grep boost | grep -v ${BOOST_VERSION}))
     if [[ -n ${oldBoosts[@]} ]]; then
         for oldBoost in ${oldBoosts[@]}; do
             echo_info "Removing old boost: ${oldBoost}"

--- a/sources/functions/libtorrent
+++ b/sources/functions/libtorrent
@@ -141,48 +141,57 @@ function cleanup_repo_libtorrent() {
 }
 
 function booststrap() {
-    BOOST_VERSION=1_75_0
+    BOOST_VERSION=1_85_0
     export BOOST_ROOT=/opt/boost_${BOOST_VERSION}
     export BOOST_INCLUDEDIR=${BOOST_ROOT}
     export BOOST_BUILD_PATH=${BOOST_ROOT}
+    oldBoosts=($(ls /opt/boost | grep boost | grep -v ${BOOST_VERSION}))
+    if -n ${oldBoosts[@]}; then
+        for oldBoost in ${oldBoosts[@]}; do
+            echo_info "Removing old boost: ${oldBoost}"
+            if [[ -d /opt/${oldBoost} ]]; then
+                rm -rf /opt/${oldBoost}
+            fi
+        done
+    fi
     if [[ ! -d ${BOOST_ROOT} ]]; then
         echo_progress_start "Installing boost"
         cd /opt
         declare -A boost_mirror_urls=(
-    		["jfrog.io"]="https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION//_/.}/source/boost_${BOOST_VERSION}.tar.gz"
+            ["jfrog.io"]="https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION//_/.}/source/boost_${BOOST_VERSION}.tar.gz"
             ["boost.io"]="https://archives.boost.io/release/${BOOST_VERSION//_/.}/source/boost_${BOOST_VERSION}.tar.gz"
-    		["sourceforge"]="https://deac-ams.dl.sourceforge.net/project/boost/boost/${BOOST_VERSION//_/.}/boost_${BOOST_VERSION}.tar.gz"
-		)
-		
+            ["sourceforge"]="https://deac-ams.dl.sourceforge.net/project/boost/boost/${BOOST_VERSION//_/.}/boost_${BOOST_VERSION}.tar.gz"
+        )
+
         boost_failed_downloads=0
         boost_valid_mime_types=("application/octet-stream" "application/x-gzip")
-        
-		for boost_mirror in "${!boost_mirror_urls[@]}"; do
-    		boost_url="${boost_mirror_urls[${boost_mirror}]}"
 
-    		boost_response=$(wget --spider -S --max-redirect=2 --server-response "${boost_url}" 2>&1)
-    		boost_content_type=$(echo "${boost_response}" | awk '/Content-Type/ {print $2}')
+        for boost_mirror in "${!boost_mirror_urls[@]}"; do
+            boost_url="${boost_mirror_urls[${boost_mirror}]}"
 
-    		if [[ " ${boost_valid_mime_types[*]} " == *" ${boost_content_type} "* ]]; then
-       			echo "Downloading from ${boost_mirror}: ${boost_url}..." >> ${log} 2>&1
-        		wget --max-redirect=2 "${boost_url}" >> ${log} 2>&1
-        		if [ $? -eq 0 ]; then
-            		echo_info "Download from ${boost_mirror} successful, extracting files."
-            		break
-        		else
-            		echo_info "Download from ${boost_mirror}. Trying next mirror..." >> ${log}
+            boost_response=$(wget --spider -S --max-redirect=2 --server-response "${boost_url}" 2>&1)
+            boost_content_type=$(echo "${boost_response}" | awk '/Content-Type/ {print $2}')
+
+            if [[ " ${boost_valid_mime_types[*]} " == *" ${boost_content_type} "* ]]; then
+                echo "Downloading from ${boost_mirror}: ${boost_url}..." >> ${log} 2>&1
+                wget --max-redirect=2 "${boost_url}" >> ${log} 2>&1
+                if [ $? -eq 0 ]; then
+                    echo_info "Download from ${boost_mirror} successful, extracting files."
+                    break
+                else
+                    echo_info "Download from ${boost_mirror}. Trying next mirror..." >> ${log}
                     ((boost_failed_downloads++))
-        		fi
-    		else
-        		echo_info "Skipping mirror ${boost_mirror}. Not a gzip file or offline" >> ${log} 2>&1
+                fi
+            else
+                echo_info "Skipping mirror ${boost_mirror}. Not a gzip file or offline" >> ${log} 2>&1
                 ((boost_failed_downloads++))
-    		fi
-		done
-        
+            fi
+        done
+
         if [ "${boost_failed_downloads}" -eq "${#boost_mirror_urls[@]}" ]; then
-   			echo_error "No download mirror available."
+            echo_error "No download mirror available."
             exit 1
-		fi
+        fi
         tar xvf boost_${BOOST_VERSION}.tar.gz >> ${log} 2>&1
         rm -f boost_${BOOST_VERSION}.tar.gz
         cd ${BOOST_ROOT}

--- a/sources/functions/libtorrent
+++ b/sources/functions/libtorrent
@@ -141,7 +141,14 @@ function cleanup_repo_libtorrent() {
 }
 
 function booststrap() {
-    BOOST_VERSION=1_85_0
+    case $(_os_codename) in
+        buster | focal | bullseye | jammy)
+            BOOST_VERSION=1_75_0
+            ;;
+        *)
+            BOOST_VERSION=1_85_0
+            ;;
+    esac
     export BOOST_ROOT=/opt/boost_${BOOST_VERSION}
     export BOOST_INCLUDEDIR=${BOOST_ROOT}
     export BOOST_BUILD_PATH=${BOOST_ROOT}


### PR DESCRIPTION
Old OS's cannot use 1.85 and new OS cannot compile libtorrent 1.2 without a boost upgrade.

Appears to work successfully.

Following cases were tested:

Focal: Deluge 1.3 + Deluge 2.1

Jammy: Deluge 1.3 + Deluge 2.1

Noble: Deluge 2.1 (Bookworm reports in issues)