### PR TITLE
feat: add support for Debian 13 Trixie

### DIFF
--- a/scripts/install/bazarr.sh
+++ b/scripts/install/bazarr.sh
@@ -35,7 +35,13 @@ _install() {
     esac
 
     if [[ $(_os_arch) =~ "arm" ]]; then
-        apt_install libxml2-dev libxslt1-dev python3-libxml2 python3-lxml unrar-free ffmpeg libatlas-base-dev
+        arm_deps=(libxml2-dev libxslt1-dev python3-libxml2 python3-lxml unrar-free ffmpeg)
+        if [[ -n "$(get_candidate_version libatlas-base-dev)" ]]; then
+            arm_deps+=(libatlas-base-dev)
+        else
+            echo_warn "Skipping libatlas-base-dev because no apt candidate is available on this architecture."
+        fi
+        apt_install "${arm_deps[@]}"
     fi
 
     echo_progress_start "Downloading bazarr source"

--- a/scripts/install/calibre.sh
+++ b/scripts/install/calibre.sh
@@ -25,7 +25,7 @@ else
 fi
 
 _install() {
-    apt_install xdg-utils wget xz-utils libxcb-xinerama0 libfontconfig libgl1-mesa-glx libopengl0 libxcb-cursor0
+    apt_install xdg-utils wget xz-utils libxcb-xinerama0 libfontconfig libgl1 libopengl0 libxcb-cursor0 libxkbcommon0
     echo_progress_start "Installing calibre"
     if [[ $(_os_arch) = "amd64" ]]; then
         wget https://download.calibre-ebook.com/linux-installer.sh -O /tmp/calibre-installer.sh >> $log 2>&1

--- a/scripts/install/jackett.sh
+++ b/scripts/install/jackett.sh
@@ -38,6 +38,16 @@ esac
 version=$(github_latest_version "Jackett/Jackett")
 password=$(cut -d: -f2 < /root/.master.info)
 
+echo_progress_start "Installing Jackett dependencies..."
+icu_pkg=$(apt-cache pkgnames libicu 2> /dev/null | grep -E '^libicu[0-9]+$' | sort -V | tail -n1)
+if [[ -n "$icu_pkg" ]]; then
+    apt_install "$icu_pkg"
+else
+    echo_warn "Could not detect a versioned libicu package; installing libicu-dev"
+    apt_install libicu-dev
+fi
+echo_progress_done
+
 echo_progress_start "Downloading and extracting jackett"
 cd /home/$username
 wget "https://github.com/Jackett/Jackett/releases/download/${version}/Jackett.Binaries.Linux${arch}.tar.gz" >> "$log" 2>&1

--- a/scripts/install/librespeed.sh
+++ b/scripts/install/librespeed.sh
@@ -15,7 +15,7 @@ function _installLibreSpeed1() {
     mkdir $lspdpath
     echo_progress_start "Cloning librespeed source code"
     git clone https://github.com/librespeed/speedtest.git $lspdpath > /dev/null 2>&1
-    cp $lspdpath/example-singleServer-gauges.html $lspdpath/index.html
+    cp $lspdpath/examples/example-singleServer-gauges.html $lspdpath/index.html
     swizname=$(sed -ne '/server_name/{s/.*server_name //; s/[; ].*//; p; q}' /etc/nginx/sites-enabled/default)
     if [ ! -z "$swizname" ] && [ "$swizname" != "_" ]; then
         sed -i "s/LibreSpeed Example/LibreSpeed - $swizname/g" $lspdpath/index.html

--- a/scripts/install/ombi.sh
+++ b/scripts/install/ombi.sh
@@ -4,13 +4,30 @@
 
 function _sources() {
     echo_progress_start "Installing ombi apt sources"
-    echo "deb [signed-by=/usr/share/keyrings/ombi-archive-keyring.gpg] https://apt.ombi.app/master jessie main" > /etc/apt/sources.list.d/ombi.list
-    curl -s https://apt.ombi.app/pub.key | gpg --dearmor > /usr/share/keyrings/ombi-archive-keyring.gpg 2>> ${log}
+    if [[ "$(_os_distro)" == "debian" ]] && [[ "$(_os_codename)" == "trixie" ]]; then
+        # Ombi's repo currently serves unsigned metadata rejected by apt on trixie.
+        # Keep apt-based installs working here while preserving signed-by flow elsewhere.
+        echo "deb [trusted=yes] https://apt.ombi.app/master jessie main" > /etc/apt/sources.list.d/ombi.list
+        echo_warn "Using trusted Ombi repository on Debian trixie due to upstream unsigned metadata."
+    else
+        echo "deb [signed-by=/usr/share/keyrings/ombi-archive-keyring.gpg] https://apt.ombi.app/master jessie main" > /etc/apt/sources.list.d/ombi.list
+        curl -s https://apt.ombi.app/pub.key | gpg --dearmor > /usr/share/keyrings/ombi-archive-keyring.gpg 2>> ${log}
+    fi
     echo_progress_done "Sources installed"
     apt_update
 }
 
 function _install() {
+    echo_progress_start "Installing Ombi runtime dependencies"
+    icu_pkg="$(apt-cache search '^libicu[0-9]+$' | awk '{print $1}' | sort -Vr | sed -n '1p')"
+    if [[ -n "${icu_pkg}" ]]; then
+        apt_install "${icu_pkg}"
+    else
+        # Fallback for older or unusual apt metadata where versioned runtime package is not listed.
+        apt_install libicu-dev
+    fi
+    echo_progress_done "Dependencies installed"
+
     apt_install ombi
 
     mkdir -p /etc/systemd/system/ombi.service.d

--- a/scripts/install/plex.sh
+++ b/scripts/install/plex.sh
@@ -30,7 +30,10 @@ read 'claim'
 echo_progress_start "Installing plex keys and sources ... "
 apt_install apt-transport-https
 curl -sL https://downloads.plex.tv/plex-keys/PlexSign.v2.key | gpg --yes --dearmor -o /usr/share/keyrings/plexmediaserver.v2.gpg
-echo "deb [signed-by=/usr/share/keyrings/plexmediaserver.v2.gpg] https://repo.plex.tv/deb/ public main" > /etc/apt/sources.list.d/plex.list
+# Clean up old/legacy Plex source files before writing our managed entry.
+rm -f /etc/apt/sources.list.d/plexmediaserver.list /etc/apt/sources.list.d/plexmediaserver.sources
+# repo.plex.tv is the signed Plex APT endpoint; downloads.plex.tv/repo/deb may be unsigned.
+echo "deb [signed-by=/usr/share/keyrings/plexmediaserver.v2.gpg] https://repo.plex.tv/deb public main" > /etc/apt/sources.list.d/plex.list
 echo
 
 apt_update

--- a/scripts/install/rapidleech.sh
+++ b/scripts/install/rapidleech.sh
@@ -28,6 +28,10 @@ function _installRapidleech1() {
     echo_progress_start "Cloning rapidleech"
     git clone https://github.com/Th3-822/rapidleech.git /home/"${MASTER}"/rapidleech >> $log 2>&1
     chown "${MASTER}":"${MASTER}" -R /home/"${MASTER}"/rapidleech
+    chmod 775 /home/"${MASTER}"/rapidleech/configs
+    chmod 775 /home/"${MASTER}"/rapidleech/configs/config.php
+    chmod 775 /home/"${MASTER}"/rapidleech/configs/files.lst
+    chmod 775 /home/"${MASTER}"/rapidleech/files
     echo_progress_done
 }
 

--- a/scripts/install/sabnzbd.sh
+++ b/scripts/install/sabnzbd.sh
@@ -101,6 +101,7 @@ enable_all_par = 1
 direct_unpack_threads = 1
 password = "${password}"
 username = "${user}"
+url_base = "sabnzbd"
 SAB_INI
 chown -R ${user}: /opt/sabnzbd
 chown ${user}: /home/${user}/.config

--- a/scripts/install/sickchill.sh
+++ b/scripts/install/sickchill.sh
@@ -3,7 +3,6 @@
 # Author: liara
 
 user=$(cut -d: -f1 < /root/.master.info)
-codename=$(lsb_release -cs)
 #shellcheck source=sources/functions/pyenv
 . /etc/swizzin/sources/functions/pyenv
 #shellcheck source=sources/functions/utils
@@ -31,7 +30,7 @@ if [[ -n $active ]]; then
     fi
 fi
 
-LIST='git python3-dev python3-venv python3-pip python3-rarfile' # TODO: Add appdirs
+LIST='git python3-dev python3-venv python3-pip python3-rarfile'
 apt_install $LIST
 echo_progress_start "Installing venv for sickchill"
 python3 -m venv /opt/.venv/sickchill >> ${log} 2>&1
@@ -43,8 +42,10 @@ git clone https://github.com/SickChill/SickChill.git /opt/sickchill >> ${log} 2>
 chown -R $user: /opt/sickchill
 echo_progress_done
 
-echo_progress_start "Installing requirements.txt with pip"
-sudo -u ${user} bash -c "/opt/.venv/sickchill/bin/pip3 install -r /opt/sickchill/requirements.txt" >> $log 2>&1 # requirements.txt not present...
+echo_progress_start "Installing SickChill dependencies with pip"
+sudo -u ${user} bash -c "/opt/.venv/sickchill/bin/pip3 install 'setuptools<71'" >> $log 2>&1
+sudo -u ${user} bash -c "/opt/.venv/sickchill/bin/pip3 install 'stevedore<5.2'" >> $log 2>&1
+sudo -u ${user} bash -c "/opt/.venv/sickchill/bin/pip3 install appdirs /opt/sickchill/" >> $log 2>&1
 echo_progress_done
 
 install_rar
@@ -72,6 +73,11 @@ echo_progress_done "Sickchill started"
 
 if [[ -f /install/.nginx.lock ]]; then
     echo_progress_start "Configuring nginx"
+    # Wait for SickChill to generate config.ini on first launch
+    timeout=10
+    while [[ ! -f /opt/sickchill/config.ini ]] && ((timeout-- > 0)); do
+        sleep 1
+    done
     bash /usr/local/bin/swizzin/nginx/sickchill.sh
     systemctl reload nginx
     echo_progress_done

--- a/scripts/install/sickchill.sh
+++ b/scripts/install/sickchill.sh
@@ -44,7 +44,7 @@ chown -R $user: /opt/sickchill
 echo_progress_done
 
 echo_progress_start "Installing requirements.txt with pip"
-sudo -u ${user} bash -c "/opt/.venv/sickchill/bin/pip3 install -r /opt/sickchill/requirements.txt" >> $log 2>&1
+sudo -u ${user} bash -c "/opt/.venv/sickchill/bin/pip3 install -r /opt/sickchill/requirements.txt" >> $log 2>&1 # requirements.txt not present...
 echo_progress_done
 
 install_rar

--- a/scripts/install/sickchill.sh
+++ b/scripts/install/sickchill.sh
@@ -31,7 +31,7 @@ if [[ -n $active ]]; then
     fi
 fi
 
-LIST='git python3-dev python3-venv python3-pip'
+LIST='git python3-dev python3-venv python3-pip python3-rarfile' # TODO: Add appdirs
 apt_install $LIST
 echo_progress_start "Installing venv for sickchill"
 python3 -m venv /opt/.venv/sickchill >> ${log} 2>&1

--- a/scripts/install/webmin.sh
+++ b/scripts/install/webmin.sh
@@ -5,8 +5,19 @@
 
 _install_webmin() {
     echo_progress_start "Installing Webmin repo"
-    echo "deb [signed-by=/usr/share/keyrings/webmin-archive-keyring.gpg] https://download.webmin.com/download/repository sarge contrib" > /etc/apt/sources.list.d/webmin.list
-    curl -s https://download.webmin.com/jcameron-key.asc | gpg --dearmor > /usr/share/keyrings/webmin-archive-keyring.gpg 2>> "${log}"
+    # Clean up old apt source/key artifacts that can trigger unsigned repo errors.
+    rm -f /etc/apt/sources.list.d/webmin.list \
+        /etc/apt/sources.list.d/webmin.list.save \
+        /etc/apt/trusted.gpg.d/webmin*.gpg \
+        /usr/share/keyrings/webmin-archive-keyring.gpg
+
+    install -d -m 0755 /usr/share/keyrings
+    curl -fsSL https://download.webmin.com/developers-key.asc | gpg --dearmor -o /usr/share/keyrings/webmin-archive-keyring.gpg 2>> "${log}"
+    chmod 0644 /usr/share/keyrings/webmin-archive-keyring.gpg
+
+    cat > /etc/apt/sources.list.d/webmin.list << EOF
+deb [signed-by=/usr/share/keyrings/webmin-archive-keyring.gpg] https://download.webmin.com/download/newkey/repository stable contrib
+EOF
     echo_progress_done "Repo added"
     apt_update
     apt_install webmin

--- a/scripts/install/x2go.sh
+++ b/scripts/install/x2go.sh
@@ -42,8 +42,9 @@ deb-src [signed-by=/usr/share/keyrings/x2go-archive-keyring.gpg] http://packages
 #deb-src [signed-by=/usr/share/keyrings/x2go-archive-keyring.gpg] http://packages.x2go.org/debian ${release} heuler
 EOF
     echo_progress_done "Repo added"
-    mkdir -m 700 /root/.gnupg
-    gpg --no-default-keyring --keyring /usr/share/keyrings/x2go-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys E1F958385BFE2B6E >> ${log} 2>&1
+    mkdir -p /usr/share/keyrings
+    curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xE1F958385BFE2B6E" |
+        gpg --dearmor --yes -o /usr/share/keyrings/x2go-archive-keyring.gpg >> ${log} 2>&1
     apt_update
     apt_install x2go-keyring
 fi

--- a/scripts/update/10-dependencies.sh
+++ b/scripts/update/10-dependencies.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Ensures that dependencies are installed and corrects them if that is not the case.
 
-if ! which add-apt-repository > /dev/null; then
+if ! which add-apt-repository > /dev/null && [ "$(_os_codename)" != "trixie" ]; then
     apt_install software-properties-common # Ubuntu may require universe/mutliverse enabled for certain packages so we must ensure repos are enabled before deps are attempted to installed
 fi
 
@@ -68,12 +68,20 @@ elif [[ $(_os_distro) == "debian" ]]; then
     else
         if ! grep contrib /etc/apt/sources.list | grep -q -v '^#'; then
             echo_info "Enabling contrib repo"
-            apt-add-repository -y contrib >> ${log} 2>&1
+            if [[ $(_os_codename) != "trixie" ]]; then
+                apt-add-repository -y contrib >> ${log} 2>&1
+            else
+                sed -i 's/^\(deb .*main\)/\1 contrib/' /etc/apt/sources.list >> ${log} 2>&1
+            fi
             trigger_apt_update=true
         fi
         if ! grep -P '\bnon-free(\s|$)' /etc/apt/sources.list | grep -q -v '^#'; then
             echo_info "Enabling non-free repo"
-            apt-add-repository -y non-free >> ${log} 2>&1
+            if [[ $(_os_codename) != "trixie" ]]; then
+                apt-add-repository -y non-free >> ${log} 2>&1
+            else
+                sed -i 's/^\(deb .*main.*\)/\1 non-free/' /etc/apt/sources.list >> ${log} 2>&1
+            fi
             trigger_apt_update=true
         fi
     fi

--- a/scripts/update/sickchill.sh
+++ b/scripts/update/sickchill.sh
@@ -70,7 +70,7 @@ if [[ -f /install/.sickchill.lock ]]; then
         fi
         systemctl disable -q --now ${unit} >> ${log} 2>&1
         rm_if_exists /opt/.venv/sickchill
-        LIST='git python3-dev python3-venv python3-pip'
+        LIST='git python3-dev python3-venv python3-pip python3-rarfile'
         apt_install $LIST
         python3 -m venv /opt/.venv/sickchill
 
@@ -81,8 +81,9 @@ if [[ -f /install/.sickchill.lock ]]; then
             mv /home/${user}/.sickchill /opt/sickchill
         fi
         sudo -u ${user} bash -c "cd /opt/sickchill; git pull" >> $log 2>&1
-        # echo "Installing requirements.txt with pip ..."
-        sudo -u ${user} bash -c "/opt/.venv/sickchill/bin/pip3 install -r /opt/sickchill/requirements.txt" >> $log 2>&1
+        sudo -u ${user} bash -c "/opt/.venv/sickchill/bin/pip3 install 'setuptools<71'" >> $log 2>&1
+        sudo -u ${user} bash -c "/opt/.venv/sickchill/bin/pip3 install 'stevedore<5.2'" >> $log 2>&1
+        sudo -u ${user} bash -c "/opt/.venv/sickchill/bin/pip3 install appdirs /opt/sickchill/" >> $log 2>&1
 
         cat > /etc/systemd/system/sickchill.service << SCSD
 [Unit]

--- a/setup.sh
+++ b/setup.sh
@@ -198,7 +198,7 @@ _os() {
         echo_error "Your distribution ($distribution) is not supported. Swizzin requires Ubuntu or Debian."
         exit 1
     fi
-    if [[ ! $codename =~ ^(focal|bullseye|jammy|bookworm|noble)$ ]]; then
+    if [[ ! $codename =~ ^(focal|bullseye|jammy|bookworm|noble|trixie)$ ]]; then
         echo_error "Your release ($codename) of $distribution is not supported."
         exit 1
     fi

--- a/sources/functions/deluge
+++ b/sources/functions/deluge
@@ -139,7 +139,7 @@ function deluge_version_info() {
             pythonver=python3
             pythonmajor=$(get_candidate_version python3 | cut -d. -f1-2)
             python=python3
-            deluge_git_branch="$(git ls-remote -q -t --refs https://git.deluge-torrent.org/deluge | awk '{sub("refs/tags/", ""); print $2 }' | awk '!/^$/' | sort -rV | grep "deluge-2.1." | grep -v "dev" | head -n 1)"
+            deluge_git_branch="$(git ls-remote -q -t --refs https://github.com/deluge-torrent/deluge.git | awk '{sub("refs/tags/", ""); print $2 }' | awk '!/^$/' | sort -rV | grep "deluge-2.1." | grep -v "dev" | head -n 1)"
             ;;
         2.2.x)
             cryptography=openssl
@@ -164,7 +164,7 @@ function deluge_version_info() {
             pythonver=python3
             pythonmajor=$(get_candidate_version python3 | cut -d. -f1-2)
             python=python3
-            deluge_git_branch="$(git ls-remote -q -t --refs https://git.deluge-torrent.org/deluge | awk '{sub("refs/tags/", ""); print $2 }' | awk '!/^$/' | sort -rV | grep "deluge-2.2." | grep -v "dev" | grep -v "post" | head -n 1)"
+            deluge_git_branch="$(git ls-remote -q -t --refs https://github.com/deluge-torrent/deluge.git | awk '{sub("refs/tags/", ""); print $2 }' | awk '!/^$/' | sort -rV | grep "deluge-2.2." | grep -v "dev" | grep -v "post" | head -n 1)"
             # deluge_git_branch=master
             ;;
         *)
@@ -193,9 +193,11 @@ function skip_libtorrent_deluge() {
 
 function build_libtorrent_deluge() {
     booststrap
-    echo 'using gcc : : : <cflags>"-O3 -march=native -std=c++17" <cxxflags>"-O3 -march=native -std=c++17" ;' > /root/user-config.jam
+    # libtorrent may reference zstd (e.g. v2 protocol); ensure the python module links libzstd explicitly.
+    # Without this, --as-needed can drop -lzstd and deluged fails at import: undefined symbol ZSTD_initCStream
+    echo 'using gcc : : : <cflags>"-O3 -march=native -std=c++17" <cxxflags>"-O3 -march=native -std=c++17" <linkflags>"-Wl,--no-as-needed -lzstd -Wl,--as-needed" ;' > /root/user-config.jam
     echo "using python : ${pythonmajor} : /usr/bin/${pythonver} : /usr/include/python${pythonmajor} : /usr/lib/python${pythonmajor} ;" >> /root/user-config.jam
-    apt_install ${pythonver}-dev libssl-dev
+    apt_install ${pythonver}-dev libssl-dev libzstd-dev
     rm_if_exists /tmp/libtorrent
 
     export "${libtorrent_branch}"
@@ -233,7 +235,7 @@ function build_libtorrent_deluge() {
     /opt/boost_${BOOST_VERSION}/b2 -j$(nproc) python=${pythonmajor} crypto=${cryptography} variant=release libtorrent-link=static boost-link=static install_module python-install-path=/tmp/dist/libtorrent-python/usr/local/lib/python${pythonmajor}/dist-packages >> ${log} 2>&1
     tag=" static with c++17 O3 march=native"
     mkdir -p /root/dist
-    fpm -f -C /tmp/dist/libtorrent-python -p /root/dist/${python}-libtorrent_VERSION.deb -s dir -t deb -n ${python}-libtorrent --version ${VERSION} --description "Libtorrent rasterbar python binding compiled by swizzin$tag" >> ${log} 2>&1 || {
+    fpm -f -C /tmp/dist/libtorrent-python -p /root/dist/${python}-libtorrent_VERSION.deb -s dir -t deb -n ${python}-libtorrent -d libzstd1 --version ${VERSION} --description "Libtorrent rasterbar python binding compiled by swizzin$tag" >> ${log} 2>&1 || {
         echo_error "Error packaging ${python}-libtorrent. Setup will exit"
         exit 1
     }
@@ -258,10 +260,10 @@ function build_deluge() {
     fi
     case $DELUGE_VERSION in
         2.2.x | 2.1.x | 2.0.x)
-            LIST='python3 python3-setuptools python3-pip intltool python3-zope.interface python3-twisted python3-openssl python3-xdg python3-chardet python3-mako python3-packaging python3-setproctitle python3-rencode python3-pil librsvg2-common xdg-utils'
+            LIST='python3 python3-setuptools python3-pip intltool python3-zope.interface python3-twisted python3-openssl python3-xdg python3-chardet python3-mako python3-packaging python3-setproctitle python3-rencode python3-pil python3-six librsvg2-common xdg-utils'
             pythonver=python3
             distver=python3
-            args="--python-disable-dependency=pyxdg --python-disable-dependency=pyopenssl -d python3-openssl -d python3-xdg"
+            args="--python-disable-dependency=pyxdg --python-disable-dependency=pyopenssl -d python3-openssl -d python3-xdg -d python3-six"
             ;;
         1.3-stable)
             if [[ $(_os_codename) = "buster" ]]; then
@@ -293,12 +295,9 @@ function build_deluge() {
     fi
 
     rm_if_exists /tmp/deluge
-    git clone -b ${deluge_git_branch} git://deluge-torrent.org/deluge.git /tmp/deluge >> "${log}" 2>&1 || {
-        echo_warn "Cloning Deluge from deluge-torrent.org failed, attempting github backup."
-        git clone -b ${deluge_git_branch} https://github.com/deluge-torrent/deluge/ >> "${log}" 2>&1 || {
-            echo_error "Cloning Deluge from github failed. Setup will now exit"
-            exit 1
-        }
+    git clone -b "${deluge_git_branch}" https://github.com/deluge-torrent/deluge.git /tmp/deluge >> "${log}" 2>&1 || {
+        echo_error "Cloning Deluge from GitHub failed. Setup will now exit."
+        exit 1
     }
     cd /tmp/deluge
     VERSION=$(git describe | cut -d- -f2)
@@ -351,12 +350,13 @@ function apt_install_deluge() {
 }
 
 function dweb_check() {
+    deluge_web_bin=$(command -v deluge-web || echo "/usr/bin/deluge-web")
     case $DELUGE_VERSION in
         2.2.x | 2.1.x | 2.0.x)
-            sed -i 's|ExecStart=.*|ExecStart=/usr/bin/deluge-web -d|g' /etc/systemd/system/deluge-web@.service
+            sed -i "s|ExecStart=.*|ExecStart=${deluge_web_bin} -d|g" /etc/systemd/system/deluge-web@.service
             ;;
         1.3-stable)
-            sed -i 's|ExecStart=.*|ExecStart=/usr/bin/deluge-web|g' /etc/systemd/system/deluge-web@.service
+            sed -i "s|ExecStart=.*|ExecStart=${deluge_web_bin}|g" /etc/systemd/system/deluge-web@.service
             ;;
         *)
             echo_error "$DELUGE_VERSION branch not recognized. Setup will now exit"
@@ -629,9 +629,12 @@ DHL
 
 function _dservice() {
     echo_progress_start "Adding systemd service files"
+    deluged_bin=$(command -v deluged || echo "/usr/bin/deluged")
+    deluge_web_bin=$(command -v deluge-web || echo "/usr/bin/deluge-web")
+    dvermajor=$(deluged -v | grep deluged | grep -oP '\d+\.\d+\.\d+' | cut -d. -f1)
+    args=
+    if [[ $dvermajor == 2 ]]; then args=" -d"; fi
     if [[ ! -f /etc/systemd/system/deluged@.service ]]; then
-        dvermajor=$(deluged -v | grep deluged | grep -oP '\d+\.\d+\.\d+' | cut -d. -f1)
-        if [[ $dvermajor == 2 ]]; then args=" -d"; fi
         cat > /etc/systemd/system/deluged@.service << DD
 [Unit]
 Description=Deluge Bittorrent Client Daemon
@@ -640,7 +643,7 @@ After=network.target
 [Service]
 Type=simple
 User=%i
-ExecStart=/usr/bin/deluged -d
+ExecStart=${deluged_bin} -d
 Restart=on-failure
 TimeoutStopSec=300
 
@@ -657,7 +660,7 @@ After=network.target
 [Service]
 Type=simple
 User=%i
-ExecStart=/usr/bin/deluge-web${args}
+ExecStart=${deluge_web_bin}${args}
 TimeoutStopSec=300
 Restart=on-failure
 
@@ -665,6 +668,9 @@ Restart=on-failure
 WantedBy=multi-user.target
 DW
     fi
+    sed -i "s|ExecStart=.*deluged.*|ExecStart=${deluged_bin} -d|g" /etc/systemd/system/deluged@.service
+    sed -i "s|ExecStart=.*deluge-web.*|ExecStart=${deluge_web_bin}${args}|g" /etc/systemd/system/deluge-web@.service
+    systemctl daemon-reload
     for u in "${users[@]}"; do
         systemctl enable -q deluged@${u} 2>&1 | tee -a $log
         systemctl enable -q deluge-web@${u} 2>&1 | tee -a $log

--- a/sources/functions/java
+++ b/sources/functions/java
@@ -7,12 +7,12 @@ install_java8() {
     elif [[ $distribution == "debian" ]]; then
         case $codename in
             *)
-                echo_progress_start "Adding adoptopenjdk repository"
-                curl -s https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | gpg --dearmor > /usr/share/keyrings/adoptopenjdk-archive-keyring.gpg 2>> "${log}"
-                echo "deb [signed-by=/usr/share/keyrings/adoptopenjdk-archive-keyring.gpg] https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/ ${codename} main" > /etc/apt/sources.list.d/adoptopenjdk.list
-                echo_progress_done "adoptopenjdk repos enabled"
+                echo_progress_start "Adding temurin repository"
+                curl -s https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor > /usr/share/keyrings/temurin-archive-keyring.gpg 2>> "${log}"
+                echo "deb [signed-by=/usr/share/keyrings/temurin-archive-keyring.gpg] https://packages.adoptium.net/artifactory/deb/ ${codename} main" > /etc/apt/sources.list.d/temurin.list
+                echo_progress_done "temurin repos enabled"
                 apt_update
-                apt_install adoptopenjdk-8-hotspot
+                apt_install temurin-8-jdk
                 ;;
         esac
     fi

--- a/sources/functions/libtorrent
+++ b/sources/functions/libtorrent
@@ -165,7 +165,6 @@ function booststrap() {
         echo_progress_start "Installing boost"
         cd /opt
         declare -A boost_mirror_urls=(
-            ["jfrog.io"]="https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION//_/.}/source/boost_${BOOST_VERSION}.tar.gz"
             ["boost.io"]="https://archives.boost.io/release/${BOOST_VERSION//_/.}/source/boost_${BOOST_VERSION}.tar.gz"
             ["sourceforge"]="https://deac-ams.dl.sourceforge.net/project/boost/boost/${BOOST_VERSION//_/.}/boost_${BOOST_VERSION}.tar.gz"
         )

--- a/sources/functions/mylar
+++ b/sources/functions/mylar
@@ -31,6 +31,8 @@ function _download_latest() {
     /opt/.venv/mylar/bin/pip install -r /opt/mylar/requirements.txt &>> "${log}"
     # hotfix for urllib3 breaking stuff
     /opt/.venv/mylar/bin/pip install 'urllib3<2'
+    # Python 3.13+ removed stdlib imghdr; Mylar still imports it.
+    /opt/.venv/mylar/bin/pip install standard-imghdr &>> "${log}"
     chown -R "${mylar_owner}": /opt/mylar/
     chown -R "${mylar_owner}": /opt/.venv/mylar/
 }

--- a/sources/functions/npm
+++ b/sources/functions/npm
@@ -7,7 +7,7 @@ function npm_install() {
         apt_install ca-certificates curl gnupg
         mkdir -p /etc/apt/keyrings
         curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-        NODE_MAJOR=20
+        NODE_MAJOR=24
         echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
         apt_update
         apt_install nodejs
@@ -24,13 +24,13 @@ function npm_install() {
 
 function npm_update() {
     if [[ -f /etc/apt/sources.list.d/nodesource.list ]]; then
-        if [[ $(grep -m1 -oP 'node_\d+' /etc/apt/sources.list.d/nodesource.list | sed 's/node_//g') -lt "20" ]]; then
-            echo_progress_start "Upgrading nodejs to version 20 LTS"
+        if [[ $(grep -m1 -oP 'node_\d+' /etc/apt/sources.list.d/nodesource.list | sed 's/node_//g') -lt "24" ]]; then
+            echo_progress_start "Upgrading nodejs to version 24 LTS"
             apt_update
             apt_install ca-certificates curl gnupg
             mkdir -p /etc/apt/keyrings
             curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-            NODE_MAJOR=20
+            NODE_MAJOR=24
             echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
             apt_update
             apt_upgrade


### PR DESCRIPTION
## Description
This PR adds support for Debian 13 Trixie.  
If someone could test the installs on arm64 it would be very appreciated.  

Furthermore there is a couple things i could not figure out under the `Failed or needs testing` section.  
In case anyone has any insight on the issues there, feel free to comment.  

## Fixes issues: 
fixes #1302 
fixes #1299 
fixes #1294 
fixes #1269 
fixes #1264

## Proposed Changes:
- Support Debian 13 Trixie

## Change Categories
<!-- DELETE WHICHEVER BULLET DOES NOT APPLY -->
- Bug fix               <!-- non-breaking change which fixes an issue -->
- New feature           <!-- non-breaking change which adds functionality -->
- Change in `functions` <!-- e.g. `utils`, `os`, `apt`, `ask`, etc. -->

## Checklist
- [x] Branch was made off the `develop` branch and the PR is targetting the `develop` branch
- [ ] Docs have been made OR are not necessary
    - PR link: 
- [x] Changes to panel have been made
    - PR link: https://github.com/swizzin/swizzin_dashboard/pull/82
- [x] Code conforms to project structure [(See more)](https://swizzin.ltd/dev/structure)
- [x] Prints to terminal are handled [(See more)](https://github.com/swizzin/swizzin/blob/master/CONTRIBUTING.md#printing-into-the-terminal)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] Testing was done
   - [ ] Tests created or no new tests necessary
   - [ ] Tests executed

## Test scenarios
Every install has been tested on a fresh minimal installation of Debian 13 Trixie with one user.

<details>
<summary>Tested and working</summary>

- airsonic  
- autobrr  
- btsync  
- calibre  
- calibrecs  
- calibreweb  
- deluge repo  
- deluge 2.2  
- deluge 2.1  
- deluge 2.0  
- emby 
- ffmpeg  
- filebrowser  
- flood  
- jackett  
- jellyfin
- jfago  
- librespeed  
- lidarr  
- medusa (there is still no rar package for arm64 in trixie)  
- mylar  
- navidrome  
- netdata  
- netronome  
- nextcloud  
- nginx  
- nzbget  
- nzbhydra (currently only amd64 is supported - see https://github.com/swizzin/swizzin/pull/1254)
- ombi  
- organizr  
- panel  
- plex  
- prowlarr  
- qbittorrent repo  
- qbittorrent 4.3.9  
- qbittorrent 4.4.5  
- qbittorrent 4.5.5  
- qbittorrent 4.6.7  
- qbittorrent 5.0.5  
- qbittorrent 5.1.4  
- quassel
- qui  
- quota  
- radarr  
- rapidleech
- rclone  
- rtorrent 0.15.5  
- rtorrent 0.15.3  
- rtorrent 0.15.1  
- rtorrent 0.10.0  
- rtorrent 0.9.8  
- rtorrent 0.9.7  
- rtorrent 0.9.6  
- rtorrent repo  
- rutorrent  
- sabnzbd  
- shellinabox  
- sickchill
- sickgear  
- sonarr  
- syncthing  
- tautulli  
- transmission  
- vsftpd  
- wireguard  
- znc
</details>

<details>
<summary>Failed or needs testing</summary>

- bazarr - libatlas-base-dev has no installation candidate on arm64
- letsencrypt (installs but no cert issued due to local dev env)  
- lounge - failed on arm64 - need more logs
- xmrig - config fails  
</details>


### Architectures
<!--
Please use these emojis here to fill the table below. It will nicely auto-format with spacing, don't worry. Leave empty wherever you do not know / have not tested
✅ = Works successfully
❎ = Does not work BUT is handled gracefully
🛠 = Still WIP
❌ = Broken / not working
-->
|   			| `amd64` 	| `armhf` 	| `arm64` 	| Unspecified 	|
|--------		|-------- 	|-------- 	|-------- 	|----------		|
| Jammy 		|			|			|			|				|
| Focal 		|			|			|			|				|
| Bookworm      |           |           |           |               |
| Trixie   |     ❌     |          |     ❌     |               |
| Bullseye		|			|			|			|				|
| Buster		|			|			|			|				|
| Raspbian  	|	⚫️		|			|	⚫️		|	⚫️			|

### ✅❎ Passed  
### 🛠🛠 TODO  
### ❌❌ Currently failing



<!-- EXAMPLES :
- Fresh app install without nginx
    - With only one user
    - With multiple users present
- Fresh Install with nginx present nginx
    - With only one user
    - With multiple users present
- Fresh install and nginx install afterwards
    - With only one user
    - With multiple users present
- Update from version in master
- Upgrade from version in master
- Password gets changed from `box` in app
- User removal from `box` acting on app
- New user in `box` gets added to app
- Sysinfo compatibility
    - Info washed
    - Content available
-->

