### PR TITLE
allow unattended user create when already exists in system

### DIFF
--- a/scripts/box
+++ b/scripts/box
@@ -276,7 +276,10 @@ function _adduser() {
 
     if id -u "${user}" > /dev/null 2>&1; then
         echo_info "The user ${user} already appears to be present on this machine; however, it does not appear to be configured as a swizzin user.\nThe user will be added to swizzin."
-        ask "Continue setting up user?" Y || exit 1
+        if [ -z "$UNATTEND" ]; then
+            ask "Continue setting up user?" Y || exit 1
+        fi
+
         existing=true
     fi
 

--- a/scripts/box
+++ b/scripts/box
@@ -276,7 +276,7 @@ function _adduser() {
 
     if id -u "${user}" > /dev/null 2>&1; then
         echo_info "The user ${user} already appears to be present on this machine; however, it does not appear to be configured as a swizzin user.\nThe user will be added to swizzin."
-        if [ -z "$UNATTEND" ]; then
+        if [[ "$UNATTEND" == 'true' ]]; then
             ask "Continue setting up user?" Y || exit 1
         fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -232,8 +232,8 @@ function _intro() {
 
 function _adduser() {
     echo_info "Creating master user"
-    export SETUP_USER=true                                     # This sets whiptail in box adduser
-    bash /etc/swizzin/scripts/box adduser "$user" "$pass" || { # TODO make it so that the password does not hit the logs
+    export SETUP_USER=true                                                             # This sets whiptail in box adduser
+    UNATTEND=${unattend:-0} bash /etc/swizzin/scripts/box adduser "$user" "$pass" || { # TODO make it so that the password does not hit the logs
         echo_error "Installation aborted!"
         exit 1
     }

--- a/setup.sh
+++ b/setup.sh
@@ -232,8 +232,8 @@ function _intro() {
 
 function _adduser() {
     echo_info "Creating master user"
-    export SETUP_USER=true                                                             # This sets whiptail in box adduser
-    UNATTEND=${unattend:-0} bash /etc/swizzin/scripts/box adduser "$user" "$pass" || { # TODO make it so that the password does not hit the logs
+    export SETUP_USER=true                                                            # This sets whiptail in box adduser
+    UNATTEND="${unattend}" bash /etc/swizzin/scripts/box adduser "$user" "$pass" || { # TODO make it so that the password does not hit the logs
         echo_error "Installation aborted!"
         exit 1
     }


### PR DESCRIPTION
pass unattend variable to box for adduser and skip an `ask` if unattend is true