### PR TITLE
fix(flood): make --baseuri systemd override idempotent

### DIFF
--- a/scripts/nginx/flood.sh
+++ b/scripts/nginx/flood.sh
@@ -39,6 +39,8 @@ FLUPS
     fi
 done
 
-sed -i '/ExecStart=/ s/$/ --baseuri=\/flood/' /etc/systemd/system/flood@.service
-systemctl daemon-reload
+if ! grep -q -- '--baseuri=/flood' /etc/systemd/system/flood@.service; then
+    sed -i '/ExecStart=/ s/$/ --baseuri=\/flood/' /etc/systemd/system/flood@.service
+    systemctl daemon-reload
+fi
 systemctl try-restart flood@${user}


### PR DESCRIPTION
## Summary
- `scripts/nginx/flood.sh` unconditionally appends `--baseuri=/flood` to the `flood@.service` `ExecStart` line every time it runs, with no idempotency check.
- This script runs both on install and whenever nginx configs are reinstalled for all apps (e.g. `box upgrade nginx`), so repeated runs duplicate the flag: `--baseuri=/flood --baseuri=/flood`.
- Newer `flood` (4.x, npm-global/Jesec) parses duplicate CLI flags into an array and its stricter config validation rejects it: `Invalid configuration: [{ "code": "invalid_type", "expected": "string", "received": "array", "path": ["baseURI"] }]`.
- Result: `flood@<user>.service` crash-loops (`Restart=on-failure`, restart counter climbing) after any `box upgrade nginx` on a proxied (nginx) install.

Reproduced live: running `box upgrade nginx` on a working install duplicated the flag and put `flood@debian.service` into a crash loop (33 restarts observed before manual fix).

## Fix
Guard the `sed` with a `grep -q` check so `--baseuri=/flood` is only appended if not already present.

## Test plan
- [x] Reproduced the duplicate-flag crash loop on a live install
- [x] Confirmed manually de-duplicating the flag and restarting resolves it (`flood` responds `200 OK` on `/flood/`)
- [x] After the fix, re-running the nginx config script does not re-append the flag when already present