### PR TITLE
fix(node): bump managed Node.js line from 20 to 22 (20 is EOL)

### DIFF
--- a/sources/functions/npm
+++ b/sources/functions/npm
@@ -7,7 +7,7 @@ function npm_install() {
         apt_install ca-certificates curl gnupg
         mkdir -p /etc/apt/keyrings
         curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-        NODE_MAJOR=20
+        NODE_MAJOR=22
         echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
         apt_update
         apt_install nodejs
@@ -24,13 +24,13 @@ function npm_install() {
 
 function npm_update() {
     if [[ -f /etc/apt/sources.list.d/nodesource.list ]]; then
-        if [[ $(grep -m1 -oP 'node_\d+' /etc/apt/sources.list.d/nodesource.list | sed 's/node_//g') -lt "20" ]]; then
-            echo_progress_start "Upgrading nodejs to version 20 LTS"
+        if [[ $(grep -m1 -oP 'node_\d+' /etc/apt/sources.list.d/nodesource.list | sed 's/node_//g') -lt "22" ]]; then
+            echo_progress_start "Upgrading nodejs to version 22 LTS"
             apt_update
             apt_install ca-certificates curl gnupg
             mkdir -p /etc/apt/keyrings
             curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-            NODE_MAJOR=20
+            NODE_MAJOR=22
             echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
             apt_update
             apt_upgrade


### PR DESCRIPTION
## Summary
- Node.js 20 reached end-of-life on **2026-04-30** and no longer receives upstream security patches. The 2026-07-29 release shipped 11 CVEs (3 High severity, including an HTTP/2 heap-use-after-free and a `--permission` sandbox bypass) for the 22.x/24.x/26.x lines only — the 20.x line gets nothing, ever.
- `sources/functions/npm` hardcodes `NODE_MAJOR=20` in both `npm_install()` (fresh installs) and the `npm_update()` guard (`-lt "20"`), so any swizzin box — new or existing — silently stays pinned to an EOL, unpatched Node line indefinitely. There's no path in the codebase that would ever move it past 20.
- Practical fallout observed on a live box: recent `npm`-global packages that swizzin manages (e.g. `flood` >=4.12) already declare `engines.node >=22`, so staying on Node 20 also means losing the ability to pick up upstream updates for those packages without manually overriding the engine check.

## Fix
Bump the pinned major from `20` to `22` (current active LTS) in both the install and upgrade-guard code paths.

## Test plan
- [x] Reproduced on a live box: Node 20.20.2, `npm install -g flood@latest` warns `EBADENGINE` (`required: >=22.0.0`) instead of cleanly upgrading
- [x] Manually bumped Node 20 → 22 via the same NodeSource mechanism this function uses; confirmed `apt-get update`/`install nodejs` cleanly upgrades to `22.23.2`, all npm-dependent services (flood) restart healthy on the new runtime with no EBADENGINE warnings