### PR TITLE
rTorrent: Add support for 0.15.1

### DIFF
--- a/sources/functions/rtorrent
+++ b/sources/functions/rtorrent
@@ -8,15 +8,15 @@ function whiptail_rtorrent() {
 	if [[ -z $rtorrentver ]] && [[ -z $1 ]] && [[ -z $RTORRENT_VERSION ]]; then
         repov=$(get_candidate_version rtorrent)
 
-        whiptail --title "rTorrent Install Advisory" --msgbox "We recommend rTorrent version selection instead of repo (distro) releases. They will compile additional performance and stability improvements in 90s. UDNS includes a stability patch for UDP trackers on rTorrent." 15 50
+        whiptail --title "rTorrent Install Advisory" --msgbox "We recommend the latest rTorrent version selection instead of repo (distro) releases. They will compile additional performance and stability improvements in 90s." 15 50
 
         function=$(whiptail --title "Choose an rTorrent version" --menu "All versions other than repo will be locally compiled from source" --ok-button "Continue" 14 50 5 \
+            0.15.1 "" \
             0.10.0 "" \
             0.9.8 "" \
             0.9.7 "" \
             0.9.6 "" \
             UDNS "(0.9.8)" \
-            PGO "(0.9.8)" \
             Repo "(${repov})" 3>&1 1>&2 2>&3) || {
             echo_error "rTorrent version choice aborted"
             exit 1
@@ -34,49 +34,42 @@ function set_rtorrent_version() {
             export rtorrentver='0.9.6'
             export libtorrentver='0.13.6'
             export libudns='false'
-            export rtorrentpgo='false'
             ;;
 
         0.9.7 | '0.9.7')
             export rtorrentver='0.9.7'
             export libtorrentver='0.13.7'
             export libudns='false'
-            export rtorrentpgo='false'
             ;;
 
         0.9.8 | '0.9.8')
             export rtorrentver='0.9.8'
             export libtorrentver='0.13.8'
             export libudns='false'
-            export rtorrentpgo='false'
             ;;
-			
+
         0.10.0 | '0.10.0')
             export rtorrentver='0.10.0'
             export libtorrentver='0.14.0'
             export libudns='false'
-            export rtorrentpgo='false'
+            ;;
+
+        0.15.1 | '0.15.1')
+            export rtorrentver='0.15.1'
+            export libtorrentver='0.15.1'
+            export libudns='false'
             ;;
 
         UDNS | 'UDNS')
             export rtorrentver='0.9.8'
             export libtorrentver='0.13.8'
             export libudns='true'
-            export rtorrentpgo='false'
-            ;;
-			
-		PGO | 'PGO')
-            export rtorrentver='0.9.8'
-            export libtorrentver='0.13.8'
-            export libudns='true'
-            export rtorrentpgo='true'
             ;;
 
         Repo | 'Repo')
             export rtorrentver='repo'
             export libtorrentver='repo'
             export libudns='false'
-            export rtorrentpgo='false'
             ;;
 
         *)
@@ -107,12 +100,6 @@ function configure_rtorrent() {
         export rtorrentlevel="-O3"
     else
         export rtorrentlevel="-O2"
-    fi
-    # GCC PGO for program compilation
-    if [[ ${rtorrentpgo} == "true" ]]; then
-        export rtorrentprofile="-fprofile-use"
-    else
-        export rtorrentprofile=""	
     fi
 }
 
@@ -156,7 +143,13 @@ function depends_rtorrent() {
     fi
 }
 
-function build_xmlrpc-c() {
+function build_xmlrpc-c() {    
+    if [[ ! ${rtorrentver} == "0.15.1" ]]; then
+        build_xmlrpc-c_old
+    fi
+}
+
+function build_xmlrpc-c_old() {
     cd "/tmp"
     . /etc/swizzin/sources/functions/utils
     rm_if_exists "/tmp/xmlrpc-c"
@@ -185,7 +178,7 @@ function build_xmlrpc-c() {
 }
 
 function build_libtorrent_rakshasa() {
-    if [[ ${libtorrentver} == "0.14.0" ]]; then
+    if [[ ${libtorrentver} == "0.14.0" || ${libtorrentver} == "0.15.1" ]]; then
         build_libtorrent_rakshasa_new
     else
         build_libtorrent_rakshasa_old
@@ -284,7 +277,7 @@ function install_libtorrent_rakshasa() {
 }
 
 function build_rtorrent() {
-    if [[ ${rtorrentver} == "0.10.0" ]]; then
+    if [[ ${rtorrentver} == "0.10.0" || ${rtorrentver} == "0.15.1" ]]; then
         build_rtorrent_new
     else
         build_rtorrent_old
@@ -295,12 +288,24 @@ function build_rtorrent_new() {
     . /etc/swizzin/sources/functions/utils
     download_rtorrent
     auto_patch_rtorrent
-	
-    autoreconf -vfi >> $log 2>&1	
-    ./configure --prefix=/usr --with-xmlrpc-c >> $log 2>&1 || {
-        echo_error "Something went wrong while configuring rtorrent"
-        exit 1
-    }
+
+    if [[ ${rtorrentver} == "0.10.0" ]]; then
+        patch -p1 < /etc/swizzin/sources/patches/rtorrent/1310-scgi-fix.patch >> "$log" 2>&1
+    fi
+
+    autoreconf -vfi >> $log 2>&1
+
+    if [[ ${rtorrentver} == "0.10.0" ]]; then
+        ./configure --prefix=/usr --with-xmlrpc-c >> $log 2>&1 || {
+            echo_error "Something went wrong while configuring rtorrent 0.10.0 with xmlrpc-c"
+            exit 1
+        }
+    else
+        ./configure --prefix=/usr --with-xmlrpc-tinyxml2 >> $log 2>&1 || {
+            echo_error "Something went wrong while configuring rtorrent with tinyxml2"
+            exit 1
+        }
+    fi
     make -j$(nproc) CXXFLAGS="-w ${rtorrentlevel} ${rtorrentflto} ${rtorrentpipe}" >> $log 2>&1 || {
         echo_error "Something went wrong while making rtorrent"
         exit 1
@@ -312,8 +317,8 @@ function build_rtorrent_new() {
 function build_rtorrent_old() {
     download_rtorrent
     auto_patch_rtorrent
-	
-    #apply memory leak fixes to 0.9.8 branches bases only (0.9.8, UDNS, PGO) to reduce maintenance and testing
+
+    #apply memory leak fixes to 0.9.8 branches bases only (0.9.8, UDNS) to reduce maintenance and testing
     #apply first thing to ensure compatibility with the tracker delay scrape patch by modifying higher line numbers first
     if [[ ${rtorrentver} == "0.9.8" ]]; then
         patch -p1 < /etc/swizzin/sources/patches/rtorrent/rtorrent-ml-fixes-0.9.8.patch >> "$log" 2>&1
@@ -344,23 +349,7 @@ function build_rtorrent_old() {
         echo_error "Something went wrong while configuring rtorrent"
         exit 1
     }
-    if [[ ${rtorrentpgo} == "true" ]]; then
-        echo_log_only "Begin fprofile generate for rTorrent"
-        make -j$(nproc) CXXFLAGS="-w ${rtorrentlevel} ${rtorrentflto} ${rtorrentpipe} ${stdc} -fprofile-generate" >> $log 2>&1 || {
-            echo_error "Something went wrong while making rtorrent with -fprofile-generate"
-            exit 1
-        }
-        make install >> $log 2>&1
-        echo_info "Running rTorrent PGO for 30s. Please wait..."
-        touch ~/.rtorrent.rc
-        screen -d -m -fa -S rtorrent_pgo rtorrent
-        sleep 30
-        screen -X -S rtorrent_pgo quit
-        rm_if_exists "~/.rtorrent.rc"
-        make clean >> $log 2>&1
-        echo_log_only "End fprofile generate for rTorrent"
-    fi
-    make -j$(nproc) CXXFLAGS="-w ${rtorrentlevel} ${rtorrentflto} ${rtorrentpipe} ${stdc} ${rtorrentprofile}" >> $log 2>&1 || {
+    make -j$(nproc) CXXFLAGS="-w ${rtorrentlevel} ${rtorrentflto} ${rtorrentpipe} ${stdc}" >> $log 2>&1 || {
         echo_error "Something went wrong while making rtorrent"
         exit 1
     }

--- a/sources/patches/rtorrent/1310-scgi-fix.patch
+++ b/sources/patches/rtorrent/1310-scgi-fix.patch
@@ -1,0 +1,29 @@
+From 09f4d4844bacd6a3623bd307250ab9c2e83aa4d0 Mon Sep 17 00:00:00 2001
+From: stickz <stickman002@mail.com>
+Date: Fri, 25 Oct 2024 12:35:43 -0400
+Subject: [PATCH] Resolve scgi software crash
+
+This commit resolves a scgi software crash when the scgi socket is closed before the message can be sent. It instructs `::send()` not to send a SIGPIPE termination signal. Instead the value -1 is returned and handled bellow. The SCgiTask is closed and a new one is sent to complete the task.
+
+```
+Thread 3 "rtorrent scgi" received signal SIGPIPE, Broken pipe.
+                                                             [Switching to Thread 0x7fffe635c6c0 (LWP 2443872)]
+0x00007ffff7929a84 in send () from /lib/x86_64-linux-gnu/libc.so.6
+```
+---
+ src/rpc/scgi_task.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/rpc/scgi_task.cc b/src/rpc/scgi_task.cc
+index 9f2e32902..160ba5082 100644
+--- a/src/rpc/scgi_task.cc
++++ b/src/rpc/scgi_task.cc
+@@ -200,7 +200,7 @@ SCgiTask::event_read() {
+ 
+ void
+ SCgiTask::event_write() {
+-  int bytes = ::send(m_fileDesc, m_position, m_bufferSize, 0);
++  int bytes = ::send(m_fileDesc, m_position, m_bufferSize, MSG_NOSIGNAL);
+ 
+   if (bytes == -1) {
+     if (!rak::error_number::current().is_blocked_momentary())


### PR DESCRIPTION
- Add support for rTorrent `0.15.1` with vendor `tinyxml2` instead of `xmlrpc-c`. This is now stable and tested with the arr suite and other indexers. It contains a significant reduction in overhead and will reduce future code maintenance. [rakshasa](https://github.com/rakshasa) posted a hotfix, so would could distribute a stable release of `tinyxml2`.
- Patch rTorrent `0.10.0` with a common scgi fix to a software crash. Linux distributions are distributing this patch.
- Remove the broken `PGO` option from the whiptail menu. It never worked properly and this will reduce maintenance.
- Remove note about `UDNS` from the whiptail menu. Add keyword "latest" instead to encourage selection of the most stable release.