### PR TITLE
fix: release-independent installer bugs (fancyindex, php-fpm, qbittorrent 5.2, xmrig, nzbhydra, lounge, wireguard)

### DIFF
--- a/scripts/install/lounge.sh
+++ b/scripts/install/lounge.sh
@@ -12,10 +12,28 @@ function _install() {
         exit 1
     }
     yarn --non-interactive cache clean >> $log 2>&1
-    sudo -u lounge bash -c "thelounge install thelounge-theme-zenburn" >> $log 2>&1
     echo_progress_done
 
+    # Install the zenburn theme into THELOUNGE_HOME. Run right after `yarn global add`, the
+    # install can silently no-op (returning 0 without persisting), leaving config.js pointing
+    # at a theme that isn't there ("default theme ... does not exist"). So pin THELOUNGE_HOME,
+    # retry, and confirm it actually landed in packages/package.json before referencing it.
     mkdir -p /opt/lounge/.thelounge/
+    chown -R lounge: /opt/lounge
+    echo_progress_start "Installing lounge theme"
+    lounge_theme="default"
+    for _ in 1 2 3; do
+        sudo -H -u lounge bash -c "THELOUNGE_HOME=/opt/lounge/.thelounge thelounge install thelounge-theme-zenburn" >> $log 2>&1
+        if grep -q 'thelounge-theme-zenburn' /opt/lounge/.thelounge/packages/package.json 2> /dev/null; then
+            lounge_theme="thelounge-theme-zenburn"
+            break
+        fi
+        sleep 2
+    done
+    if [[ $lounge_theme == "default" ]]; then
+        echo_warn "thelounge-theme-zenburn could not be installed; lounge will use the default theme."
+    fi
+    echo_progress_done
 
     cat > /opt/lounge/.thelounge/config.js << 'EOF'
 "use strict";
@@ -500,6 +518,12 @@ module.exports = {
 	},
 };
 EOF
+
+    # config.js is written with the theme hard-coded; drop back to the default theme if the
+    # zenburn package didn't actually install, so lounge doesn't warn about a missing theme.
+    if [[ $lounge_theme != "thelounge-theme-zenburn" ]]; then
+        sed -i 's/theme: "thelounge-theme-zenburn"/theme: "default"/' /opt/lounge/.thelounge/config.js
+    fi
 
     chown -R lounge: /opt/lounge
 

--- a/scripts/install/nginx.sh
+++ b/scripts/install/nginx.sh
@@ -201,7 +201,7 @@ echo_progress_done "Config installed"
 
 echo_progress_start "Installing fancyindex"
 git clone https://github.com/Naereen/Nginx-Fancyindex-Theme/ /tmp/fancyindex >> $log 2>&1
-mv /tmp/fancyindex/Nginx-Fancyindex-Theme-dark /srv/fancyindex >> $log 2>&1
+mv /tmp/fancyindex/Nginx-Fancyindex /srv/fancyindex >> $log 2>&1
 rm -rf /tmp/fancyindex
 
 cat > /etc/nginx/snippets/fancyindex.conf << FIC

--- a/scripts/install/nzbhydra.sh
+++ b/scripts/install/nzbhydra.sh
@@ -42,7 +42,11 @@ wget -O nzbhydra2.zip ${latest} >> ${log} 2>&1
 unzip nzbhydra2.zip >> ${log} 2>&1
 rm -f nzbhydra2.zip
 
-chmod +x nzbhydra2 nzbhydra2wrapperPy3.py
+# Upstream no longer ships a standalone "nzbhydra2" launcher (it runs via the Py3 wrapper),
+# so only mark the files that actually exist executable instead of erroring on the old name.
+for f in nzbhydra2 nzbhydra2wrapperPy3.py nzbhydra2wrapper.py; do
+    [[ -f $f ]] && chmod +x "$f"
+done
 chown -R ${username}: /opt/nzbhydra2
 echo_progress_done
 

--- a/scripts/install/wireguard.sh
+++ b/scripts/install/wireguard.sh
@@ -171,9 +171,22 @@ if [[ -f /install/.wireguard.lock ]]; then
 fi
 if [[ -z $wgiface ]]; then
     defiface=$(route | grep '^default' | grep -o '[^ ]*$')
+    # Fall back to `ip route` if net-tools reports nothing (route is deprecated).
+    [[ -z $defiface ]] && defiface=$(ip -o route show default 2> /dev/null | grep -oP 'dev \K\S+' | head -1)
     IFACES=($(ip link show | grep -i broadcast | grep UP | grep qlen | cut -d: -f 2 | cut -d@ -f 1 | sed -e 's/ //g'))
     #MASTER=$(ip link show | grep -i broadcast | grep -e MASTER | cut -d: -f 2| cut -d@ -f 1 | sed -e 's/ //g')
     _defiface_confirm
+    # If the confirmation prompt was skipped (e.g. no tty during an unattended install),
+    # `select` exits without setting wgiface, and an empty interface produces a broken
+    # PostUp rule ("iptables ... -o  -m state") that stops wg-quick from starting. Fall
+    # back to the auto-detected interface so the generated config is always valid.
+    if [[ -z $wgiface ]]; then
+        wgiface=$defiface
+    fi
+    if [[ -z $wgiface ]]; then
+        echo_error "Could not determine the main network interface for WireGuard. Setup will exit."
+        exit 1
+    fi
     if [[ -f /install/.wireguard.lock ]]; then echo $wgiface > /install/.wireguard.lock; fi
 fi
 

--- a/scripts/install/xmrig.sh
+++ b/scripts/install/xmrig.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 # xmrig installer
 # Author: liara
+#shellcheck source=sources/functions/utils
+. /etc/swizzin/sources/functions/utils
 user=$(cut -d: -f1 < /root/.master.info)
 noexec=$(grep "/tmp" /etc/fstab | grep noexec)
-latest=$(curl -s https://github.com/xmrig/xmrig/releases/latest | grep -oP 'v\K\d+.\d+.\d+')
+# GitHub's /releases/latest page is now a bodyless redirect, so scraping it returns an empty
+# version and `git clone --branch v` fails, cascading into every later step. Resolve the tag
+# via the redirect target instead (github_latest_version returns e.g. "v6.21.0").
+latest=$(github_latest_version xmrig/xmrig)
 
 while true; do
     echo_query "Please choose a dev donation amount. Minimum fee is 1%."
@@ -43,10 +48,21 @@ apt_install screen git build-essential cmake libuv1-dev libmicrohttpd-dev libssl
 
 cd /tmp
 echo_progress_start "Cloning xmrig"
-git clone --depth 1 --single-branch --branch v${latest} https://github.com/xmrig/xmrig.git >> $log 2>&1
+if [[ -z $latest ]]; then
+    echo_error "Could not determine the latest xmrig release. Setup will exit."
+    exit 1
+fi
+rm_if_exists /tmp/xmrig
+git clone --depth 1 --single-branch --branch ${latest} https://github.com/xmrig/xmrig.git >> $log 2>&1 || {
+    echo_error "Cloning xmrig ${latest} failed. Setup will exit."
+    exit 1
+}
 echo_progress_done
 
-cd xmrig
+cd xmrig || {
+    echo_error "xmrig source directory missing after clone. Setup will exit."
+    exit 1
+}
 sed -i "s/donate.ssl.xmrig.com/diglett.swizzin.ltd/g" src/net/strategies/DonateStrategy.cpp
 sed -i "s/donate.v2.xmrig.com/diglett.swizzin.ltd/g" src/net/strategies/DonateStrategy.cpp
 sed -i "s/kDefaultDonateLevel = 5/kDefaultDonateLevel = $fee/g" src/donate.h
@@ -60,6 +76,10 @@ mkdir build
 cd build
 cmake .. >> $log 2>&1
 make -j$(nproc) >> $log 2>&1
+if [[ ! -f xmrig ]]; then
+    echo_error "xmrig build did not produce a binary. Check ${log}. Setup will exit."
+    exit 1
+fi
 mv xmrig /usr/local/bin/
 echo_progress_done
 
@@ -80,9 +100,11 @@ if [[ -n $noexec ]]; then
     mount -o remount,noexec /tmp
 fi
 
-if [[ -z $(grep vm.nr_hugepages=128 /etc/sysctl.conf) ]]; then
-    echo "vm.nr_hugepages=128" >> /etc/sysctl.conf
-    sysctl -p
+# Trixie ships no /etc/sysctl.conf by default (settings live in /etc/sysctl.d/), so grepping
+# it errors. Use a drop-in, which is the supported way to add sysctl settings.
+if [[ ! -f /etc/sysctl.d/99-xmrig.conf ]]; then
+    echo "vm.nr_hugepages=128" > /etc/sysctl.d/99-xmrig.conf
+    sysctl -p /etc/sysctl.d/99-xmrig.conf >> $log 2>&1
 fi
 
 cat > /etc/systemd/system/xmrig.service << XMR
@@ -104,8 +126,8 @@ XMR
 
 echo_progress_done
 
-echo_progress_start
+echo_progress_start "Starting xmrig"
 systemctl enable -q --now xmrig 2>&1 | tee -a $log
-echo_done
+echo_progress_done
 touch /install/.xmrig.lock
 echo_success "Xmrig Installed"

--- a/scripts/install/znc.sh
+++ b/scripts/install/znc.sh
@@ -59,6 +59,14 @@ if [[ -f /install/nginx.lock ]]; then
     le_znc_hook
 fi
 
+# znc --makeconf is interactive; if it was cancelled or driven without a tty it produces no
+# config. Don't write a lock and claim success in that case -- the daemon would have nothing
+# to serve and the grep below would just spam "No such file" errors.
+if [[ ! -f /home/znc/.znc/configs/znc.conf ]]; then
+    echo_error "ZNC configuration was not created (znc --makeconf did not complete). ZNC is not configured; re-run the install and answer the prompts. Setup will exit."
+    exit 1
+fi
+
 systemctl start znc
 echo "$(grep Port /home/znc/.znc/configs/znc.conf | sed -e 's/^[ \t]*//')" > /install/.znc.lock
 echo "$(grep SSL /home/znc/.znc/configs/znc.conf | sed -e 's/^[ \t]*//')" >> /install/.znc.lock

--- a/scripts/nginx/webmin.sh
+++ b/scripts/nginx/webmin.sh
@@ -31,4 +31,7 @@ bind=127.0.0.1
 sockets=
 EOF
 
-systemctl reload webmin
+# Use restart rather than reload: this runs immediately after apt has started webmin, and
+# a SIGHUP landing before miniserv installs its handler terminates it instead of reloading,
+# leaving webmin dead after a successful-looking install.
+systemctl restart webmin

--- a/sources/functions/php
+++ b/sources/functions/php
@@ -5,7 +5,15 @@ function restart_php_fpm() {
     version=$(php_service_version)
     serv="php${version}-fpm.service"
     echo_log_only "Restarting $serv"
+    # Installing several php-using apps in one run bounces this unit repeatedly. systemd's
+    # default rate limit (StartLimitBurst=5 per 10s) then refuses to start it and leaves it
+    # failed with 'start-limit-hit', silently taking down every php app on the box. Clearing
+    # the counter first makes the restart reliable regardless of how often we were called.
+    systemctl reset-failed "$serv" >> $log 2>&1
     systemctl restart $serv >> $log 2>&1
+    if ! systemctl is-active --quiet "$serv"; then
+        echo_warn "$serv did not come back up; check 'journalctl -u $serv'"
+    fi
 }
 
 function reload_php_fpm() {

--- a/sources/functions/qbittorrent
+++ b/sources/functions/qbittorrent
@@ -245,7 +245,7 @@ function qbittorrent_version_info() {
             cryptography_type=openssl
             build_type=cmake
             ;;
-        5.1.*)
+        5.1.* | 5.2.*)
             if [[ -n ${LIBTORRENT_VERSION} ]]; then
                 case $LIBTORRENT_VERSION in
                     RC_2_0)
@@ -271,7 +271,7 @@ function qbittorrent_version_info() {
             build_type=cmake
             ;;
         *)
-            echo_error "qBittorrent version should be between 4.1.*(.*) and 5.1.*(.*) -- Setup will not proceed."
+            echo_error "qBittorrent version should be between 4.1.*(.*) and 5.2.*(.*) -- Setup will not proceed."
             exit 1
             ;;
     esac


### PR DESCRIPTION
## Description

A set of **release-independent** bug fixes for existing installers. None of these are specific to Debian 13 — each breaks on currently-supported releases (Bookworm/Bullseye/Jammy/Focal/Noble) today. They were surfaced while testing every installer on a fresh box, but the root causes are upstream package changes, GitHub behaviour changes, or service-timing races that affect all releases.

Kept deliberately separate from the Debian 13 / Trixie work so these can land on `develop` without waiting on it.

## Fixes

- **nginx / fancyindex** — `Naereen/Nginx-Fancyindex-Theme` renamed its theme dir from `Nginx-Fancyindex-Theme-dark` to `Nginx-Fancyindex`, so the `mv` silently failed, `/srv/fancyindex` was never created and the two following `sed` calls errored. The theme has been silently missing on every install.
- **php-fpm** — `restart_php_fpm` uses `systemctl restart`, and several nginx app configs call it. Installing multiple php-using apps back-to-back trips systemd's `StartLimitBurst=5`, leaving php-fpm `failed` and silently taking down every php app (panel, rutorrent, organizr). Now `reset-failed` first and verify it comes back.
- **qbittorrent** — 5.2 has shipped, so `QBITTORRENT_VERSION=latest` (the value in `unattended.example.env`) now resolves to 5.2.x, which the version table rejected outright. 5.2 shares 5.1's Qt6/cmake/libtorrent requirements. Verified v5.2.3 builds from source and runs.
- **xmrig** — GitHub's `/releases/latest` is now a bodyless redirect, so scraping it returns an empty version and `git clone --branch v` fails, cascading through the whole installer (no binary, no config). Resolve the tag via `github_latest_version`, guard the clone/build, use an `/etc/sysctl.d` drop-in, fix an `echo_done` typo.
- **nzbhydra** — upstream dropped the standalone `nzbhydra2` launcher (runs via the Py3 wrapper now), so `chmod +x nzbhydra2` errored every install. Only chmod files that exist.
- **lounge** — the zenburn theme install could silently no-op, leaving `config.js` pointing at a missing theme (startup `WARN` on every boot). Pin `THELOUNGE_HOME`, retry + verify, and fall back to the default theme in config when it isn't there.
- **wireguard** — if the interface-confirm prompt is skipped (no tty), `select` exits without setting `$wgiface`, producing a broken `iptables ... -o  -m state` PostUp rule that stops `wg-quick`. Fall back to the auto-detected interface, plus an `ip route` fallback for detection.
- **webmin** / **znc** — small robustness fixes: `webmin` restart-instead-of-reload avoids a SIGHUP-during-startup race that leaves it dead after a successful-looking install; `znc` now fails loudly if `--makeconf` produced no config instead of writing a bogus lock.

## Testing

Each fix was verified by installing the affected app on a fresh box and confirming the live result (service active, endpoint reachable) — e.g. qBittorrent v5.2.3 built and running, xmrig building with a valid `config.json`, php apps surviving a multi-app install, wireguard tunnel up with a valid PostUp rule.
