### PR TITLE
ensure develop resets from origin

### DIFF
--- a/scripts/box
+++ b/scripts/box
@@ -120,9 +120,9 @@ function _clr() {
 
 function _update() {
     # Checking for develop branch
+    SWIZ_GIT_REF="origin/master"
     if [ "$branch_name" == "develop" ]; then
         SWIZ_GIT_REF="origin/develop"
-        export SWIZ_GIT_REF
     fi
 
     if [[ -L /etc/swizzin ]]; then
@@ -147,34 +147,35 @@ function _update() {
 You will not be receiving any new updates past the last supported commit. Swizzin will continue to run as-is.
 We URGE you to migrate to a supported release if/while you still have the chance."
             SWIZ_GIT_REF="tags/eol-$(_os_codename)"
-            export SWIZ_GIT_REF
             ;;
     esac
+    export SWIZ_GIT_REF
     echo_log_only "noupdate = $noupdate"
     # If there is nothing blocking the update...
     if [[ -z $noupdate ]]; then
         # Run the git update procedure
         echo_progress_start "Updating swizzin local repository"
-        git -C /etc/swizzin checkout "${SWIZ_GIT_REF:-master}" >> $log 2>&1 ||
+        git -C /etc/swizzin checkout "${SWIZ_GIT_REF}" >> $log 2>&1 ||
             {
                 echo_warn "Unclean repo detected, resetting current branch."
                 git -C /etc/swizzin reset --hard >> $log 2>&1
-                git -C /etc/swizzin checkout "${SWIZ_GIT_REF:-master}" >> $log 2>&1
+                git -C /etc/swizzin checkout "${SWIZ_GIT_REF}" >> $log 2>&1
             }
         {
             #shellcheck disable=SC2129
             git -C /etc/swizzin fetch --all --tags --prune >> $log 2>&1
-            git -C /etc/swizzin reset --hard "${SWIZ_GIT_REF:-origin/master}" >> $log 2>&1
+            git -C /etc/swizzin reset --hard "${SWIZ_GIT_REF}" >> $log 2>&1
         } || {
             echo_error "Failed to update from git"
             exit 1
         }
-        echo_progress_done "Local repository updated using: ${SWIZ_GIT_REF:-master}"
+        echo_progress_done "Local repository updated using: ${SWIZ_GIT_REF}"
         echo_info "HEAD is now set to $(git -C /etc/swizzin log --pretty=format:'%h' -n1)"
     else
         echo_warn "$noupdate_message"
     fi
-    export SWIZ_REPO_SCRIPT_RAN=true
+    SWIZ_REPO_SCRIPT_RAN=true
+    export SWIZ_REPO_SCRIPT_RAN
 
     echo_log_only "Re-sourcing globals.sh"
     # source globals again in case changes were made

--- a/scripts/box
+++ b/scripts/box
@@ -121,7 +121,7 @@ function _clr() {
 function _update() {
     # Checking for develop branch
     if [ "$branch_name" == "develop" ]; then
-        SWIZ_GIT_REF="develop"
+        SWIZ_GIT_REF="origin/develop"
         export SWIZ_GIT_REF
     fi
 

--- a/scripts/box
+++ b/scripts/box
@@ -120,9 +120,9 @@ function _clr() {
 
 function _update() {
     # Checking for develop branch
-    SWIZ_GIT_REF="origin/master"
+    git_ref="origin/master"
     if [ "$branch_name" == "develop" ]; then
-        SWIZ_GIT_REF="origin/develop"
+        git_ref="origin/develop"
     fi
 
     if [[ -L /etc/swizzin ]]; then
@@ -146,30 +146,29 @@ function _update() {
             echo_warn "${name^} is not supported by swizzin at this stage.
 You will not be receiving any new updates past the last supported commit. Swizzin will continue to run as-is.
 We URGE you to migrate to a supported release if/while you still have the chance."
-            SWIZ_GIT_REF="tags/eol-$(_os_codename)"
+            git_ref="tags/eol-$(_os_codename)"
             ;;
     esac
-    export SWIZ_GIT_REF
     echo_log_only "noupdate = $noupdate"
     # If there is nothing blocking the update...
     if [[ -z $noupdate ]]; then
         # Run the git update procedure
         echo_progress_start "Updating swizzin local repository"
-        git -C /etc/swizzin checkout "${SWIZ_GIT_REF}" >> $log 2>&1 ||
+        git -C /etc/swizzin checkout "${git_ref}" >> $log 2>&1 ||
             {
                 echo_warn "Unclean repo detected, resetting current branch."
                 git -C /etc/swizzin reset --hard >> $log 2>&1
-                git -C /etc/swizzin checkout "${SWIZ_GIT_REF}" >> $log 2>&1
+                git -C /etc/swizzin checkout "${git_ref}" >> $log 2>&1
             }
         {
             #shellcheck disable=SC2129
             git -C /etc/swizzin fetch --all --tags --prune >> $log 2>&1
-            git -C /etc/swizzin reset --hard "${SWIZ_GIT_REF}" >> $log 2>&1
+            git -C /etc/swizzin reset --hard "${git_ref}" >> $log 2>&1
         } || {
             echo_error "Failed to update from git"
             exit 1
         }
-        echo_progress_done "Local repository updated using: ${SWIZ_GIT_REF}"
+        echo_progress_done "Local repository updated using: ${git_ref}"
         echo_info "HEAD is now set to $(git -C /etc/swizzin log --pretty=format:'%h' -n1)"
     else
         echo_warn "$noupdate_message"


### PR DESCRIPTION
Due to this reset here you would only reset against the _local_ version of develop, not the one on origin.
https://github.com/swizzin/swizzin/blob/802036d3d68520fe3c10597d949f3e4e1409be3c/scripts/box#L167 

It's easier to maintain this if the default is clearly at the top and we're not swapping things around


