### PR TITLE
rTorrent: Version 0.10.0 & fix xmlrpc-c

### DIFF
--- a/sources/functions/rtorrent
+++ b/sources/functions/rtorrent
@@ -11,6 +11,7 @@ function whiptail_rtorrent() {
         whiptail --title "rTorrent Install Advisory" --msgbox "We recommend rTorrent version selection instead of repo (distro) releases. They will compile additional performance and stability improvements in 90s. UDNS includes a stability patch for UDP trackers on rTorrent." 15 50
 
         function=$(whiptail --title "Choose an rTorrent version" --menu "All versions other than repo will be locally compiled from source" --ok-button "Continue" 14 50 5 \
+            0.10.0 "" \
             0.9.8 "" \
             0.9.7 "" \
             0.9.6 "" \
@@ -46,6 +47,13 @@ function set_rtorrent_version() {
         0.9.8 | '0.9.8')
             export rtorrentver='0.9.8'
             export libtorrentver='0.13.8'
+            export libudns='false'
+            export rtorrentpgo='false'
+            ;;
+			
+        0.10.0 | '0.10.0')
+            export rtorrentver='0.10.0'
+            export libtorrentver='0.14.0'
             export libudns='false'
             export rtorrentpgo='false'
             ;;
@@ -113,7 +121,7 @@ function depends_rtorrent() {
         APT='subversion dos2unix bc screen zip unzip sysstat build-essential comerr-dev
     dstat automake libtool libcppunit-dev libssl-dev pkg-config libcurl4-openssl-dev
     libsigc++-2.0-dev unzip curl libncurses5-dev yasm fontconfig libfontconfig1
-    libfontconfig1-dev mediainfo'
+    libfontconfig1-dev mediainfo autoconf-archive'
         apt_install $APT
 
         . /etc/swizzin/sources/functions/fpm
@@ -157,7 +165,7 @@ function build_xmlrpc-c() {
     cd /tmp/xmlrpc-c
     cp -rf /etc/swizzin/sources/patches/rtorrent/xmlrpc-config.guess config.guess >> $log 2>&1
     cp -rf /etc/swizzin/sources/patches/rtorrent/xmlrpc-config.sub config.sub >> $log 2>&1
-    ./configure --prefix=/usr --disable-cplusplus --disable-wininet-client --disable-libwww-client >> $log 2>&1 || {
+    ./configure --prefix=/usr --disable-cplusplus --disable-wininet-client --disable-libwww-client --disable-abyss-server --disable-cgi-server >> $log 2>&1 || {
         echo_error "Something went wrong while configuring xmlrpc"
         exit 1
     }
@@ -177,25 +185,36 @@ function build_xmlrpc-c() {
 }
 
 function build_libtorrent_rakshasa() {
-    libtorrentloc="https://github.com/rakshasa/libtorrent/archive/refs/tags/v${libtorrentver}.tar.gz"
-    cd "/tmp"
-    . /etc/swizzin/sources/functions/utils
-    rm_if_exists "/tmp/libtorrent"
-    mkdir /tmp/libtorrent
-    curl -sL ${libtorrentloc} -o /tmp/libtorrent-${libtorrentver}.tar.gz
-    VERSION=$libtorrentver
-    tar -xf /tmp/libtorrent-${libtorrentver}.tar.gz -C /tmp/libtorrent --strip-components=1 >> $log 2>&1
-    cd /tmp/libtorrent >> $log 2>&1
-
-    if [[ -f /root/libtorrent-rakshasa-${libtorrentver}.patch ]]; then
-        patch -p1 < /root/libtorrent-rakshasa-${libtorrentver}.patch >> ${log} 2>&1 || {
-            echo _error "Something went wrong when patching libtorrent-rakshasa"
-            exit 1
-        }
-        echo_info "Libtorrent-rakshasa patch found and applied!"
+    if [[ ${libtorrentver} == "0.14.0" ]]; then
+        build_libtorrent_rakshasa_new
     else
-        echo_log_only "No libtorrent-rakshasa patch found at /root/libtorrent-rakshasa-${libtorrentver}.patch"
+        build_libtorrent_rakshasa_old
     fi
+}
+
+function build_libtorrent_rakshasa_new() {
+    . /etc/swizzin/sources/functions/utils
+    download_libtorrent_rakshasa
+    auto_patch_libtorrent_rakshasa
+
+    autoreconf -vfi >> $log 2>&1
+    ./configure --prefix=/usr --enable-aligned >> $log 2>&1 || {
+        echo_error "Something went wrong while configuring libtorrent"
+        exit 1
+    }
+    make -j$(nproc) CXXFLAGS="-w ${rtorrentlevel} ${rtorrentflto} ${rtorrentpipe}" >> $log 2>&1 || {
+        echo_error "Something went wrong while making libtorrent"
+        exit 1
+    }
+
+    install_libtorrent_rakshasa
+}
+
+function build_libtorrent_rakshasa_old() {
+    . /etc/swizzin/sources/functions/utils
+    download_libtorrent_rakshasa
+    auto_patch_libtorrent_rakshasa
+
     if [[ ${libudns} == "true" ]]; then
         patch -p1 < /etc/swizzin/sources/patches/rtorrent/libtorrent-udns-0.13.8.patch >> "$log" 2>&1
         patch -p1 < /etc/swizzin/sources/patches/rtorrent/libtorrent-scanf-0.13.8.patch >> "$log" 2>&1
@@ -223,6 +242,37 @@ function build_libtorrent_rakshasa() {
         echo_error "Something went wrong while making libtorrent"
         exit 1
     }
+
+    install_libtorrent_rakshasa
+}
+
+function download_libtorrent_rakshasa() {
+    libtorrentloc="https://github.com/rakshasa/libtorrent/archive/refs/tags/v${libtorrentver}.tar.gz"
+    cd "/tmp"
+    . /etc/swizzin/sources/functions/utils
+    rm_if_exists "/tmp/libtorrent"
+    mkdir /tmp/libtorrent
+    curl -sL ${libtorrentloc} -o /tmp/libtorrent-${libtorrentver}.tar.gz
+    tar -xf /tmp/libtorrent-${libtorrentver}.tar.gz -C /tmp/libtorrent --strip-components=1 >> $log 2>&1
+    cd /tmp/libtorrent >> $log 2>&1
+}
+
+function auto_patch_libtorrent_rakshasa() {
+    . /etc/swizzin/sources/functions/utils
+    if [[ -f /root/libtorrent-rakshasa-${libtorrentver}.patch ]]; then
+        patch -p1 < /root/libtorrent-rakshasa-${libtorrentver}.patch >> ${log} 2>&1 || {
+            echo _error "Something went wrong when patching libtorrent-rakshasa"
+            exit 1
+        }
+        echo_info "Libtorrent-rakshasa patch found and applied!"
+    else
+        echo_log_only "No libtorrent-rakshasa patch found at /root/libtorrent-rakshasa-${libtorrentver}.patch"
+    fi
+}
+
+function install_libtorrent_rakshasa() {
+    VERSION=$libtorrentver
+    . /etc/swizzin/sources/functions/utils
     rm_if_exists "/tmp/dist/libtorrent-rakshasa"
     make DESTDIR=/tmp/dist/libtorrent-rakshasa install >> $log 2>&1
     mkdir -p /root/dist
@@ -234,24 +284,35 @@ function build_libtorrent_rakshasa() {
 }
 
 function build_rtorrent() {
-    rtorrentloc="https://github.com/rakshasa/rtorrent/archive/refs/tags/v${rtorrentver}.tar.gz"
-    cd "/tmp"
-    . /etc/swizzin/sources/functions/utils
-    rm_if_exists "/tmp/rtorrent*"
-    mkdir /tmp/rtorrent
-    curl -sL ${rtorrentloc} -o /tmp/rtorrent-${rtorrentver}.tar.gz
-    tar -xzf /tmp/rtorrent-${rtorrentver}.tar.gz -C /tmp/rtorrent --strip-components=1 >> $log 2>&1
-    VERSION=$rtorrentver
-    cd /tmp/rtorrent
-    if [[ -f /root/rtorrent-${rtorrentver}.patch ]]; then
-        patch -p1 < /root/rtorrent-${rtorrentver}.patch >> ${log} 2>&1 || {
-            echo _error "Something went wrong when patching rTorrent"
-            exit 1
-        }
-        echo_info "rTorrent patch found and applied!"
+    if [[ ${rtorrentver} == "0.10.0" ]]; then
+        build_rtorrent_new
     else
-        echo_log_only "No rTorrent patch found at /root/rtorrent-${rtorrentver}.patch"
+        build_rtorrent_old
     fi
+}
+
+function build_rtorrent_new() {
+    . /etc/swizzin/sources/functions/utils
+    download_rtorrent
+    auto_patch_rtorrent
+	
+    autoreconf -vfi >> $log 2>&1	
+    ./configure --prefix=/usr --with-xmlrpc-c >> $log 2>&1 || {
+        echo_error "Something went wrong while configuring rtorrent"
+        exit 1
+    }
+    make -j$(nproc) CXXFLAGS="-w ${rtorrentlevel} ${rtorrentflto} ${rtorrentpipe}" >> $log 2>&1 || {
+        echo_error "Something went wrong while making rtorrent"
+        exit 1
+    }
+
+    install_rtorrent
+}
+
+function build_rtorrent_old() {
+    download_rtorrent
+    auto_patch_rtorrent
+	
     #apply memory leak fixes to 0.9.8 branches bases only (0.9.8, UDNS, PGO) to reduce maintenance and testing
     #apply first thing to ensure compatibility with the tracker delay scrape patch by modifying higher line numbers first
     if [[ ${rtorrentver} == "0.9.8" ]]; then
@@ -303,6 +364,37 @@ function build_rtorrent() {
         echo_error "Something went wrong while making rtorrent"
         exit 1
     }
+
+    install_rtorrent
+}
+
+function download_rtorrent() {
+    rtorrentloc="https://github.com/rakshasa/rtorrent/archive/refs/tags/v${rtorrentver}.tar.gz"
+    cd "/tmp"
+    . /etc/swizzin/sources/functions/utils
+    rm_if_exists "/tmp/rtorrent*"
+    mkdir /tmp/rtorrent
+    curl -sL ${rtorrentloc} -o /tmp/rtorrent-${rtorrentver}.tar.gz
+    tar -xzf /tmp/rtorrent-${rtorrentver}.tar.gz -C /tmp/rtorrent --strip-components=1 >> $log 2>&1
+    cd /tmp/rtorrent
+}
+
+function auto_patch_rtorrent() {
+    . /etc/swizzin/sources/functions/utils
+    if [[ -f /root/rtorrent-${rtorrentver}.patch ]]; then
+        patch -p1 < /root/rtorrent-${rtorrentver}.patch >> ${log} 2>&1 || {
+            echo _error "Something went wrong when patching rTorrent"
+            exit 1
+        }
+        echo_info "rTorrent patch found and applied!"
+    else
+        echo_log_only "No rTorrent patch found at /root/rtorrent-${rtorrentver}.patch"
+    fi
+}
+
+function install_rtorrent() {
+    VERSION=$rtorrentver
+    . /etc/swizzin/sources/functions/utils
     rm_if_exists "/tmp/dist/rtorrent"
     make DESTDIR=/tmp/dist/rtorrent install >> $log 2>&1
     mkdir -p /root/dist


### PR DESCRIPTION
Adds support for rTorrent 0.10.0 without dropping old versions and fixes xmlrpc-c not to build unused code. Tested on Ubuntu Server 24.04.1 LTS. Successfully downloaded Linux ISO in 15 seconds with new version of rTorrrent!