### PR TITLE
Update sabnzbd.sh

### DIFF
--- a/scripts/nginx/sabnzbd.sh
+++ b/scripts/nginx/sabnzbd.sh
@@ -22,6 +22,8 @@ location /sabnzbd {
   proxy_pass        http://127.0.0.1:65080/sabnzbd;
   auth_basic "What's the password?";
   auth_basic_user_file /etc/htpasswd.d/htpasswd.${user};
+  allow 127.0.0.0/16;       # localhost (covers 127.0.0.1)
+  deny  all;                # everything else must use basic auth
 }
 SAB
 fi


### PR DESCRIPTION
I feel like /sabnzbd/api url endpoint shouldnt go through basic auth. Otherwise why is it api? 

<!--Heya! Thanks for the PR. Please fill out this short little form below to help us review this faster-->
Ok, basic auth is used even if you hit domain.tld/sabnzbd/api which breaks any apps using domain.tld forcing users to use 127.0.0.1:65080/sabnzbd/api because nginx says 401

there are some reasons to go through https://domain.tld:443/sabnzbd like for example you have a docker container that cant use localhost, or you want to cut down on support requests for people who assume they should put domain.tld/sabnzbd in sonarr isntead of localhost. 
<!-- Any general story time goes here :) Feel free to add screenshots/recording of your change in action here-->

## Fixes issues: 
- Issue #nr...
- Un-tracked issue...

## Proposed Changes:
- Changed basic auth off for 

## Change Categories
<!-- DELETE WHICHEVER BULLET DOES NOT APPLY -->
- Bug fix               <!-- non-breaking change which fixes an issue -->


## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [X] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [X] Docs have been made OR are not necessary
    - PR link: 
- [X] Changes to panel have been made OR are not necessary
    - PR link: 
- [X] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [X] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] Testing was done
   - [X] Tests created or no new tests necessary
   - [X] Tests executed

## Test scenarios
curl -sS "https://domain.tld:443/sabnzbd/api?mode=get_config&apikey=mysabnzbdapigoeshere&output=json"

### Architectures
<!--
Please use these emojis here to fill the table below. It will nicely auto-format with spacing, don't worry. Leave empty wherever you do not know / have not tested
✅ = Works successfully
❎ = Does not work BUT is handled gracefully
🛠 = Still WIP
❌ = Broken / not working
-->
|   			| `amd64` 	| `armhf` 	| `arm64` 	| Unspecified 	|
|--------		|-------- 	|-------- 	|-------- 	|----------		|
| Jammy 		|		✅	|		✅	|		✅	|			✅	|
| Focal 		|		✅	|		✅	|			✅|			✅	|
| Bookworm      |        ✅   |     ✅      |     ✅      |      ✅         |
| Bullseye		|		✅	|		✅	|		✅	|		✅		|
| Buster		|		✅	|		✅	|		✅	|			✅	|
| Raspbian  	|	⚫️		|			|	⚫️		|	⚫️			|

### ✅❎ Passed
bro, nginx is arch agnostic and this is a very minor change with acceptable stanza
### 🛠🛠 TODO
works on my machine
### ❌❌ Currently failing
my mental health

