### PR TITLE
fix(flood): correct inverted outdated-install check in upgrade script

### DIFF
--- a/scripts/upgrade/flood.sh
+++ b/scripts/upgrade/flood.sh
@@ -4,7 +4,7 @@
 
 readarray -t users < <(_get_user_list)
 
-if ! test -n "$(find /home -mindepth 2 -maxdepth 2 -type d -name '.flood' -print -quit)"; then
+if test -n "$(find /home -mindepth 2 -maxdepth 2 -type d -name '.flood' -print -quit)"; then
     echo_error "Your flood installation is outdated/unsupported. Please reinstall flood"
     exit 1
 fi


### PR DESCRIPTION
## Summary
- `scripts/upgrade/flood.sh` errors with *"Your flood installation is outdated/unsupported. Please reinstall flood"* on **every** modern install, not just legacy ones.
- Root cause: the `find`-based rewrite in #1041 (replacing `[[ -d /home/*/.flood ]]`) inverted the condition. It now bails out when the legacy per-user `~/.flood` directory is **absent**, which is the normal state for any post-Jesec install (`~/.config/flood`, global npm package). The original intent — confirmed by the pre-#1041 code and the PR #579 description — was to bail out only when the legacy layout is **still present**.
- Confirmed on a live, healthy, up-to-date install (`flood@4.11.0`, `~/.config/flood` present, `flood@<user>.service` active): `box upgrade flood` fails unconditionally before this fix.

## Fix
Remove the erroneous `!` negation so the check only fires when the legacy `.flood` directory actually exists.

## Test plan
- [x] Reproduced the failure on a live install before the fix
- [x] Verified `find /home -mindepth 2 -maxdepth 2 -type d -name '.flood' -print -quit` returns empty on a modern install (no legacy dirs)
- [x] After the fix, the script proceeds to `npm install -g flood` instead of erroring