### PR TITLE
fix editorconfig shfmt support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,17 +19,9 @@ trim_trailing_whitespace = false
 [*.{yml,yaml}]
 indent_size = 2
 
-[[bash]]
+[{*.sh,scripts/**/*,sources/**/*}]
 indent_size = 4
-# -ln bash
-shell_variant      = bash
-# -ci
-switch_case_indent = true
-# -sr
-space_redirects    = true
-
-[[shell]]
-indent_size = 4
+# Settings for shfmt
 # -ln bash
 shell_variant      = bash
 # -ci


### PR DESCRIPTION
`[[bash]]` is not really legal editorconfig so `bash-language-server` does not support it via their go library.]

Switch to basic globs instead
