### PR TITLE
Test ssl bump cf api test

### DIFF
--- a/scripts/install/letsencrypt.sh
+++ b/scripts/install/letsencrypt.sh
@@ -39,7 +39,7 @@ if [[ $main == yes ]]; then
     sed -i "s/server_name .*;/server_name $hostname;/g" /etc/nginx/sites-enabled/default
 fi
 
-if [[ -n $LE_CF_API ]] || [[ -n $LE_CF_EMAIL ]] || [[ -n $LE_CF_ZONE ]]; then
+if [[ -n $LE_CF_API ]] || [[ -n $LE_CF_ZONE ]]; then
     LE_BOOL_CF=yes
 fi
 
@@ -83,17 +83,10 @@ if [[ ${cf} == yes ]]; then
         api=$LE_CF_API
     fi
 
-    if [[ -z $LE_CF_EMAIL ]]; then
-        echo_query "CF Email"
-        read -e email
-    else
-        api=$LE_CF_EMAIL
-    fi
-
     export CF_Key="${api}"
-    export CF_Email="${email}"
 
-    valid=$(curl -X GET "https://api.cloudflare.com/client/v4/user" -H "X-Auth-Email: $email" -H "X-Auth-Key: $api" -H "Content-Type: application/json")
+
+    valid=$(curl -X GET "https://api.cloudflare.com/client/v4/user" -H "X-Auth-Key: $api" -H "Content-Type: application/json")
     if [[ $valid == *"\"success\":false"* ]]; then
         message="API CALL FAILED. DUMPING RESULTS:\n$valid"
         echo_error "$message"
@@ -109,8 +102,8 @@ if [[ ${cf} == yes ]]; then
             zone=$LE_CF_ZONE
         fi
 
-        zoneid=$(curl -s -X GET "https://api.cloudflare.com/client/v4/zones?name=$zone" -H "X-Auth-Email: $email" -H "X-Auth-Key: $api" -H "Content-Type: application/json" | grep -Po '(?<="id":")[^"]*' | head -1)
-        addrecord=$(curl -s -X POST "https://api.cloudflare.com/client/v4/zones/$zoneid/dns_records" -H "X-Auth-Email: $email" -H "X-Auth-Key: $api" -H "Content-Type: application/json" --data "{\"id\":\"$zoneid\",\"type\":\"A\",\"name\":\"$hostname\",\"content\":\"$ip\",\"proxied\":true}")
+        zoneid=$(curl -s -X GET "https://api.cloudflare.com/client/v4/zones?name=$zone" -H "X-Auth-Key: $api" -H "Content-Type: application/json" | grep -Po '(?<="id":")[^"]*' | head -1)
+        addrecord=$(curl -s -X POST "https://api.cloudflare.com/client/v4/zones/$zoneid/dns_records" -H "X-Auth-Key: $api" -H "Content-Type: application/json" --data "{\"id\":\"$zoneid\",\"type\":\"A\",\"name\":\"$hostname\",\"content\":\"$ip\",\"proxied\":true}")
         if [[ $addrecord == *"\"success\":false"* ]]; then
             message="API UPDATE FAILED. DUMPING RESULTS:\n$addrecord"
             echo_error "$message"

--- a/scripts/install/nginx.sh
+++ b/scripts/install/nginx.sh
@@ -59,7 +59,7 @@ rm_if_exists $templog
 touch $templog
 
 # Start openssl dhparam as a background task using temp.log
-openssl dhparam -out dhparam.pem 2048 >> $templog 2>&1 &
+openssl dhparam -out dhparam.pem 4096 >> $templog 2>&1 &
 
 # Install packages for nginx in the foreground
 APT="nginx libnginx-mod-http-fancyindex subversion ssl-cert php-fpm libfcgi0ldbl php-cli php-dev php-xml php-curl php-xmlrpc php-json php-mbstring php-opcache php-zip ${geoip} ${mcrypt}"
@@ -80,8 +80,8 @@ cd /etc/php
 phpv=$(ls -d */ | cut -d/ -f1)
 echo_progress_start "Making adjustments to PHP"
 for version in $phpv; do
-    sed -i -e "s/post_max_size = 8M/post_max_size = 64M/" \
-        -e "s/upload_max_filesize = 2M/upload_max_filesize = 92M/" \
+    sed -i -e "s/post_max_size = 8M/post_max_size = 100M/" \
+        -e "s/upload_max_filesize = 2M/upload_max_filesize = 100M/" \
         -e "s/expose_php = On/expose_php = Off/" \
         -e "s/128M/768M/" \
         -e "s/;cgi.fix_pathinfo=1/cgi.fix_pathinfo=0/" \
@@ -150,9 +150,11 @@ mkdir -p /etc/nginx/snippets/
 mkdir -p /etc/nginx/apps/
 
 cat > /etc/nginx/snippets/ssl-params.conf << SSC
-ssl_protocols TLSv1.2 TLSv1.3;
+ssl_protocols TLSv1.3;
 ssl_prefer_server_ciphers on;
-ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:EECDH+AESGCM:EDH+AESGCM;
+ssl_ciphers EECDH+CHACHA20:EECDH+AESGCM:EDH+AESGCM;
+ssl_conf_command Ciphersuites TLS_CHACHA20_POLY1305_SHA256:TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256;
+ssl_conf_command Options PrioritizeChaCha;
 ssl_ecdh_curve secp384r1;
 ssl_session_cache shared:SSL:10m;
 ssl_session_tickets off;


### PR DESCRIPTION
<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->

## Description
<!-- Any general story time goes here :) Feel free to add screenshots/recording of your change in action here-->
Noticed this original script calls for Cloudflare Global key versus zoned API tokens. 
Also noticed SSL support for older browsers which I don't use and prefer stronger encryption. Feel it's easier to enable TLS 1.2 for older support but keep stronger ciphers instead by default. 

## Fixes issues: 
- LetsEncrypt required CF_EMAIL + GLOBAL API KEY.  Didn't like having my global key out there so I tested with just API token keys. 
- SSL Strong Ciphers modern browser only spec nginx. (TLS 1.3 + STRONGER CIPHERS)
- dhparam.pem bump from  2096 < 4096

## Proposed Changes:
- Changed SSL nginx conf based on [https://cipherlist.eu/](https://cipherlist.eu/)
- Bump openssl dhparam -out to 4096.
- Remove email and CF Global key requirement in favor of API tokens for zoned domain names. 

## Change Categories

- Bug fix               Cloudflare Global API Key request removal.  
- Breaking change       Strong Browser Support only with TLS 1.3 only. (EX: no older android browsers will work). 
- Change in `functions` No old browsers with weak TLS or ciphers will work. 


## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- Testing in Ubuntu 24.04 VM. 
- Test build with all tools. 
-  verify acme.sh renewal without global keys and is affected by changes. 
