### PR TITLE
feat(qbittorrent): add support for version 5.2.x

### DIFF
--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -14,6 +14,7 @@ function whiptail_qbittorrent() {
         latestv46=$(echo "$releases" | grep -m1 -oP '^4\.6\.\d?.?\d')
         latestv50=$(echo "$releases" | grep -m1 -oP '^5\.0\.\d?.?\d')
         latestv51=$(echo "$releases" | grep -m1 -oP '^5\.1\.\d?.?\d')
+        latestv52=$(echo "$releases" | grep -m1 -oP '^5\.2\.\d?.?\d')
         #latestv=$(echo "$releases" | grep -m1 -oP '\d.\d?.?\d?.?\d')
         repov=$(get_candidate_version qbittorrent-nox)
         case ${codename} in
@@ -41,6 +42,7 @@ function whiptail_qbittorrent() {
                 function=$(
                     whiptail --title "Pick qbittorrent version" --menu "Choose a qBittorrent version:" --ok-button "Continue" --nocancel 12 50 6 \
                         "Repo" "${repov}" \
+                        "5.2" "(${latestv52})" \
                         "5.1" "(${latestv51})" \
                         "5.0" "(${latestv50})" \
                         "4.6" "(${latestv46})" \
@@ -80,6 +82,9 @@ function whiptail_qbittorrent() {
                 ;;
             5.1)
                 export QBITTORRENT_VERSION=${latestv51}
+                ;;
+            5.2)
+                export QBITTORRENT_VERSION=${latestv52}
                 ;;
             Repo)
                 export QBITTORRENT_VERSION=repo
@@ -270,8 +275,33 @@ function qbittorrent_version_info() {
             cryptography_type=openssl
             build_type=cmake
             ;;
+        5.2.*)
+            if [[ -n ${LIBTORRENT_VERSION} ]]; then
+                case $LIBTORRENT_VERSION in
+                    RC_2_0)
+                        libtorrent_branch=RC_2_0
+                        ;;
+                    RC_1_2)
+                        libtorrent_branch=RC_1_2
+                        ;;
+                    *)
+                        echo_error "LIBTORRENT_VERSION must be either RC_1_2 or RC_2_0. You entered ${LIBTORRENT_VERSION}."
+                        exit 1
+                        ;;
+                esac
+                echo_info "Overriding libtorrent version with ${LIBTORRENT_VERSION}"
+            else
+                libtorrent_branch=RC_1_2
+            fi
+            libtorrent_minimum_version=1.2.20
+            stdcver="c++20"
+            qt_minimum_version=6.6 # Support for Qt 6.5 was dropped with 5.2 (see https://github.com/qbittorrent/qBittorrent/pull/22599)
+            qbt_use_qt6=ON
+            cryptography_type=openssl
+            build_type=cmake
+            ;;
         *)
-            echo_error "qBittorrent version should be between 4.1.*(.*) and 5.1.*(.*) -- Setup will not proceed."
+            echo_error "qBittorrent version should be between 4.1.*(.*) and 5.2.*(.*) -- Setup will not proceed."
             exit 1
             ;;
     esac


### PR DESCRIPTION
## Description
This PR adds support for the qBittorrent 5.2.x versions.

## Proposed Changes:
- Add qBittorrent 5.2.x versions to the installer and bumped minimum Qt framework version to 6.6.x 
(see https://github.com/qbittorrent/qBittorrent/pull/22599)

## Change Categories
- New feature: qBittorrent 5.2.x support    
- Changes for/in `box install qbittorrent` / `sources/functions/qbittorrent`

## Checklist
<!-- Please note that we also require you to check the CONTRIBUTORS.md file, this is just a short list-->
- [x] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [x] Docs have been made OR are not necessary
    - PR link: *not necessary*
- [x] Changes to panel have been made OR are not necessary
    - PR link:  *not necessary*
- [x] Code conforms to project structure
- [x] Prints to terminal are handled
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Testing was done
   - [x] Tests created or **no new tests necessary**
   - [x] Tests executed

## Test scenarios

Tested installation of qBittorrent v5.2.0 on a fresh minimal installation VM of Debian 12.13.0
with a SSH server, the standard system utilities install and a single user (apart from root).
Debian 13 has not been tested since it is not supported by swizzin at the point of creating this PR.
Panel and nginx have been installed at setup. qBittorrent has been installed with `box install` afterwards.
Ran `box test` and `box test qbittorrent` which both resulted in "All tests completed succesfully."

```
qBittorrent was built with the following libraries:

Qt: 6.7.3
Libtorrent: 1.2.20.0
Boost: 1.85.0
OpenSSL: 3.0.19
zlib: 1.3.1.zlib-ng
```

---

#### Note:
There's been a discussion in discord about the auth changes on the side of qbittorrent regarding basic auth.
(see https://github.com/qbittorrent/qBittorrent/pull/23564)
When logging into swizzin, qbittorrent does no longer show a login page due to it using basic auth info now.
Furthermore when navigating directly to /qbittorrent/ (without logging into the panel before)
you now get a basic auth popup instead of the qbittorrent login form.
So it is safe to assume that no changes regarding basic auth should be needed.

---

If additional testing is required please let me know.

---

### Architectures
<!--
Please use these emojis here to fill the table below. It will nicely auto-format with spacing, don't worry. Leave empty wherever you do not know / have not tested
✅ = Works successfully
❎ = Does not work BUT is handled gracefully
🛠 = Still WIP
❌ = Broken / not working
-->
|   			| `amd64` 	| `armhf` 	| `arm64` 	| Unspecified 	|
|--------		|-------- 	|-------- 	|-------- 	|----------		|
| Jammy 		|			|			|			|				|
| Focal 		|			|			|			|				|
| Bookworm      |      ✅      |           |           |               |
| Bullseye		|			|			|			|				|
| Buster		|			|			|			|				|
| Raspbian  	|	⚫️		|			|	⚫️		|	⚫️			|

Thank you for maintaining this project and keep up the amazing work!