### PR TITLE
ruTorrent v5.0 compatibility

### DIFF
--- a/sources/functions/rutorrent
+++ b/sources/functions/rutorrent
@@ -15,6 +15,7 @@ function rutorrent_install() {
         chown -R www-data:www-data /srv/rutorrent
         rm -rf /srv/rutorrent/plugins/throttle
         rm -rf /srv/rutorrent/plugins/_cloudflare
+        rm -rf /srv/rutorrent/plugins/dump
         rm -rf /srv/rutorrent/plugins/extratio
         rm -rf /srv/rutorrent/plugins/rpc
         rm -rf /srv/rutorrent/plugins/geoip


### PR DESCRIPTION
This 1 line of code (that you don't have to review @liaralabs) will stop ruTorrent v5.0 from exploding (when it's released) for seamless upgrades! `rm -rf /srv/rutorrent/plugins/dump`