### PR TITLE
Update nzbget scripts

### DIFF
--- a/scripts/install/nzbget.sh
+++ b/scripts/install/nzbget.sh
@@ -14,7 +14,7 @@
 function _download() {
     echo_progress_start "Downloading install script"
     cd /tmp
-    wget https://nzbget.net/download/nzbget-latest-bin-linux.run >> $log 2>&1
+    wget https://nzbget.com/download/nzbget-latest-bin-linux.run >> $log 2>&1
     echo_progress_done
 }
 
@@ -30,9 +30,9 @@ After=network.target
 User=%i
 Group=%i
 Type=forking
-ExecStart=/bin/sh -c "/home/%i/nzbget/nzbget -D"
-ExecStop=/bin/sh -c "/home/%i/nzbget/nzbget -Q"
-ExecReload=/bin/sh -c "/home/%i/nzbget/nzbget -O"
+ExecStart=/bin/sh -c "/opt/nzbget/nzbget -D"
+ExecStop=/bin/sh -c "/opt/nzbget/nzbget -Q"
+ExecReload=/bin/sh -c "/opt/nzbget/nzbget -O"
 Restart=on-failure
 
 [Install]
@@ -45,30 +45,18 @@ function _install() {
     cd /tmp
     for u in "${users[@]}"; do
         echo_progress_start "Installing nzbget for $u"
-        sh nzbget-latest-bin-linux.run --destdir /home/$u/nzbget >> $log 2>&1
-        chown -R $u:$u /home/$u/nzbget
+        sh nzbget-latest-bin-linux.run --destdir /opt/nzbget >> $log 2>&1
+        chown -R $u:$u /opt/nzbget
         if [[ $u == $master ]]; then
             :
         else
             port=$(shuf -i 6000-7000 -n 1)
             secureport=$(shuf -i 6000-7000 -n 1)
-            sed -i "s/ControlPort=6789/ControlPort=${port}/g" /home/$u/nzbget/nzbget.conf
-            sed -i "s/SecurePort=6791/SecurePort=${secureport}/g" /home/$u/nzbget/nzbget.conf
+            sed -i "s/ControlPort=6789/ControlPort=${port}/g" /opt/nzbget/nzbget.conf
+            sed -i "s/SecurePort=6791/SecurePort=${secureport}/g" /opt/nzbget/nzbget.conf
         fi
         echo_progress_done "Nzbget installed for $u"
     done
-
-    if [[ ! -d /home/$u/.ssl/ ]]; then
-        mkdir -p /home/$u/.ssl/
-    fi
-
-    . /etc/swizzin/sources/functions/ssl
-
-    create_self_ssl $u
-
-    sed -i "s/SecureControl=no/SecureControl=yes/g" /home/$u/nzbget/nzbget.conf
-    sed -i "s/SecureCert=/SecureCert=\/home\/$u\/.ssl\/$u-self-signed.crt/g" /home/$u/nzbget/nzbget.conf
-    sed -i "s/SecureKey=/SecureKey=\/home\/$u\/.ssl\/$u-self-signed.key/g" /home/$u/nzbget/nzbget.conf
 
     if [[ -f /install/.nginx.lock ]]; then
         echo_progress_start "Configuring nginx"

--- a/scripts/nginx/nzbget.sh
+++ b/scripts/nginx/nzbget.sh
@@ -22,10 +22,10 @@ fi
 
 for u in "${users[@]}"; do
     isactive=$(systemctl is-active nzbget@$u)
-    sed -i "s/SecureControl=yes/SecureControl=no/g" /home/$u/nzbget/nzbget.conf
-    sed -i "s/ControlIP=0.0.0.0/ControlIP=127.0.0.1/g" /home/$u/nzbget/nzbget.conf
-    sed -i "s/ControlUsername=nzbget/ControlUsername=/g" /home/$u/nzbget/nzbget.conf
-    sed -i "s/ControlPassword=tegbzn6789/ControlPassword=/g" /home/$u/nzbget/nzbget.conf
+    sed -i "s/SecureControl=yes/SecureControl=no/g" /opt/nzbget/nzbget.conf
+    sed -i "s/ControlIP=0.0.0.0/ControlIP=127.0.0.1/g" /opt/nzbget/nzbget.conf
+    sed -i "s/ControlUsername=nzbget/ControlUsername=/g" /opt/nzbget/nzbget.conf
+    sed -i "s/ControlPassword=tegbzn6789/ControlPassword=/g" /opt/nzbget/nzbget.conf
 
     if [[ ! -f /etc/nginx/conf.d/${u}.nzbget.conf ]]; then
         NZBPORT=$(grep ControlPort /home/$u/nzbget/nzbget.conf | cut -d= -f2)

--- a/scripts/remove/nzbget.sh
+++ b/scripts/remove/nzbget.sh
@@ -5,7 +5,7 @@ users=($(cut -d: -f1 < /etc/htpasswd))
 for u in "${users[@]}"; do
     systemctl stop -q nzbget@$u
     systemctl disable -q nzbget@$u
-    rm -rf /home/$u/nzbget
+    rm -rf /opt/nzbget
     rm /etc/nginx/conf.d/$u.nzbget.conf
 done
 

--- a/scripts/tests/nzbget.sh
+++ b/scripts/tests/nzbget.sh
@@ -16,7 +16,7 @@ for user in "${users[@]}"; do
         BAD=true
         continue
     }
-    confpath="/home/${user}/nzbget/nzbget.conf"
+    confpath="/opt/nzbget/nzbget.conf"
     port=$(grep 'ControlPort' "$confpath" | cut -d= -f2)
     check_port_curl "$port" "$extra_params" || BAD=true
 done

--- a/scripts/update/nzbget.sh
+++ b/scripts/update/nzbget.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ -f /install/.nzbget.lock ]]; then
-    if grep -q "ExecStart=/home/%I/nzbget/nzbget -D" /etc/systemd/system/nzbget@.service; then
+    if grep -q "ExecStart=/opt/nzbget/nzbget -D" /etc/systemd/system/nzbget@.service; then
         echo_progress_start "Updating NZBGet systemd service file with forking"
         cat > /etc/systemd/system/nzbget@.service << NZBGD
 [Unit]
@@ -13,9 +13,9 @@ After=network.target
 User=%I
 Group=%I
 Type=forking
-ExecStart=/bin/sh -c "/home/%I/nzbget/nzbget -D"
-ExecStop=/bin/sh -c "/home/%I/nzbget/nzbget -Q"
-ExecReload=/bin/sh -c "/home/%I/nzbget/nzbget -O"
+ExecStart=/bin/sh -c "/opt/nzbget/nzbget -D"
+ExecStop=/bin/sh -c "/opt/nzbget/nzbget -Q"
+ExecReload=/bin/sh -c "/opt/nzbget/nzbget -O"
 Restart=on-failure
 
 [Install]

--- a/scripts/update/nzbget.sh
+++ b/scripts/update/nzbget.sh
@@ -6,7 +6,7 @@ if [[ -f /install/.nzbget.lock ]]; then
         cat > /etc/systemd/system/nzbget@.service << NZBGD
 [Unit]
 Description=NZBGet Daemon
-Documentation=http://nzbget.net/Documentation
+Documentation=http://nzbget.com/documentation
 After=network.target
 
 [Service]


### PR DESCRIPTION
## Description
The nzbget script has been out of date for a while. Updated simple items to at least bring it back up to swizzin guidelines by installing the latest version from nzbget.com instead of .net and installing nzbget in /opt

## Fixes issues: 
- Switched to active development version of nzbget
- Moded install location

## Proposed Changes:
- Switched to active development version of nzbget
- Moded install location

## Change Categories
- New feature

## Checklist
- [x] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [x] Docs have been made OR are not necessary
    - PR link: 
- [x] Changes to panel have been made OR are not necessary
    - PR link: 
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Testing was done
   - [x] Tests created or no new tests necessary
   - [x] Tests executed

## Test scenarios
Tested working on local install, no errors in logs.

### Architectures
<!--
Please use these emojis here to fill the table below. It will nicely auto-format with spacing, don't worry. Leave empty wherever you do not know / have not tested
✅ = Works successfully
❎ = Does not work BUT is handled gracefully
🛠 = Still WIP
❌ = Broken / not working
-->
|   			| `amd64` 	| `armhf` 	| `arm64` 	| Unspecified 	|
|--------		|-------- 	|-------- 	|-------- 	|----------		|
| Jammy 		|			|			|			|				|
| Focal 		|			|			|			|				|
| Bookworm      |           |           |           |               |
| Bullseye		|			|			|			|				|
| Buster		|			|			|			|				|
| Raspbian  	|	⚫️		|			|	⚫️		|	⚫️			|

### ✅❎ Passed

### 🛠🛠 TODO

### ❌❌ Currently failing
